### PR TITLE
Histogram statistics tasks from courseware_studentmodule/sqoop exports

### DIFF
--- a/edx/analytics/tasks/location_per_course.py
+++ b/edx/analytics/tasks/location_per_course.py
@@ -282,7 +282,6 @@ class InsertToMysqlCourseEnrollByCountryTask(InsertToMysqlCourseEnrollByCountryT
 class InsertToMysqlCourseEnrollByCountryWorkflow(
         QueryLastCountryPerCourseMixin,
         LastCountryOfUserMixin,
-        OverwriteOutputMixin,
         InsertToMysqlCourseEnrollByCountryTaskBase):
     """
     Write to course_enrollment_location_current table from CountUserActivityPerInterval.

--- a/edx/analytics/tasks/studentmodule_dist.py
+++ b/edx/analytics/tasks/studentmodule_dist.py
@@ -1,0 +1,303 @@
+"""
+Tasks to compute histogram distribution from the courseware_studentmodule table in edx-platform's mysql database,
+either by producing a new dump with sqoop or using existing dumps, and export them into analytics-data-api's
+mysql database.
+"""
+
+import csv
+from collections import defaultdict
+import logging
+
+import luigi
+
+from edx.analytics.tasks.mapreduce import MapReduceJobTask, MapReduceJobTaskMixin
+from edx.analytics.tasks.sqoop import SqoopImportFromMysql
+from edx.analytics.tasks.util import csv_util
+from edx.analytics.tasks.url import url_path_join, get_target_from_url
+from edx.analytics.tasks.database_exports import FIELD_SIZE_LIMIT, StudentModuleRecord
+from edx.analytics.tasks.mysql_load import MysqlInsertTask
+
+log = logging.getLogger(__name__)
+
+
+# Increase maximum number of characters per field since we have
+# entries that easily exceed the default value of 124 KB.
+csv.field_size_limit(FIELD_SIZE_LIMIT)
+
+
+######################################################################
+###       Abstract Import and Histogram Calculation Section        ###
+######################################################################
+class HistogramTaskFromSqoopParamsMixin(object):
+    """
+    Mixin the parameters for HistogramsFromStudentModule that involve Sqoop
+
+    Parameters:
+        * name: Name of this run
+        * dest: URL of S3 location/directory where the task outputs
+        * credentials: creds for the edx-platform db
+        * sqoop_overwrite:  Overwrite any existing imports.  Default is false.
+        * num_mappers: number of mappers for Sqoop to use
+    """
+    name = luigi.Parameter()
+    dest = luigi.Parameter()
+    credentials = luigi.Parameter(
+        default_from_config={'section': 'database-import', 'name': 'credentials'}
+    )
+    sqoop_overwrite = luigi.BooleanParameter(default=False)  # prefixed with sqoop for disambiguation
+    num_mappers = luigi.Parameter(default=None, significant=False)  # TODO: move to config
+
+
+class HistogramFromStudentModuleSqoopWorkflowBase(
+    HistogramTaskFromSqoopParamsMixin,
+    MapReduceJobTask
+):
+    """
+    Abstract base class for taking a Sqoop dump of a courseware_studentmodule table and calculating histogram data
+
+    Implementers must override mapper_yield and reducer_yield
+    """
+    def mapper(self, line):
+        """
+        Yields the correct values by consulting mapper_yield
+        """
+        values = csv_util.parse_line(line, dialect='mysqldump')
+        record = StudentModuleRecord(*values)
+        return self.mapper_yield(record)  # return generator we got from yield
+
+    def mapper_yield(self, record):
+        """
+        Takes a record:StudentModuleRecord and decides how the mapper should yield the data.
+
+        Subclasses need to implement this.  Must "return" a generator (via yield)
+        """
+        raise NotImplementedError
+
+    def reducer(self, key, values):
+        """
+        Collates values and produces histogram data
+        """
+        histogram = defaultdict(int)  # int() returns 0
+        for v in values:
+            histogram[v] += 1
+        return self.reducer_yield(key, histogram)  # return generator we got from yield
+
+    def reducer_yield(self, reducer_key, histogram):
+        """
+        Formats the yielded output from the histogram.  Subclasses need to implement this.
+
+        Must "return" a generator (via yield)
+
+        Parameters:
+            * reducer_key: key fed into the reducer
+            * histogram: the computed histogram
+        """
+        raise NotImplementedError
+
+    def requires(self):
+        table_name = 'courseware_studentmodule'
+        return SqoopImportFromMysql(
+            credentials=self.credentials,
+            destination=url_path_join(self.dest, table_name),
+            table_name=table_name,
+            num_mappers=self.num_mappers,
+            overwrite=self.sqoop_overwrite,
+        )
+
+
+######################################################################
+###           Abstract Export to Mysql Workflow Section            ###
+######################################################################
+class HistogramFromSqoopToMySQLWorkflowBase(
+    HistogramTaskFromSqoopParamsMixin,
+    MapReduceJobTaskMixin,
+    MysqlInsertTask
+):
+    """
+    An abstract base class that formulates the workflow that runs sqoop to produce a sql dump, generates
+    a histogram, and then exports to the analytics database.
+
+    Clears the target mysql table before writing.
+
+    Implementers must inherit from this base class and define the properties specifying of the mysql export
+    i.e. table, columns, indexes, etc, (or mix it in, e.g. InsertToMysqlGradeDistTableMixin).
+    They must also override sqoop_histogram_task
+
+    One notable subtlety is that this needs 2 sets of mysql credentials,
+    Parameter "--import-credentials" is the location of the readonly edx-platform db creds
+    Parameter "--credentials" is the location of the analytics-db creds
+    """
+    sqoop_histogram_task = None  # implementers must override default
+
+    import_credentials = luigi.Parameter()  # location of the edx-platform db creds
+
+    overwrite = True  # always overwrite the exported MySQL table.  Independent of sqoop_overwrite, which is for import
+
+    @property
+    def insert_source_task(self):
+        return self.sqoop_histogram_task(
+            mapreduce_engine=self.mapreduce_engine,
+            n_reduce_tasks=self.n_reduce_tasks,
+            name=self.name,
+            dest=self.dest,
+            credentials=self.import_credentials,
+            num_mappers=self.num_mappers,
+            sqoop_overwrite=self.sqoop_overwrite,
+        )
+
+
+######################################################################
+###               Grade Distribution Section                       ###
+######################################################################
+class GradeDistFromStudentModuleMixin(object):
+    """
+    Takes a SQL dump of a courseware_studentmodule table and calculates the grade distribution per module
+    """
+    def mapper_yield(self, record):
+        if record.grade != "NULL":
+            yield (record.module_id, record.course_id), (record.grade, record.max_grade)
+
+    def reducer_yield(self, reducer_key, histogram):
+        for k in histogram:
+            yield [
+                reducer_key[0],  # module_id
+                reducer_key[1],  # course_id
+                k[0] if k[0] != "NULL" else None,  # grade, converting "NULL" -> None
+                k[1] if k[1] != "NULL" else None,  # max_grade, converting "NULL" -> None
+                histogram[k],  # count
+            ]
+
+    def output(self):
+        output_name = u'grade_dist_{name}/'.format(name=self.name)
+        return get_target_from_url(url_path_join(self.dest, output_name))
+
+
+class GradeDistFromSqoopToTSVWorkflow(
+    GradeDistFromStudentModuleMixin,
+    HistogramFromStudentModuleSqoopWorkflowBase,
+):
+    """
+    Task that sqoops a SQL dump of a courseware_studentmodule table, calculates the grade distribution per module,
+    and outputs a TSV
+
+    This is a concrete class that does work, but it's simply a composition that needs no code.  Instead of
+    defining mapper_yield and reducer_yield in this class, we get it from a mixin so as to not copy-paste code
+    """
+    pass
+
+
+class InsertToMysqlGradeDistTableMixin(object):
+    """
+    Define grade_distribution table.
+    """
+    @property
+    def table(self):
+        return "grade_distribution"
+
+    @property
+    def columns(self):
+        return [
+            ('module_id', 'VARCHAR(255) NOT NULL'),
+            ('course_id', 'VARCHAR(255) NOT NULL'),
+            ('grade', 'DOUBLE'),
+            ('max_grade', 'DOUBLE'),
+            ('count', 'INT(11) NOT NULL'),
+        ]
+
+    @property
+    def indexes(self):
+        return [
+            ('module_id',),
+            ('course_id',),
+        ]
+
+
+class GradeDistFromSqoopToMySQLWorkflow(
+    InsertToMysqlGradeDistTableMixin,
+    HistogramFromSqoopToMySQLWorkflowBase,
+):
+    """
+    Task class that writes to grade_distribution table from GradeDistFromStudentModuleSqoopWorkflow.
+
+    Gets most of its functionality from inheritance.  E.g. uses InsertToMysqlGradeDistTableMixin
+    instead of copy-paste
+    """
+    sqoop_histogram_task = GradeDistFromSqoopToTSVWorkflow
+
+
+######################################################################
+###                Open Distribution Section                       ###
+######################################################################
+class SeqOpenDistFromStudentModuleMixin(object):
+    """
+    Takes a SQL dump of a courseware_studentmodule table and calculates the "open" count per subsection/sequential
+
+    The open count is just the number of existent rows for that subsection/sequential, which indicates that a student
+    has instantiated that subsection/sequential ("opened").
+    """
+    def mapper_yield(self, record):
+        if record.module_type == "sequential":
+            yield (record.module_id, record.course_id), record.module_id  # values should all be identical per key
+
+    def reducer_yield(self, reducer_key, histogram):
+        for k in histogram:
+            yield [
+                reducer_key[0],  # module_id
+                reducer_key[1],  # course_id
+                histogram[k],  # count
+            ]
+
+    def output(self):
+        output_name = u'seq_open_dist_{name}/'.format(name=self.name)
+        return get_target_from_url(url_path_join(self.dest, output_name))
+
+
+class SeqOpenDistFromSqoopToTSVWorkflow(
+    SeqOpenDistFromStudentModuleMixin,
+    HistogramFromStudentModuleSqoopWorkflowBase,
+):
+    """
+    Sqoops a SQL dump of courseware_studentmodule and calculates the "open" distribution per subsection/sequential
+
+    This is a concrete class that does work, but it's simply a composition that needs no code
+    e.g. it gets the redefinition of mapper_yield and reducer_yield from SeqOpenDistFromStudentModuleMixin
+    instead of copy-pasting code
+    """
+    pass
+
+
+class InsertToMysqlSeqOpenDistTableMixin(object):
+    """
+    Define sequential_open_distribution table.
+    """
+    @property
+    def table(self):
+        return "sequential_open_distribution"
+
+    @property
+    def columns(self):
+        return [
+            ('module_id', 'VARCHAR(255) NOT NULL'),
+            ('course_id', 'VARCHAR(255) NOT NULL'),
+            ('count', 'INT(11) NOT NULL'),
+        ]
+
+    @property
+    def indexes(self):
+        return [
+            ('module_id',),
+            ('course_id',),
+        ]
+
+
+class SeqOpenDistFromSqoopToMySQLWorkflow(
+    InsertToMysqlSeqOpenDistTableMixin,
+    HistogramFromSqoopToMySQLWorkflowBase,
+):
+    """
+    Task class that writes to sequential_open_distribution table from SeqOpenDistFromStudentModuleSqoopWorkflow.
+
+    Gets most of its functionality from inheritance
+    E.g. gets the table definition from InsertToMysqlSeqOpenDistTableMixin instead of copy-paste code.
+    """
+    sqoop_histogram_task = SeqOpenDistFromSqoopToTSVWorkflow

--- a/edx/analytics/tasks/tests/acceptance/fixtures/input/courseware_studentmodule_for_histograms.sql
+++ b/edx/analytics/tasks/tests/acceptance/fixtures/input/courseware_studentmodule_for_histograms.sql
@@ -1,0 +1,19 @@
+-- MySQL dump 10.13  Distrib 5.6.19, for osx10.9 (x86_64)
+--
+-- Host: localhost    Database: analytics
+-- ------------------------------------------------------
+-- Server version	5.6.19
+--
+-- Table structure for table `courseware_studentmodule`
+--
+--
+DROP TABLE IF EXISTS `courseware_studentmodule`;
+
+CREATE TABLE `courseware_studentmodule` (`id` int(11) NOT NULL AUTO_INCREMENT, `module_type` varchar(32) NOT NULL DEFAULT 'problem', `module_id` varchar(255) NOT NULL, `student_id` int(11) NOT NULL, `state` longtext, `grade` double DEFAULT NULL, `created` datetime NOT NULL, `modified` datetime NOT NULL, `max_grade` double DEFAULT NULL,`done` varchar(8) NOT NULL,`course_id` varchar(255) NOT NULL, PRIMARY KEY (`id`),UNIQUE KEY `courseware_studentmodule_student_id_635d77aea1256de5_uniq` (`student_id`,`module_id`,`course_id`),KEY `courseware_studentmodule_42ff452e` (`student_id`), KEY `courseware_studentmodule_3216ff68` (`created`), KEY `courseware_studentmodule_6dff86b5` (`grade`),KEY `courseware_studentmodule_5436e97a` (`modified`),KEY `courseware_studentmodule_2d8768ff` (`module_type`),KEY `courseware_studentmodule_f53ed95e` (`module_id`),KEY `courseware_studentmodule_1923c03f` (`done`),KEY `courseware_studentmodule_ff48d8e5` (`course_id`) ) ENGINE=InnoDB AUTO_INCREMENT=97296 DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `courseware_studentmodule`
+--
+INSERT INTO `courseware_studentmodule` VALUES (97281,'problem','i4x://stanford/analytics/problem/test1',1,'{}',0,'2014-08-22 20:36:43','2014-08-22 20:36:43',2,'na','stanford/analytics/tests'),(97283,'problem','i4x://stanford/analytics/problem/test1',2,'{}',1,'2014-08-22 20:36:43','2014-08-22 20:36:43',2,'na','stanford/analytics/tests'),(97284,'problem','i4x://stanford/analytics/problem/test1',3,'{}',2,'2014-08-22 20:36:43','2014-08-22 20:36:43',2,'na','stanford/analytics/tests'),(97285,'problem','i4x://stanford/analytics/problem/test1',4,'{}',0,'2014-08-22 20:36:43','2014-08-22 20:36:43',2,'na','stanford/analytics/tests'),(97286,'problem','i4x://stanford/analytics/problem/test1',5,'{}',0,'2014-08-22 20:36:43','2014-08-22 20:36:43',2,'na','stanford/analytics/tests'),(97288,'problem','i4x://stanford/analytics/problem/test1',6,'{}',1,'2014-08-22 20:36:43','2014-08-22 20:36:43',2,'na','stanford/analytics/tests'),(97289,'problem','i4x://stanford/analytics/problem/test2',6,'{}',1,'2014-08-22 20:36:43','2014-08-22 20:36:43',NULL,'na','stanford/analytics/tests'),(97290,'problem','i4x://stanford/analytics/problem/test2',7,'{}',1,'2014-08-22 20:36:43','2014-08-22 20:36:43',1,'na','stanford/analytics/tests'),(97291,'problem','i4x://stanford/analytics/problem/test2',8,'{}',0,'2014-08-22 20:36:43','2014-08-22 20:36:43',1,'na','stanford/analytics/tests'),(97292,'sequential','i4x://stanford/analytics/sequential/test2',8,'{}',NULL,'2014-08-22 20:36:43','2014-08-22 20:36:43',NULL,'na','stanford/analytics/tests'),(97293,'sequential','i4x://stanford/analytics/sequential/test1',9,'{}',NULL,'2014-08-22 20:36:43','2014-08-22 20:36:43',NULL,'na','stanford/analytics/tests'),(97295,'sequential','i4x://stanford/analytics/sequential/test2',9,'{}',NULL,'2014-08-22 20:36:43','2014-08-22 20:36:43',NULL,'na','stanford/analytics/tests');
+
+-- Dump completed on 2014-08-22 13:59:58

--- a/edx/analytics/tasks/tests/acceptance/test_studentmodule_dist.py
+++ b/edx/analytics/tasks/tests/acceptance/test_studentmodule_dist.py
@@ -1,0 +1,117 @@
+"""
+Run end-to-end acceptance tests regarding the import of courseware_studentmodule, the computation of histgrams,
+and the exporting of that data into the analytics database.
+
+The goal of these tests is to emulate (as closely as possible) user actions and validate user visible outputs.
+"""
+
+import logging
+import os
+
+from edx.analytics.tasks.url import url_path_join
+from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase
+
+
+log = logging.getLogger(__name__)
+
+
+class CSMHistogramAcceptanceTest(AcceptanceTestCase):
+    """Validate the courseware_studentmodule -> luigi -> analytics db data pipeline"""
+
+    ENVIRONMENT = 'acceptance'
+    SQL_FILE = 'courseware_studentmodule_for_histograms.sql'
+
+    def setUp(self):
+        super(CSMHistogramAcceptanceTest, self).setUp()
+
+    def load_data_from_sql_file(self):
+        """
+        External Effect: Drops courseware_studentmodule table and loads it with data from a static file.
+        """
+        self.import_db.execute_sql_file(
+            os.path.join(self.data_dir, 'input', self.SQL_FILE)
+        )
+
+    def test_grade_dist_db_to_db(self):
+        """
+        Tests the grade_dist data flow starting from courseware_studentmodule table in mysql, including running sqoop
+        """
+        self.load_data_from_sql_file()
+        self.run_grade_dist_sqoop_workflow()
+        self.validate_grade_dist_in_analytics_db()
+
+    def run_grade_dist_sqoop_workflow(self):
+        """
+        Preconditions: Populated courseware_studentmodule table in the MySQL database.
+        External Effect: Generates a sqoop dump with the contents of courseware_studentmodule from the MySQL
+            database for the test course and stores it in S3.  Then populates the analytics database table
+            grade_distribution with histogram data.
+        """
+        self.task.launch([
+            'GradeDistFromSqoopToMySQLWorkflow',
+            '--import-credentials', self.import_db.credentials_file_url,
+            '--credentials', self.export_db.credentials_file_url,
+            '--name', self.ENVIRONMENT,
+            '--dest', url_path_join(self.test_out, self.ENVIRONMENT),
+            '--num-mappers', str(self.NUM_MAPPERS),
+            '--n-reduce-tasks', str(self.NUM_REDUCERS),
+            '--sqoop-overwrite',
+        ])
+
+    def validate_grade_dist_in_analytics_db(self):
+        """
+        Preconditions: Table grade_distribution has been populated by luigi workflows
+        """
+        expected_grade_dist_rows = (
+            # (module_id, course_id, grade, max_grade, count)
+            ("i4x://stanford/analytics/problem/test1", "stanford/analytics/tests", 0.0, 2.0, 3),
+            ("i4x://stanford/analytics/problem/test1", "stanford/analytics/tests", 1.0, 2.0, 2),
+            ("i4x://stanford/analytics/problem/test1", "stanford/analytics/tests", 2.0, 2.0, 1),
+            ("i4x://stanford/analytics/problem/test2", "stanford/analytics/tests", 0.0, 1.0, 1),
+            ("i4x://stanford/analytics/problem/test2", "stanford/analytics/tests", 1.0, 1.0, 1),
+            ("i4x://stanford/analytics/problem/test2", "stanford/analytics/tests", 1.0, None, 1),  # max_grade = NULL
+        )
+        with self.export_db.cursor() as cursor:
+            cursor.execute('SELECT `module_id`, `course_id`, `grade`, `max_grade`, `count` from grade_distribution')
+            all_rows = cursor.fetchall()
+            self.assertEqual(set(all_rows), set(expected_grade_dist_rows))
+
+    def test_seq_open_dist_db_to_db(self):
+        """
+        Tests the seq_open_dist data flow starting from courseware_studentmodule table in mysql, including running sqoop
+        """
+        self.load_data_from_sql_file()
+        self.run_seq_open_dist_sqoop_workflow()
+        self.validate_seq_open_dist_in_analytics_db()
+
+    def run_seq_open_dist_sqoop_workflow(self):
+        """
+        Preconditions: Populated courseware_studentmodule table in the MySQL database.
+        External Effect: Generates a sqoop dump with the contents of courseware_studentmodule from the MySQL
+            database for the test course and stores it in S3.  Then populates the analytics database table
+            sequential_open_distribution with histogram data.
+        """
+        self.task.launch([
+            'SeqOpenDistFromSqoopToMySQLWorkflow',
+            '--import-credentials', self.import_db.credentials_file_url,
+            '--credentials', self.export_db.credentials_file_url,
+            '--name', self.ENVIRONMENT,
+            '--dest', url_path_join(self.test_out, self.ENVIRONMENT),
+            '--num-mappers', str(self.NUM_MAPPERS),
+            '--n-reduce-tasks', str(self.NUM_REDUCERS),
+            '--sqoop-overwrite',
+        ])
+
+    def validate_seq_open_dist_in_analytics_db(self):
+        """
+        Preconditions: Table sequential_open_distribution has been populated by luigi workflows
+        """
+        expected_seq_open_dist_rows = (
+            # (module_id, course_id, count)
+            ("i4x://stanford/analytics/sequential/test1", "stanford/analytics/tests", 1),
+            ("i4x://stanford/analytics/sequential/test2", "stanford/analytics/tests", 2),
+        )
+        with self.export_db.cursor() as cursor:
+            cursor.execute('SELECT `module_id`, `course_id`, `count` from sequential_open_distribution')
+            all_rows = cursor.fetchall()
+            self.assertEqual(set(all_rows), set(expected_seq_open_dist_rows))

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ edx.analytics.tasks =
     database-import = edx.analytics.tasks.database_imports:ImportAllDatabaseTablesTask
     location-per-course = edx.analytics.tasks.location_per_course:LastCountryOfUser
     course-facts-to-mysql = edx.analytics.tasks.daily_enrollment_trends:ImportCourseDailyFactsIntoMysql
+    grade-dist = edx.analytics.tasks.studentmodule_dist:GradeDistFromSqoopToMySQLWorkflow
 
 mapreduce.engine =
     hadoop = edx.analytics.tasks.mapreduce:MapReduceJobRunner


### PR DESCRIPTION
@mulby @brianhw 

These tasks compute histogram statistics from courseware_studentmodule dumps.  There are 2 statistics, grade distribution and open count for sequential modules, that Stanford currently calculates directly from c_sm to render a view in the lms instructor panel, that we'd like to replace with aggregated data from the analytics database (for faster loading).

Both grade dist and seq open count have 2 workflows, one from an existing CSV (pre-sqooped) db dump and one that includes running sqoop.  There are acceptance tests covering all 4 of these workflows.

Also, let me lay out the class/mixin hierarchy I was going for.  I wanted to capture the somewhat abstract idea of "calculating histogram statistics from a dump of courseware_studentmodule" and make it easy to build implementations that do something specific with that.  So that abstract concept maps to an abstract base class `HistogramsFromStudentModuleBase`.  Then, two abstract workflows corresponding to "start from CSV"  and "start from Sqoop" (`HistogramFromStudentModuleDumpWorkflowBase` and `HistogramFromStudentModuleSqoopWorkflowBase`) inherit from that abstract base class.  

Then, attributes specific to "grade distribution" versus "sequential open distribution" are mixed in to (composed with) those abstract workflows to form the final concrete workflows.
