### PR TITLE
Loosen access restrictions on temp working dir to match logging dir.

### DIFF
--- a/share/task.yml
+++ b/share/task.yml
@@ -59,7 +59,7 @@
         - "{{ root_log_dir }}"
 
     - name: working directories created
-      file: path={{ item }} state=directory owner={{ ansible_ssh_user }} group={{ ansible_ssh_user }}
+      file: path={{ item }} state=directory mode=777 owner={{ ansible_ssh_user }} group={{ ansible_ssh_user }}
       sudo: True
       with_items:
         - "{{ working_dir }}"


### PR DESCRIPTION
This will clear up autogather-related permissions errors in Hive.

@brianhw @mulby @jhelbert 

See builds 295 (full suite) and 294 (one test) from analytics-tasks-acceptance-test-manual.
