### PR TITLE
Support computation of multiple weeks of user activity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,9 @@ coverage-local: test-local
 	diff-quality --violations=pylint --html-report diff_quality_pylint.html
 
 	# Compute style violations
-	pep8 edx > pep8.report || echo "Not pep8 clean"
-	pylint -f parseable edx > pylint.report || echo "Not pylint clean"
+	pep8 edx > pep8.report
+	# Ignore TODOs
+	pylint --disable=W0511 -f parseable edx > pylint.report || echo "Not pylint clean"
 
 coverage: test coverage-local
 

--- a/config/local.cfg
+++ b/config/local.cfg
@@ -6,6 +6,7 @@ marker = /tmp/antasks/marker/
 
 [event-logs]
 source = /tmp/antasks/input/
+pattern = .*tracking.log-(?P<date>\d{8}).*\.gz
 
 [manifest]
 path = /tmp/antasks/manifest/

--- a/config/test.cfg
+++ b/config/test.cfg
@@ -3,6 +3,7 @@
 [hive]
 release = apache
 database = default
+warehouse_path = s3://fake/warehouse/
 
 [database-export]
 database = to_database
@@ -52,3 +53,6 @@ history = s3://fake/enrollment_reports/enrollment_history.tsv
 [geolocation]
 geolocation_data = s3://fake/geo.dat
 
+[calendar]
+interval = 2012-01-01-2050-01-01
+fiscal_year_begins = 7

--- a/edx/analytics/tasks/calendar.py
+++ b/edx/analytics/tasks/calendar.py
@@ -1,0 +1,109 @@
+
+from datetime import datetime, timedelta
+import logging
+
+import luigi
+
+from edx.analytics.tasks.database_imports import ImportIntoHiveTableTask
+from edx.analytics.tasks.url import url_path_join, get_target_from_url
+from edx.analytics.tasks.util.hive import ImportIntoHiveTableTask, HivePartition, TABLE_FORMAT_TSV
+from edx.analytics.tasks.util.overwrite import OverwriteOutputMixin
+
+log = logging.getLogger(__name__)
+
+try:
+    from isoweek import Week
+except ImportError:
+    log.warning('isoweek module not available')
+
+MONTHS_PER_YEAR = 12
+MONTHS_PER_QUARTER = MONTHS_PER_YEAR / 4
+
+
+class CalendarMixin(OverwriteOutputMixin):
+
+    interval = luigi.DateIntervalParameter(
+        default_from_config={'section': 'calendar', 'name': 'interval'}
+    )
+    fiscal_year_begins = luigi.IntParameter(
+        default_from_config={'section': 'calendar', 'name': 'fiscal_year_begins'}
+    )
+
+
+class CalendarTask(CalendarMixin, luigi.Task):
+
+    output_root = luigi.Parameter()
+
+    def output(self):
+        return get_target_from_url(self.output_root, 'data.tsv')
+
+    def run(self):
+        self.remove_output_on_overwrite()
+
+        with self.output().open('w') as output_file:
+            for date in self.interval:
+                if date.month >= self.fiscal_year_begins:
+                    fiscal_year = date.year + 1
+                    fiscal_quarter = (date.month - self.fiscal_year_begins) / MONTHS_PER_QUARTER
+                else:
+                    fiscal_year = date.year
+                    fiscal_quarter = ((date.month + MONTHS_PER_YEAR) - self.fiscal_year_begins) / MONTHS_PER_QUARTER
+
+                fiscal_quarter += 1
+
+                iso_year, iso_weekofyear, iso_weekday = date.isocalendar()
+                week = Week(iso_year, iso_weekofyear)
+
+                column_values = (
+                    date.isoformat(),
+                    date.year,
+                    date.month,
+                    date.day,
+                    '{0:04d}W{1:02d}'.format(iso_year, iso_weekofyear),
+                    week.monday().isoformat(),
+                    (week.sunday() + timedelta(1)).isoformat(),
+                    iso_weekday,
+                    '{0:04d}Q{1}'.format(fiscal_year, fiscal_quarter),
+                    fiscal_year,
+                    fiscal_quarter,
+                )
+                output_file.write('\t'.join([unicode(v) for v in column_values]) + '\n')
+
+
+class ImportCalendarToHiveTask(CalendarMixin, ImportIntoHiveTableTask):
+
+    @property
+    def table_name(self):
+        return 'calendar'
+
+    @property
+    def columns(self):
+        return [
+            ('date', 'STRING'),
+            ('year', 'INT'),
+            ('month', 'INT'),
+            ('day', 'INT'),
+            ('iso_weekofyear', 'STRING'),
+            ('iso_week_start', 'STRING'),
+            ('iso_week_end', 'STRING'),
+            ('iso_weekday', 'INT'),
+            ('fiscal_quarter', 'INT'),
+            ('fiscal_year', 'INT'),
+            ('fiscal_quarterofyear', 'INT'),
+        ]
+
+    @property
+    def table_format(self):
+        return TABLE_FORMAT_TSV
+
+    @property
+    def partition(self):
+        return HivePartition('interval', str(self.interval))
+
+    def requires(self):
+        return CalendarTask(
+            output_root=self.partition_location,
+            interval=self.interval,
+            fiscal_year_begins=self.fiscal_year_begins,
+            overwrite=self.overwrite,
+        )

--- a/edx/analytics/tasks/course_enroll.py
+++ b/edx/analytics/tasks/course_enroll.py
@@ -181,7 +181,7 @@ class BaseCourseEnrollmentTaskDownstreamMixin(OverwriteOutputMixin, MapReduceJob
     dest = luigi.Parameter()
     include = luigi.Parameter(is_list=True, default=('*',))
     manifest = luigi.Parameter(default=None)
-    run_date = luigi.Parameter(default=datetime.date.today())
+    run_date = luigi.Parameter(default=datetime.datetime.utcnow().date().isoformat())
 
 
 ##################################
@@ -203,10 +203,6 @@ class CourseEnrollmentEventsPerDay(
         output_name = 'course_enrollment_events_per_day_{name}/dt={date}/'.format(name=self.name, date=self.run_date)
         return get_target_from_url(url_path_join(self.dest, output_name))
 
-    def run(self):
-        self.remove_output_on_overwrite()
-        super(CourseEnrollmentEventsPerDay, self).run()
-
 
 class CourseEnrollmentChangesPerDay(
         CourseEnrollmentChangesPerDayMixin,
@@ -225,10 +221,6 @@ class CourseEnrollmentChangesPerDay(
             manifest=self.manifest,
             overwrite=self.overwrite,
         )
-
-    def run(self):
-        self.remove_output_on_overwrite()
-        super(CourseEnrollmentChangesPerDay, self).run()
 
     def output(self):
         output_name = 'course_enrollment_changes_per_day_{name}/dt={date}/'.format(name=self.name, date=self.run_date)

--- a/edx/analytics/tasks/daily_enrollment_trends.py
+++ b/edx/analytics/tasks/daily_enrollment_trends.py
@@ -2,12 +2,13 @@
 Determine the number of users that are enrolled in each course over time
 """
 import logging
-import textwrap
 
 import luigi
 
-from edx.analytics.tasks.util.hive import ImportIntoHiveTableTask, HiveTableFromQueryTask, HivePartition, TABLE_FORMAT_TSV
-from edx.analytics.tasks.url import get_target_from_url, url_path_join
+from edx.analytics.tasks.util.hive import (
+    ImportIntoHiveTableTask, HiveTableFromQueryTask, HivePartition, TABLE_FORMAT_TSV
+)
+from edx.analytics.tasks.url import url_path_join
 from edx.analytics.tasks.course_enroll import CourseEnrollmentChangesPerDay, BaseCourseEnrollmentTaskDownstreamMixin
 from edx.analytics.tasks.mysql_load import MysqlInsertTask
 

--- a/edx/analytics/tasks/daily_enrollment_trends.py
+++ b/edx/analytics/tasks/daily_enrollment_trends.py
@@ -3,8 +3,10 @@ Determine the number of users that are enrolled in each course over time
 """
 import logging
 import textwrap
+
 import luigi
-from edx.analytics.tasks.database_imports import ImportIntoHiveTableTask
+
+from edx.analytics.tasks.util.hive import ImportIntoHiveTableTask, HiveTableFromQueryTask, HivePartition, TABLE_FORMAT_TSV
 from edx.analytics.tasks.url import get_target_from_url, url_path_join
 from edx.analytics.tasks.course_enroll import CourseEnrollmentChangesPerDay, BaseCourseEnrollmentTaskDownstreamMixin
 from edx.analytics.tasks.mysql_load import MysqlInsertTask
@@ -39,11 +41,11 @@ class ImportDailyEnrollmentTrendsToHiveTask(BaseCourseEnrollmentTaskDownstreamMi
     @property
     def table_format(self):
         """Provides structure of Hive external table data."""
-        return "ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t'"
+        return TABLE_FORMAT_TSV
 
     @property
-    def partition_date(self):
-        return str(self.run_date)
+    def partition(self):
+        return HivePartition('dt', str(self.run_date))
 
     def requires(self):
         return CourseEnrollmentChangesPerDay(
@@ -64,15 +66,7 @@ class ImportCourseEnrollmentOffsetsBlacklist(ImportIntoHiveTableTask):
     """
     Imports list of courses to blacklist from enrollment sums calculations.
     A new partition is created for every date where the blacklist is updated.
-
-    The input file is a tsv file assumed to exist at
-    s3://some-bucket/blacklist/enrollment/dt=<partition_date>
-
-    The file copied into the original partition 2014-08-27 is
-    s3://some-bucket/course_enrollment_offsets_with_2012_Spring.tsv.
-    ex. DemoOrgX/CourseFoo/3T2013 2013-12-03  12533
-
-     """
+    """
 
     blacklist_date = luigi.Parameter(
         default_from_config={'section': 'enrollments', 'name': 'blacklist_date'}
@@ -89,30 +83,21 @@ class ImportCourseEnrollmentOffsetsBlacklist(ImportIntoHiveTableTask):
         ]
 
     @property
-    def table_location(self):
-        return "s3://some-bucket/blacklist/enrollment/"
-
-    @property
-    def partition_date(self):
-        return self.blacklist_date
+    def partition(self):
+        return HivePartition('dt', self.blacklist_date)
 
     @property
     def table_format(self):
         """Provides format of Hive external table data."""
-        return "ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t'"
+        return TABLE_FORMAT_TSV
 
 
-class SumEnrollmentDeltasTask(BaseCourseEnrollmentTaskDownstreamMixin, ImportIntoHiveTableTask):
+class SumEnrollmentDeltasTask(BaseCourseEnrollmentTaskDownstreamMixin, HiveTableFromQueryTask):
     """Defines task to perform sum in Hive to find course enrollment counts."""
-    blacklist_date = luigi.Parameter(
-        default_from_config={'section': 'enrollments', 'name': 'blacklist_date'}
-    )
 
-    def query(self):
-        create_table_statements = super(SumEnrollmentDeltasTask, self).query()
-        query_format = textwrap.dedent("""
-            INSERT OVERWRITE TABLE {table_name}
-            PARTITION (dt='{partition_date}')
+    @property
+    def insert_query(self):
+        return """
             SELECT e.*
             FROM
             (
@@ -122,23 +107,11 @@ class SumEnrollmentDeltasTask(BaseCourseEnrollmentTaskDownstreamMixin, ImportInt
                     order by date ASC
                     ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
                 )
-                FROM {incremental_table_name} e
+                FROM course_enrollment_changes_per_day e
             ) e
-            LEFT OUTER JOIN {blacklist_table} b on (e.course_id = b.course_id)
+            LEFT OUTER JOIN course_enrollment_blacklist b ON e.course_id = b.course_id
             WHERE b.course_id IS NULL;
-
-        """)
-
-        insert_query = query_format.format(
-            table_name=self.table_name,
-            partition_date=self.partition_date,
-            incremental_table_name="course_enrollment_changes_per_day",
-            blacklist_table="course_enrollment_blacklist"
-        )
-
-        query = create_table_statements + insert_query
-        log.debug('Executing hive query: %s', query)
-        return query
+        """
 
     @property
     def table_name(self):
@@ -157,31 +130,30 @@ class SumEnrollmentDeltasTask(BaseCourseEnrollmentTaskDownstreamMixin, ImportInt
         return url_path_join(self.dest, self.table_name)
 
     @property
-    def table_format(self):
-        """Provides format of Hive external table data."""
-        return "ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t'"
+    def partition(self):
+        return HivePartition('dt', str(self.run_date))
 
     @property
-    def partition_date(self):
-        return str(self.run_date)
-
-    def output(self):
-        # partition_location is a property depending on table_location and partitions
-        return get_target_from_url(self.partition_location)
+    def table_format(self):
+        """Provides structure of Hive external table data."""
+        return TABLE_FORMAT_TSV
 
     def requires(self):
-        return ImportDailyEnrollmentTrendsToHiveTask(
-            mapreduce_engine=self.mapreduce_engine,
-            lib_jar=self.lib_jar,
-            n_reduce_tasks=self.n_reduce_tasks,
-            name=self.name,
-            src=self.src,
-            dest=self.dest,
-            include=self.include,
-            manifest=self.manifest,
-            overwrite=self.overwrite,
-            run_date=self.run_date
-        ), ImportCourseEnrollmentOffsetsBlacklist(blacklist_date=self.blacklist_date)
+        return (
+            ImportDailyEnrollmentTrendsToHiveTask(
+                mapreduce_engine=self.mapreduce_engine,
+                lib_jar=self.lib_jar,
+                n_reduce_tasks=self.n_reduce_tasks,
+                name=self.name,
+                src=self.src,
+                dest=self.dest,
+                include=self.include,
+                manifest=self.manifest,
+                overwrite=self.overwrite,
+                run_date=self.run_date
+            ),
+            ImportCourseEnrollmentOffsetsBlacklist(),
+        )
 
 
 class ImportCourseDailyFactsIntoMysql(BaseCourseEnrollmentTaskDownstreamMixin, MysqlInsertTask):

--- a/edx/analytics/tasks/database_imports.py
+++ b/edx/analytics/tasks/database_imports.py
@@ -6,12 +6,11 @@ import logging
 import textwrap
 
 import luigi
-from luigi.hive import HiveQueryTask, HivePartitionTarget
 
 from edx.analytics.tasks.sqoop import SqoopImportFromMysql
 from edx.analytics.tasks.url import url_path_join
+from edx.analytics.tasks.util.hive import ImportIntoHiveTableTask, HivePartition
 from edx.analytics.tasks.util.overwrite import OverwriteOutputMixin
-from edx.analytics.tasks.util.hive import hive_database_name
 
 log = logging.getLogger(__name__)
 
@@ -43,119 +42,10 @@ class DatabaseImportMixin(object):
     credentials = luigi.Parameter(
         default_from_config={'section': 'database-import', 'name': 'credentials'}
     )
-    import_date = luigi.DateParameter(default=None)
+    import_date = luigi.DateParameter(default=datetime.datetime.utcnow().date())
 
     num_mappers = luigi.Parameter(default=None, significant=False)
     verbose = luigi.BooleanParameter(default=False, significant=False)
-
-    def __init__(self, *args, **kwargs):
-        super(DatabaseImportMixin, self).__init__(*args, **kwargs)
-
-        if not self.import_date:
-            self.import_date = datetime.datetime.utcnow().date()
-
-
-class ImportIntoHiveTableTask(OverwriteOutputMixin, HiveQueryTask):
-    """
-    Abstract class to import data into a Hive table.
-
-    Requires four properties and a requires() method to be defined.
-    """
-
-    def query(self):
-        # TODO: Figure out how to clean up old data. This just cleans
-        # out old metastore info, and doesn't actually remove the table
-        # data.
-
-        # Ensure there is exactly one available partition in the
-        # table. Don't keep historical partitions since we don't want
-        # to commit to taking snapshots at any regular interval. They
-        # will happen when/if they need to happen.  Table snapshots
-        # should *not* be used for analyzing trends, instead we should
-        # rely on events or database tables that keep historical
-        # information.
-        query_format = textwrap.dedent("""
-            USE {database_name};
-            DROP TABLE IF EXISTS {table_name};
-            CREATE EXTERNAL TABLE {table_name} (
-                {col_spec}
-            )
-            PARTITIONED BY (dt STRING)
-            {table_format}
-            LOCATION '{location}';
-            ALTER TABLE {table_name} ADD PARTITION (dt = '{partition_date}');
-        """)
-
-        query = query_format.format(
-            database_name=hive_database_name(),
-            table_name=self.table_name,
-            col_spec=','.join([' '.join(c) for c in self.columns]),
-            location=self.table_location,
-            table_format=self.table_format,
-            partition_date=self.partition_date,
-        )
-
-        log.debug('Executing hive query: %s', query)
-
-        # Mark the output as having been removed, even though
-        # that doesn't technically happen until the query has been
-        # executed (and in particular that the 'DROP TABLE' is executed).
-        log.info("Marking existing output as having been removed for task %s", str(self))
-        self.attempted_removal = True
-
-        return query
-
-    @property
-    def partition(self):
-        """Provides name of Hive database table partition."""
-        # The Luigi hive code expects partitions to be defined by dictionaries.
-        return {'dt': self.partition_date}
-
-    @property
-    def partition_location(self):
-        """Provides location of Hive database table's partition data."""
-        # The actual folder name where the data is stored is expected to be in the format <key>=<value>
-        partition_name = '='.join(self.partition.items()[0])
-        # Make sure that input path ends with a slash, to indicate a directory.
-        # (This is necessary for S3 paths that are output from Hadoop jobs.)
-        return url_path_join(self.table_location, partition_name + '/')
-
-    @property
-    def table_name(self):
-        """Provides name of Hive database table."""
-        raise NotImplementedError
-
-    @property
-    def table_format(self):
-        """Provides format of Hive database table's data."""
-        raise NotImplementedError
-
-    @property
-    def table_location(self):
-        """Provides root location of Hive database table's data."""
-        raise NotImplementedError
-
-    @property
-    def partition_date(self):
-        """Provides value to use in constructing the partition name of Hive database table."""
-        raise NotImplementedError
-
-    @property
-    def columns(self):
-        """
-        Provides definition of columns in Hive.
-
-        This should define a list of (name, definition) tuples, where
-        the definition defines the Hive type to use. For example,
-        ('first_name', 'STRING').
-
-        """
-        raise NotImplementedError
-
-    def output(self):
-        return HivePartitionTarget(
-            self.table_name, self.partition, database=hive_database_name(), fail_missing_table=False
-        )
 
 
 class ImportMysqlToHiveTableTask(DatabaseImportMixin, ImportIntoHiveTableTask):
@@ -170,14 +60,9 @@ class ImportMysqlToHiveTableTask(DatabaseImportMixin, ImportIntoHiveTableTask):
         return url_path_join(self.destination, self.table_name)
 
     @property
-    def table_format(self):
-        # Use default of hive built-in format.
-        return ""
-
-    @property
-    def partition_date(self):
+    def partition(self):
         # Partition date is provided by DatabaseImportMixin.
-        return self.import_date.isoformat()
+        return HivePartition('dt', self.import_date.isoformat())
 
     def requires(self):
         return SqoopImportFromMysql(

--- a/edx/analytics/tasks/database_imports.py
+++ b/edx/analytics/tasks/database_imports.py
@@ -3,7 +3,6 @@ Import data from external RDBMS databases into Hive.
 """
 import datetime
 import logging
-import textwrap
 
 import luigi
 
@@ -56,13 +55,21 @@ class ImportMysqlToHiveTableTask(DatabaseImportMixin, ImportIntoHiveTableTask):
     """
 
     @property
+    def table_name(self):
+        raise NotImplementedError
+
+    @property
+    def columns(self):
+        raise NotImplementedError
+
+    @property
     def table_location(self):
         return url_path_join(self.destination, self.table_name)
 
     @property
     def partition(self):
         # Partition date is provided by DatabaseImportMixin.
-        return HivePartition('dt', self.import_date.isoformat())
+        return HivePartition('dt', self.import_date.isoformat())  # pylint: disable=no-member
 
     def requires(self):
         return SqoopImportFromMysql(

--- a/edx/analytics/tasks/launchers/local.py
+++ b/edx/analytics/tasks/launchers/local.py
@@ -28,7 +28,7 @@ OVERRIDE_CONFIGURATION_FILE = 'override.cfg'
 
 def main():
     # In order to see errors during extension loading, you can uncomment the next line.
-    # logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(level=logging.DEBUG)
 
     # Load tasks configured using entry_points
     # TODO: launch tasks by their entry_point name

--- a/edx/analytics/tasks/launchers/local.py
+++ b/edx/analytics/tasks/launchers/local.py
@@ -27,6 +27,8 @@ OVERRIDE_CONFIGURATION_FILE = 'override.cfg'
 
 
 def main():
+    """The primary entry point used to launch luigi tasks."""
+
     # In order to see errors during extension loading, you can uncomment the next line.
     logging.basicConfig(level=logging.DEBUG)
 

--- a/edx/analytics/tasks/location_per_course.py
+++ b/edx/analytics/tasks/location_per_course.py
@@ -3,17 +3,18 @@ Determine the number of users in each country are enrolled in each course.
 """
 import datetime
 import logging
-import textwrap
 
 import luigi
-from luigi.hive import HiveQueryTask, ExternalHiveTask
+from luigi.hive import ExternalHiveTask
 
 from edx.analytics.tasks.database_imports import ImportStudentCourseEnrollmentTask, ImportAuthUserTask
-from edx.analytics.tasks.util.hive import ImportIntoHiveTableTask, HiveTableFromQueryTask, WarehouseDownstreamMixin, HivePartition, TABLE_FORMAT_TSV
+from edx.analytics.tasks.util.hive import (
+    ImportIntoHiveTableTask, HiveTableFromQueryTask, WarehouseDownstreamMixin, HivePartition, TABLE_FORMAT_TSV
+)
 from edx.analytics.tasks.mapreduce import MapReduceJobTask, MapReduceJobTaskMixin
 from edx.analytics.tasks.mysql_load import MysqlInsertTask
 from edx.analytics.tasks.pathutil import EventLogSelectionMixin, EventLogSelectionDownstreamMixin
-from edx.analytics.tasks.url import ExternalURL, get_target_from_url, url_path_join
+from edx.analytics.tasks.url import ExternalURL, get_target_from_url
 from edx.analytics.tasks.user_location import BaseGeolocation, GeolocationMixin
 from edx.analytics.tasks.util.overwrite import OverwriteOutputMixin
 from edx.analytics.tasks.util import eventlog
@@ -117,7 +118,7 @@ class ImportLastCountryOfUserToHiveTask(LastCountryOfUserMixin, ImportIntoHiveTa
         # Because this data comes from EventLogSelectionDownstreamMixin,
         # we will use the end of the interval used to calculate
         # the country information.
-        return HivePartition('dt', self.interval.date_b.strftime('%Y-%m-%d'))
+        return HivePartition('dt', self.interval.date_b.strftime('%Y-%m-%d'))  # pylint: disable=no-member
 
     def requires(self):
         return LastCountryOfUser(
@@ -154,7 +155,7 @@ class QueryLastCountryPerCourseTask(HiveTableFromQueryTask):
 
     @property
     def partition(self):
-        return HivePartition('dt', self.import_date.isoformat())
+        return HivePartition('dt', self.import_date.isoformat())  # pylint: disable=no-member
 
     @property
     def table_name(self):
@@ -228,6 +229,10 @@ class InsertToMysqlCourseEnrollByCountryTask(MysqlInsertTask):
             ('course_id',),
             ('date', 'course_id'),
         ]
+
+    @property
+    def insert_source_task(self):
+        raise NotImplementedError
 
 
 class InsertToMysqlCourseEnrollByCountryWorkflow(

--- a/edx/analytics/tasks/mapreduce.py
+++ b/edx/analytics/tasks/mapreduce.py
@@ -115,6 +115,12 @@ class MapReduceJobRunner(luigi.hadoop.HadoopJobRunner):
             jobconfs=job_confs,
         )
 
+    def run_job(self, job):
+        if hasattr(job, 'remove_output_on_overwrite'):
+            job.remove_output_on_overwrite()
+
+        return super(MapReduceJobRunner, self).run_job(job)
+
 
 class EmulatedMapReduceJobRunner(luigi.hadoop.JobRunner):
     """

--- a/edx/analytics/tasks/mapreduce.py
+++ b/edx/analytics/tasks/mapreduce.py
@@ -140,19 +140,21 @@ class EmulatedMapReduceJobRunner(luigi.hadoop.JobRunner):
 
     """
 
-    def group(self, input):
+    def group(self, input_lines):
+        """Emulates the sort and grouping operations that map-reduce does in the shuffle"""
         output = StringIO.StringIO()
-        lines = []
-        for i, line in enumerate(input):
+        output_lines = []
+        for i, line in enumerate(input_lines):
             parts = line.rstrip('\n').split('\t')
             blob = md5(str(i)).hexdigest()  # pseudo-random blob to make sure the input isn't sorted
-            lines.append((parts[:-1], blob, line))
-        for k, _, line in sorted(lines):
+            output_lines.append((parts[:-1], blob, line))
+        for _, _, line in sorted(output_lines):
             output.write(line)
         output.seek(0)
         return output
 
     def run_job(self, job):
+        """A bare-bones emulation of the execution of a map-reduce job. Very limited in scope."""
         job.init_hadoop()
         job.init_mapper()
         map_output = StringIO.StringIO()
@@ -170,7 +172,7 @@ class EmulatedMapReduceJobRunner(luigi.hadoop.JobRunner):
 
                 os.environ['map_input_file'] = input_target.path
                 try:
-                    outputs = job._map_input((line[:-1] for line in input_file))
+                    outputs = job._map_input((line[:-1] for line in input_file))  # pylint: disable=protected-access
                     job.internal_writer(outputs, map_output)
                 finally:
                     del os.environ['map_input_file']
@@ -180,15 +182,15 @@ class EmulatedMapReduceJobRunner(luigi.hadoop.JobRunner):
         reduce_input = self.group(map_output)
         try:
             reduce_output = job.output().open('w')
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             reduce_output = StringIO.StringIO()
 
         try:
-            job._run_reducer(reduce_input, reduce_output)
+            job._run_reducer(reduce_input, reduce_output)  # pylint: disable=protected-access
         finally:
             try:
                 reduce_output.close()
-            except Exception:
+            except Exception:  # pylint: disable=broad-except
                 pass
 
 

--- a/edx/analytics/tasks/reports/enrollments.py
+++ b/edx/analytics/tasks/reports/enrollments.py
@@ -1,7 +1,7 @@
 """Enrollment related reports"""
 
 import csv
-from datetime import timedelta, date
+from datetime import timedelta, datetime
 
 import luigi
 import luigi.hdfs
@@ -27,7 +27,7 @@ class CourseEnrollmentCountMixin(MapReduceJobTaskMixin):
     days = luigi.Parameter(default=DEFAULT_NUM_DAYS)
     offsets = luigi.Parameter(default=None)
     history = luigi.Parameter(default=None)
-    date = luigi.DateParameter(default=date.today())
+    date = luigi.DateParameter(default=datetime.utcnow().date().isoformat())
     statuses = luigi.Parameter(default=None)
     manifest = luigi.Parameter(default=None)
     manifest_path = luigi.Parameter(default=None)

--- a/edx/analytics/tasks/tests/acceptance/test_database_export.py
+++ b/edx/analytics/tasks/tests/acceptance/test_database_export.py
@@ -180,7 +180,7 @@ class ExportAcceptanceTest(AcceptanceTestCase):
         validation_dir = os.path.join(self.working_dir, 'validation')
         os.makedirs(validation_dir)
 
-        today = datetime.datetime.utcnow().strftime('%Y-%m-%d')
+        today = datetime.datetime.utcnow().date().isoformat()
         bucket = boto.connect_s3().get_bucket(self.config.get('exporter_output_bucket'))
         export_id = '{org}-{date}'.format(org=self.org_id, date=today)
         filename = export_id + '.zip'

--- a/edx/analytics/tasks/tests/acceptance/test_hive.py
+++ b/edx/analytics/tasks/tests/acceptance/test_hive.py
@@ -47,7 +47,7 @@ class HiveAcceptanceTest(AcceptanceTestCase):
         self.task.launch([
             'ImportStudentCourseEnrollmentTask',
             '--credentials', self.import_db.credentials_file_url,
-            '--import-date', str(datetime.date.today()),
+            '--import-date', datetime.datetime.utcnow().date().isoformat(),
             '--num-mappers', str(self.NUM_MAPPERS),
             '--destination', self.test_src,
         ])

--- a/edx/analytics/tasks/tests/acceptance/test_location_per_course.py
+++ b/edx/analytics/tasks/tests/acceptance/test_location_per_course.py
@@ -29,8 +29,6 @@ class LocationByCourseAcceptanceTest(AcceptanceTestCase):
             'InsertToMysqlCourseEnrollByCountryWorkflow',
             '--source', self.test_src,
             '--interval', self.DATE_INTERVAL.to_string(),
-            '--user-country-output', url_path_join(self.test_out, 'user'),
-            '--course-country-output', url_path_join(self.test_out, 'country'),
             '--n-reduce-tasks', str(self.NUM_REDUCERS),
         ])
 

--- a/edx/analytics/tasks/tests/acceptance/test_user_activity.py
+++ b/edx/analytics/tasks/tests/acceptance/test_user_activity.py
@@ -19,11 +19,10 @@ class UserActivityAcceptanceTest(AcceptanceTestCase):
         self.upload_tracking_log(self.INPUT_FILE, self.START_DATE)
 
         self.task.launch([
-            'CountUserActivityPerIntervalTaskWorkflow',
+            'UserActivityWorkflow',
             '--source', self.test_src,
             '--interval', self.DATE_INTERVAL.to_string(),
             '--credentials', self.export_db.credentials_file_url,
-            '--output-root', self.test_out,
             '--n-reduce-tasks', str(self.NUM_REDUCERS),
         ])
 

--- a/edx/analytics/tasks/tests/test_database_imports.py
+++ b/edx/analytics/tasks/tests/test_database_imports.py
@@ -28,14 +28,14 @@ class ImportStudentCourseEnrollmentTestCase(unittest.TestCase):
         expected_query = textwrap.dedent(
             """
             USE default;
-            DROP TABLE IF EXISTS student_courseenrollment;
+
             CREATE EXTERNAL TABLE student_courseenrollment (
                 id INT,user_id INT,course_id STRING,created TIMESTAMP,is_active BOOLEAN,mode STRING
             )
             PARTITIONED BY (dt STRING)
 
             LOCATION 's3://foo/bar/student_courseenrollment';
-            ALTER TABLE student_courseenrollment ADD PARTITION (dt = '2014-07-01');
+            ALTER TABLE student_courseenrollment ADD PARTITION (dt='2014-07-01');
             """
         )
         self.assertEquals(query, expected_query)
@@ -49,7 +49,7 @@ class ImportStudentCourseEnrollmentTestCase(unittest.TestCase):
         # kwargs = {'overwrite': False}
         kwargs = {}
         task = ImportStudentCourseEnrollmentTask(**kwargs)
-        with patch('edx.analytics.tasks.database_imports.HivePartitionTarget') as mock_target:
+        with patch('edx.analytics.tasks.util.hive.HivePartitionTarget') as mock_target:
             output = mock_target()
             # Make MagicMock act more like a regular mock, so that flatten() does the right thing.
             del output.__iter__

--- a/edx/analytics/tasks/tests/test_location_per_course.py
+++ b/edx/analytics/tasks/tests/test_location_per_course.py
@@ -294,7 +294,10 @@ class InsertToMysqlCourseEnrollByCountryWorkflowTestCase(unittest.TestCase):
         required_tasks = task.requires()
         self.assertEquals(len(required_tasks), 2)
         self.assertEquals(required_tasks['credentials'].output().path, 's3://config/credentials/output-database.json')
-        self.assertEquals(required_tasks['insert_source'].output().path, 's3://fake/warehouse/course_enrollment_location_current/dt=2014-08-23')
+        self.assertEquals(
+            required_tasks['insert_source'].output().path,
+            's3://fake/warehouse/course_enrollment_location_current/dt=2014-08-23'
+        )
 
     def test_requires_with_overwrite(self):
         kwargs = self._get_kwargs()

--- a/edx/analytics/tasks/tests/test_location_per_course.py
+++ b/edx/analytics/tasks/tests/test_location_per_course.py
@@ -23,8 +23,8 @@ class LastCountryOfUserMapperTestCase(BaseUserLocationEventTestCase):
     def setUp(self):
         self.task = LastCountryOfUser(
             mapreduce_engine='local',
-            user_country_output='test://output/',
             interval=Year.parse('2013'),
+            output_root='s3://fake/warehouse/last_country_of_user'
         )
         self.task.init_local()
 
@@ -78,8 +78,8 @@ class LastCountryOfUserReducerTestCase(unittest.TestCase):
         self.earlier_timestamp = "2013-12-15T15:38:32.805444"
         self.task = LastCountryOfUser(
             mapreduce_engine='local',
-            user_country_output='test://output/',
             interval=Year.parse('2014'),
+            output_root='s3://fake/warehouse/last_country_of_user'
         )
         self.task.geoip = FakeGeoLocation()
 
@@ -158,8 +158,7 @@ class ImportLastCountryOfUserToHiveTestCase(unittest.TestCase):
     def _get_kwargs(self):
         """Provides minimum args for instantiating ImportLastCountryOfUserToHiveTask."""
         return {
-            'interval': Year.parse('2013'),
-            'user_country_output': 's3://output/path',
+            'interval': Year.parse('2013')
         }
 
     def test_query_with_date_interval(self):
@@ -168,14 +167,14 @@ class ImportLastCountryOfUserToHiveTestCase(unittest.TestCase):
         expected_query = textwrap.dedent(
             """
             USE default;
-            DROP TABLE IF EXISTS last_country_of_user;
+
             CREATE EXTERNAL TABLE last_country_of_user (
                 country_name STRING,country_code STRING,username STRING
             )
             PARTITIONED BY (dt STRING)
-            ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t'
-            LOCATION 's3://output/path';
-            ALTER TABLE last_country_of_user ADD PARTITION (dt = '2014-01-01');
+            ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t'
+            LOCATION 's3://fake/warehouse/last_country_of_user/';
+            ALTER TABLE last_country_of_user ADD PARTITION (dt='2014-01-01');
             """
         )
         self.assertEquals(query, expected_query)
@@ -188,7 +187,7 @@ class ImportLastCountryOfUserToHiveTestCase(unittest.TestCase):
 
     def test_no_overwrite(self):
         task = ImportLastCountryOfUserToHiveTask(**self._get_kwargs())
-        with patch('edx.analytics.tasks.database_imports.HivePartitionTarget') as mock_target:
+        with patch('edx.analytics.tasks.util.hive.HivePartitionTarget') as mock_target:
             output = mock_target()
             # Make MagicMock act more like a regular mock, so that flatten() does the right thing.
             del output.__iter__
@@ -203,7 +202,7 @@ class ImportLastCountryOfUserToHiveTestCase(unittest.TestCase):
     def test_requires(self):
         task = ImportLastCountryOfUserToHiveTask(**self._get_kwargs())
         required_task = task.requires()
-        self.assertEquals(required_task.output().path, 's3://output/path/dt=2014-01-01')
+        self.assertEquals(required_task.output().path, 's3://fake/warehouse/last_country_of_user/dt=2014-01-01')
 
 
 class QueryLastCountryPerCourseTaskTestCase(unittest.TestCase):
@@ -212,7 +211,8 @@ class QueryLastCountryPerCourseTaskTestCase(unittest.TestCase):
     def _get_kwargs(self):
         """Provides minimum args for instantiating QueryLastCountryPerCourseTask."""
         return {
-            'course_country_output': 's3://output/path',
+            'overwrite': True,
+            'import_date': '2014-08-23'
         }
 
     def test_query(self):
@@ -223,15 +223,15 @@ class QueryLastCountryPerCourseTaskTestCase(unittest.TestCase):
             USE default;
             DROP TABLE IF EXISTS course_enrollment_location_current;
             CREATE EXTERNAL TABLE course_enrollment_location_current (
-                date STRING,
-                course_id STRING,
-                country_code STRING,
-                count INT
+                date STRING,course_id STRING,country_code STRING,count INT
             )
-            ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t'
-            LOCATION 's3://output/path';
+            PARTITIONED BY (dt STRING)
+            ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t'
+            LOCATION 's3://fake/warehouse/course_enrollment_location_current/';
+            ALTER TABLE course_enrollment_location_current ADD PARTITION (dt='2014-08-23');
 
-            INSERT OVERWRITE TABLE course_enrollment_location_current
+            INSERT INTO TABLE course_enrollment_location_current
+            PARTITION (dt='2014-08-23')
             SELECT
                 sce.dt,
                 sce.course_id,
@@ -248,7 +248,7 @@ class QueryLastCountryPerCourseTaskTestCase(unittest.TestCase):
 
     def test_output(self):
         task = QueryLastCountryPerCourseTask(**self._get_kwargs())
-        self.assertEquals(task.output().path, 's3://output/path')
+        self.assertEquals(task.output().path, 's3://fake/warehouse/course_enrollment_location_current/dt=2014-08-23')
 
     def test_requires(self):
         task = QueryLastCountryPerCourseTask(**self._get_kwargs())
@@ -264,13 +264,12 @@ class QueryLastCountryPerCourseWorkflowTestCase(unittest.TestCase):
         """Provides minimum args for instantiating QueryLastCountryPerCourseWorkflow."""
         return {
             'interval': Year.parse('2013'),
-            'user_country_output': 's3://output/user_country/path',
-            'course_country_output': 's3://output/course_country/path',
+            'import_date': '2014-08-23'
         }
 
     def test_output(self):
         task = QueryLastCountryPerCourseWorkflow(**self._get_kwargs())
-        self.assertEquals(task.output().path, 's3://output/course_country/path')
+        self.assertEquals(task.output().path, 's3://fake/warehouse/course_enrollment_location_current/dt=2014-08-23')
 
     def test_requires(self):
         task = QueryLastCountryPerCourseWorkflow(**self._get_kwargs())
@@ -286,9 +285,8 @@ class InsertToMysqlCourseEnrollByCountryWorkflowTestCase(unittest.TestCase):
         """Provides minimum args for instantiating InsertToMysqlCourseEnrollByCountryWorkflow."""
         return {
             'interval': Year.parse('2013'),
-            'user_country_output': 's3://output/user_country/path',
-            'course_country_output': 's3://output/course_country/path',
             'credentials': 's3://config/credentials/output-database.json',
+            'import_date': '2014-08-23'
         }
 
     def test_requires(self):
@@ -296,7 +294,7 @@ class InsertToMysqlCourseEnrollByCountryWorkflowTestCase(unittest.TestCase):
         required_tasks = task.requires()
         self.assertEquals(len(required_tasks), 2)
         self.assertEquals(required_tasks['credentials'].output().path, 's3://config/credentials/output-database.json')
-        self.assertEquals(required_tasks['insert_source'].output().path, 's3://output/course_country/path')
+        self.assertEquals(required_tasks['insert_source'].output().path, 's3://fake/warehouse/course_enrollment_location_current/dt=2014-08-23')
 
     def test_requires_with_overwrite(self):
         kwargs = self._get_kwargs()

--- a/edx/analytics/tasks/tests/test_user_activity.py
+++ b/edx/analytics/tasks/tests/test_user_activity.py
@@ -37,6 +37,7 @@ class CategorizeUserActivityTaskMapTest(unittest.TestCase):
 
     @property
     def date(self):
+        """Just the date extracted from self.timestamp"""
         return self.timestamp.split('T')[0]
 
     def _create_event_log_line(self, **kwargs):
@@ -163,7 +164,6 @@ class CategorizeUserActivityTaskReduceTest(unittest.TestCase):
             output_root='s3://fake/warehouse/user_activity_daily/dt=2014-08-15'
         )
 
-
     def _get_reducer_output(self, key, values):
         """Run reducer with provided values hardcoded key."""
         return tuple(self.task.reducer(key, values))
@@ -171,10 +171,6 @@ class CategorizeUserActivityTaskReduceTest(unittest.TestCase):
     def _check_output(self, key, inputs, expected):
         """Compare generated with expected output."""
         output = self._get_reducer_output(key, inputs)
-        print '--- OUTPUT ---'
-        print output
-        print '--- EXPECTED ---'
-        print expected
         self.assertItemsEqual(output, expected)
 
     def test_date_out_of_interval(self):
@@ -185,30 +181,37 @@ class CategorizeUserActivityTaskReduceTest(unittest.TestCase):
     def test_single_date(self):
         key_08_12 = (self.course_id, self.username, "2014-08-12")
         inputs_08_12 = (ACTIVE_LABEL, PROBLEM_LABEL)
-        expected_08_12 = (('2014-08-12', self.course_id, self.username, ACTIVE_LABEL, 1 ),
-                    ('2014-08-12', self.course_id, self.username, PROBLEM_LABEL, 1 ),)
+        expected_08_12 = (
+            ('2014-08-12', self.course_id, self.username, ACTIVE_LABEL, 1),
+            ('2014-08-12', self.course_id, self.username, PROBLEM_LABEL, 1),
+        )
         self._check_output(key_08_12, inputs_08_12, expected_08_12)
-
 
     def test_multiple_dates(self):
         key_08_12 = (self.course_id, self.username, "2014-08-12")
-        inputs_08_12 = (ACTIVE_LABEL, ACTIVE_LABEL, PROBLEM_LABEL, PROBLEM_LABEL,
-            PROBLEM_LABEL, PLAY_VIDEO_LABEL, PLAY_VIDEO_LABEL)
-        expected_08_12 = (('2014-08-12', self.course_id, self.username, ACTIVE_LABEL, 2 ),
-                    ('2014-08-12', self.course_id, self.username, PROBLEM_LABEL, 3 ),
-                    ('2014-08-12', self.course_id, self.username, PLAY_VIDEO_LABEL, 2 ),)
+        inputs_08_12 = (
+            ACTIVE_LABEL, ACTIVE_LABEL, PROBLEM_LABEL, PROBLEM_LABEL, PROBLEM_LABEL, PLAY_VIDEO_LABEL, PLAY_VIDEO_LABEL
+        )
+        expected_08_12 = (
+            ('2014-08-12', self.course_id, self.username, ACTIVE_LABEL, 2),
+            ('2014-08-12', self.course_id, self.username, PROBLEM_LABEL, 3),
+            ('2014-08-12', self.course_id, self.username, PLAY_VIDEO_LABEL, 2),
+        )
         self._check_output(key_08_12, inputs_08_12, expected_08_12)
-
 
         key_08_13 = (self.course_id, self.username, "2014-08-13")
         inputs_08_13 = (ACTIVE_LABEL, PLAY_VIDEO_LABEL)
-        expected_08_13 = (('2014-08-13', self.course_id, self.username, ACTIVE_LABEL, 1 ),
-                    ('2014-08-13', self.course_id, self.username, PLAY_VIDEO_LABEL, 1 ),)
+        expected_08_13 = (
+            ('2014-08-13', self.course_id, self.username, ACTIVE_LABEL, 1),
+            ('2014-08-13', self.course_id, self.username, PLAY_VIDEO_LABEL, 1),
+        )
         self._check_output(key_08_13, inputs_08_13, expected_08_13)
 
         key_08_14 = (self.course_id, self.username, "2014-08-14")
         inputs_08_14 = (ACTIVE_LABEL, PLAY_VIDEO_LABEL, PROBLEM_LABEL, PROBLEM_LABEL, ACTIVE_LABEL, ACTIVE_LABEL)
-        expected_08_14 = (('2014-08-14', self.course_id, self.username, ACTIVE_LABEL, 3 ),
-                    ('2014-08-14', self.course_id, self.username, PROBLEM_LABEL, 2 ),
-                    ('2014-08-14', self.course_id, self.username, PLAY_VIDEO_LABEL, 1 ),)
+        expected_08_14 = (
+            ('2014-08-14', self.course_id, self.username, ACTIVE_LABEL, 3),
+            ('2014-08-14', self.course_id, self.username, PROBLEM_LABEL, 2),
+            ('2014-08-14', self.course_id, self.username, PLAY_VIDEO_LABEL, 1),
+        )
         self._check_output(key_08_14, inputs_08_14, expected_08_14)

--- a/edx/analytics/tasks/tests/test_user_activity.py
+++ b/edx/analytics/tasks/tests/test_user_activity.py
@@ -7,25 +7,24 @@ import json
 from luigi import date_interval
 
 from edx.analytics.tasks.user_activity import (
-    UserActivityPerIntervalTask,
+    CategorizeUserActivityTask,
     ACTIVE_LABEL,
     PROBLEM_LABEL,
     PLAY_VIDEO_LABEL,
     POST_FORUM_LABEL,
-    CountLastElementMixin,
 )
 
 from edx.analytics.tasks.tests import unittest
 
 
-class UserActivityPerIntervalMapTest(unittest.TestCase):
+class CategorizeUserActivityTaskMapTest(unittest.TestCase):
     """
     Tests to verify that event log parsing by mapper works correctly.
     """
     def setUp(self):
-        self.interval_string = '2013-12-01-2013-12-31'
-        self.task = UserActivityPerIntervalTask(
-            interval=date_interval.Custom.parse(self.interval_string),
+        self.task = CategorizeUserActivityTask(
+            interval=date_interval.Month.parse('2013-12'),
+            output_root='s3://fake/warehouse/user_activity_daily/dt=2013-12-01'
         )
         # We're not really using Luigi properly here to create
         # the task, so set up manually.
@@ -35,6 +34,10 @@ class UserActivityPerIntervalMapTest(unittest.TestCase):
         self.username = "test_user"
         self.timestamp = "2013-12-17T15:38:32.805444"
         self.event_type = "edx.dummy.event"
+
+    @property
+    def date(self):
+        return self.timestamp.split('T')[0]
 
     def _create_event_log_line(self, **kwargs):
         """Create an event log with test values, as a JSON string."""
@@ -104,28 +107,28 @@ class UserActivityPerIntervalMapTest(unittest.TestCase):
     def test_good_dummy_event(self):
         line = self._create_event_log_line()
         event = tuple(self.task.mapper(line))
-        expected = (((self.course_id, self.username, self.interval_string), ACTIVE_LABEL),)
+        expected = (((self.course_id, self.username, self.date), ACTIVE_LABEL),)
         self.assertEquals(event, expected)
 
     def test_play_video_event(self):
         line = self._create_event_log_line(event_source='browser', event_type='play_video')
         event = tuple(self.task.mapper(line))
-        expected = (((self.course_id, self.username, self.interval_string), ACTIVE_LABEL),
-                    ((self.course_id, self.username, self.interval_string), PLAY_VIDEO_LABEL))
+        expected = (((self.course_id, self.username, self.date), ACTIVE_LABEL),
+                    ((self.course_id, self.username, self.date), PLAY_VIDEO_LABEL))
         self.assertEquals(event, expected)
 
     def test_problem_event(self):
         line = self._create_event_log_line(event_source='server', event_type='problem_check')
         event = tuple(self.task.mapper(line))
-        expected = (((self.course_id, self.username, self.interval_string), ACTIVE_LABEL),
-                    ((self.course_id, self.username, self.interval_string), PROBLEM_LABEL))
+        expected = (((self.course_id, self.username, self.date), ACTIVE_LABEL),
+                    ((self.course_id, self.username, self.date), PROBLEM_LABEL))
         self.assertEquals(event, expected)
 
     def test_post_forum_event(self):
         line = self._create_event_log_line(event_source='server', event_type='blah/blah/threads/create')
         event = tuple(self.task.mapper(line))
-        expected = (((self.course_id, self.username, self.interval_string), ACTIVE_LABEL),
-                    ((self.course_id, self.username, self.interval_string), POST_FORUM_LABEL))
+        expected = (((self.course_id, self.username, self.date), ACTIVE_LABEL),
+                    ((self.course_id, self.username, self.date), POST_FORUM_LABEL))
         self.assertEquals(event, expected)
 
     def test_exclusion_of_events_by_source(self):
@@ -147,73 +150,65 @@ class UserActivityPerIntervalMapTest(unittest.TestCase):
             self.assert_no_output_for(line)
 
 
-class UserActivityPerIntervalReduceTest(unittest.TestCase):
+class CategorizeUserActivityTaskReduceTest(unittest.TestCase):
     """
-    Tests to verify that UserActivityPerIntervalTask reducer works correctly.
+    Tests to verify that UserActivityPerDayTask reducer works correctly.
     """
     def setUp(self):
         self.course_id = 'course_id'
         self.username = 'test_user'
-        self.interval_string = '2013-12-01-2013-12-31'
-        self.task = UserActivityPerIntervalTask(
+        self.interval_string = '2014-08-11-2014-08-15'
+        self.task = CategorizeUserActivityTask(
             interval=date_interval.Custom.parse(self.interval_string),
+            output_root='s3://fake/warehouse/user_activity_daily/dt=2014-08-15'
         )
-        self.key = (self.course_id, self.username, self.interval_string)
 
-    def _get_reducer_output(self, values):
+
+    def _get_reducer_output(self, key, values):
         """Run reducer with provided values hardcoded key."""
-        return tuple(self.task.reducer(self.key, values))
+        return tuple(self.task.reducer(key, values))
 
-    def _check_output(self, inputs, expected):
+    def _check_output(self, key, inputs, expected):
         """Compare generated with expected output."""
-        self.assertEquals(self._get_reducer_output(inputs), expected)
+        output = self._get_reducer_output(key, inputs)
+        print '--- OUTPUT ---'
+        print output
+        print '--- EXPECTED ---'
+        print expected
+        self.assertItemsEqual(output, expected)
 
-    def test_no_events(self):
-        self._check_output([], tuple())
+    def test_date_out_of_interval(self):
+        key_08_12 = (self.course_id, self.username, "2014-08-18")
+        expected = tuple()
+        self._check_output(key_08_12, [], expected)
 
-    def test_single_event(self):
-        inputs = [ACTIVE_LABEL]
-        expected = ((self.course_id, '2013-12-01', '2013-12-31', ACTIVE_LABEL, self.username),)
-        self._check_output(inputs, expected)
-
-    def test_multiple_events_different(self):
-        inputs = [ACTIVE_LABEL, PROBLEM_LABEL]
-        expected = ((self.course_id, '2013-12-01', '2013-12-31', ACTIVE_LABEL, self.username),
-                    (self.course_id, '2013-12-01', '2013-12-31', PROBLEM_LABEL, self.username),)
-        self._check_output(inputs, expected)
-
-    def test_multiple_events_with_dupes(self):
-        inputs = [ACTIVE_LABEL, PROBLEM_LABEL, ACTIVE_LABEL, PROBLEM_LABEL]
-        expected = ((self.course_id, '2013-12-01', '2013-12-31', ACTIVE_LABEL, self.username),
-                    (self.course_id, '2013-12-01', '2013-12-31', PROBLEM_LABEL, self.username),)
-        self._check_output(inputs, expected)
+    def test_single_date(self):
+        key_08_12 = (self.course_id, self.username, "2014-08-12")
+        inputs_08_12 = (ACTIVE_LABEL, PROBLEM_LABEL)
+        expected_08_12 = (('2014-08-12', self.course_id, self.username, ACTIVE_LABEL, 1 ),
+                    ('2014-08-12', self.course_id, self.username, PROBLEM_LABEL, 1 ),)
+        self._check_output(key_08_12, inputs_08_12, expected_08_12)
 
 
-class CountLastElementMixinTest(unittest.TestCase):
-    """
-    Tests to verify that CountLastElementMixin works correctly.
-    """
-    def setUp(self):
-        self.interval_string = '2013-12-01-2013-12-31'
-        self.task = CountLastElementMixin()
-        self.key = ('course', '2013-01-01')
+    def test_multiple_dates(self):
+        key_08_12 = (self.course_id, self.username, "2014-08-12")
+        inputs_08_12 = (ACTIVE_LABEL, ACTIVE_LABEL, PROBLEM_LABEL, PROBLEM_LABEL,
+            PROBLEM_LABEL, PLAY_VIDEO_LABEL, PLAY_VIDEO_LABEL)
+        expected_08_12 = (('2014-08-12', self.course_id, self.username, ACTIVE_LABEL, 2 ),
+                    ('2014-08-12', self.course_id, self.username, PROBLEM_LABEL, 3 ),
+                    ('2014-08-12', self.course_id, self.username, PLAY_VIDEO_LABEL, 2 ),)
+        self._check_output(key_08_12, inputs_08_12, expected_08_12)
 
-    def _get_reducer_output(self, values):
-        """Run reducer with provided values hardcoded key."""
-        return tuple(self.task.reducer(self.key, values))
 
-    def test_mapper(self):
-        inputs = ['a', 'b', 'c', 'd']
-        expected = ((('a', 'b', 'c'), 1),)
-        output = tuple(self.task.mapper('\t'.join(inputs)))
-        self.assertEquals(output, expected)
+        key_08_13 = (self.course_id, self.username, "2014-08-13")
+        inputs_08_13 = (ACTIVE_LABEL, PLAY_VIDEO_LABEL)
+        expected_08_13 = (('2014-08-13', self.course_id, self.username, ACTIVE_LABEL, 1 ),
+                    ('2014-08-13', self.course_id, self.username, PLAY_VIDEO_LABEL, 1 ),)
+        self._check_output(key_08_13, inputs_08_13, expected_08_13)
 
-    def test_no_counts(self):
-        self.assertEquals(self._get_reducer_output([]), ((self.key, 0),))
-
-    def test_single_count(self):
-        self.assertEquals(self._get_reducer_output([1]), ((self.key, 1),))
-
-    def test_multiple_counts(self):
-        inputs = [1, 1, 1, 1, 1]
-        self.assertEquals(self._get_reducer_output(inputs), ((self.key, 5),))
+        key_08_14 = (self.course_id, self.username, "2014-08-14")
+        inputs_08_14 = (ACTIVE_LABEL, PLAY_VIDEO_LABEL, PROBLEM_LABEL, PROBLEM_LABEL, ACTIVE_LABEL, ACTIVE_LABEL)
+        expected_08_14 = (('2014-08-14', self.course_id, self.username, ACTIVE_LABEL, 3 ),
+                    ('2014-08-14', self.course_id, self.username, PROBLEM_LABEL, 2 ),
+                    ('2014-08-14', self.course_id, self.username, PLAY_VIDEO_LABEL, 1 ),)
+        self._check_output(key_08_14, inputs_08_14, expected_08_14)

--- a/edx/analytics/tasks/url.py
+++ b/edx/analytics/tasks/url.py
@@ -59,8 +59,9 @@ URL_SCHEME_TO_TARGET_CLASS = {
 }
 
 
-def get_target_from_url(url):
+def get_target_from_url(*url_parts):
     """Returns a luigi target based on the url scheme"""
+    url = url_path_join(*url_parts)
     parsed_url = urlparse.urlparse(url)
     target_class = URL_SCHEME_TO_TARGET_CLASS.get(parsed_url.scheme, DEFAULT_TARGET_CLASS)
     kwargs = {}

--- a/edx/analytics/tasks/user_activity.py
+++ b/edx/analytics/tasks/user_activity.py
@@ -1,14 +1,20 @@
 """Group events by institution and export them for research purposes"""
 
+from collections import defaultdict
 import logging
 
 import luigi
+from luigi.hive import ExternalHiveTask
 
+from edx.analytics.tasks.calendar import ImportCalendarToHiveTask
 from edx.analytics.tasks.mapreduce import MapReduceJobTask, MapReduceJobTaskMixin
 from edx.analytics.tasks.mysql_load import MysqlInsertTask
 from edx.analytics.tasks.pathutil import EventLogSelectionMixin, EventLogSelectionDownstreamMixin
+from edx.analytics.tasks.util.hive import ImportIntoHiveTableTask, HiveTableFromQueryTask, WarehouseDownstreamMixin, HivePartition, TABLE_FORMAT_TSV
+from edx.analytics.tasks.util.overwrite import OverwriteOutputMixin
 from edx.analytics.tasks.url import url_path_join, get_target_from_url, ExternalURL
 import edx.analytics.tasks.util.eventlog as eventlog
+from datetime import datetime, date, timedelta
 
 log = logging.getLogger(__name__)
 
@@ -18,26 +24,11 @@ PLAY_VIDEO_LABEL = "PLAYED_VIDEO"
 POST_FORUM_LABEL = "POSTED_FORUM"
 
 
-class UserActivityBaseTaskDownstreamMixin(object):
-    """Defines output_root parameter with appropriate default."""
-
-    output_root = luigi.Parameter(
-        default_from_config={'section': 'user-activity', 'name': 'output_root'}
-    )
-
-
-class UserActivityBaseTask(EventLogSelectionMixin, MapReduceJobTask, UserActivityBaseTaskDownstreamMixin):
+class CategorizeUserActivityTask(EventLogSelectionMixin, OverwriteOutputMixin, MapReduceJobTask):
     """
-    Base class to extract events from logs over a selected interval of time.
-
-    This class provides a parameterized mapper.  Derived classes must
-    override the predicates applied to events, and the definition of
-    what is a key and what a value from the mapper.  Derived classes
-    also define the reducer that consumes the mapper output.
+    Categorize events from logs over a selected interval of time.
 
     Parameters:
-        output_root: Directory to store the output in.
-
         The following are defined in EventLogSelectionMixin:
 
         source: A URL to a path that contains log files that contain the events.
@@ -46,6 +37,29 @@ class UserActivityBaseTask(EventLogSelectionMixin, MapReduceJobTask, UserActivit
             emitted. Note that the search interval is expanded, so events don't have to be in exactly the right file
             in order for them to be processed.
     """
+
+    output_root = luigi.Parameter()
+
+    def mapper(self, line):
+        """Default mapper implementation, that always outputs the log line, but with a configurable key."""
+        value = self.get_event_and_date_string(line)
+        if value is None:
+            return
+        event, date_string = value
+
+        username = event.get('username', '').strip()
+        if not username:
+            return
+
+        course_id = self.get_course_id(event)
+        if not course_id:
+            return
+
+        predicate_labels = self.extract_predicate_labels(event)
+        key = self._encode_tuple((course_id, username, date_string))
+
+        for label in predicate_labels:
+            yield key, label
 
     def get_course_id(self, event):
         """Gets course_id from event's data."""
@@ -68,17 +82,34 @@ class UserActivityBaseTask(EventLogSelectionMixin, MapReduceJobTask, UserActivit
 
         return course_id
 
-    def get_predicate_labels(self, event):
-        """Override this with calculation of one or more possible labels for the current event."""
-        raise NotImplementedError
+    def extract_predicate_labels(self, event):
+        """Creates labels by applying hardcoded predicates to a single event."""
+        # We only want the explicit event, not the implicit form.
+        event_type = event.get('event_type')
+        event_source = event.get('event_source')
 
-    def get_mapper_key(self, _course_id, _username, _date_string):
-        """Return a tuple representing the key to use for a log entry, or None if skipping."""
-        raise NotImplementedError
+        # Ignore all background task events, since they don't count as a form of activity.
+        if event_source == 'task':
+            return []
 
-    def get_mapper_value(self, _course_id, _username, _date_string, label):
-        """Return a tuple representing the value to use for a log entry."""
-        raise NotImplementedError
+        # Ignore all enrollment events, since they don't count as a form of activity.
+        if event_type.startswith('edx.course.enrollment.'):
+            return []
+
+        labels = [ACTIVE_LABEL]
+
+        if event_source == 'server':
+            if event_type == 'problem_check':
+                labels.append(PROBLEM_LABEL)
+
+            if event_type.endswith("threads/create"):
+                labels.append(POST_FORUM_LABEL)
+
+        if event_source == 'browser':
+            if event_type == 'play_video':
+                labels.append(PLAY_VIDEO_LABEL)
+
+        return labels
 
     def _encode_tuple(self, values):
         """
@@ -87,15 +118,11 @@ class UserActivityBaseTask(EventLogSelectionMixin, MapReduceJobTask, UserActivit
         Parameters:
             Values is a list or tuple.
 
-        This enforces a standard encoding for the parts of the
-        key. Without this a part of the key might appear differently
-        in the key string when it is coerced to a string by luigi. For
-        example, if the same key value appears in two different
-        records, one as a str() type and the other a unicode() then
-        without this change they would appear as u'Foo' and 'Foo' in
-        the final key string. Although python doesn't care about this
-        difference, hadoop does, and will bucket the values
-        separately. Which is not what we want.
+        This enforces a standard encoding for the parts of the key. Without this a part of the key might appear
+        differently in the key string when it is coerced to a string by luigi. For example, if the same key value
+        appears in two different records, one as a str() type and the other a unicode() then without this change they
+        would appear as u'Foo' and 'Foo' in the final key string. Although python doesn't care about this difference,
+        hadoop does, and will bucket the values separately. Which is not what we want.
         """
         # TODO: refactor this into a utility function and update jobs
         # to always UTF8 encode mapper keys.
@@ -104,140 +131,141 @@ class UserActivityBaseTask(EventLogSelectionMixin, MapReduceJobTask, UserActivit
         else:
             return values[0].encode('utf8')
 
-    def mapper(self, line):
-        """Default mapper implementation, that always outputs the log line, but with a configurable key."""
-        value = self.get_event_and_date_string(line)
-        if value is None:
-            return
-        event, date_string = value
-
-        username = event.get('username', '').strip()
-        if not username:
-            return
-
-        course_id = self.get_course_id(event)
-        if not course_id:
-            return
-
-        predicate_labels = self.get_predicate_labels(event)
-        key = self.get_mapper_key(course_id, username, date_string)
-
-        for label in predicate_labels:
-            output_value = self.get_mapper_value(course_id, username, date_string, label)
-            yield self._encode_tuple(key), output_value
-
-
-def extract_predicate_labels(event):
-    """Creates labels by applying hardcoded predicates to a single event."""
-    # We only want the explicit event, not the implicit form.
-    event_type = event.get('event_type')
-    event_source = event.get('event_source')
-
-    # Ignore all background task events, since they don't count as a form of activity.
-    if event_source == 'task':
-        return []
-
-    # Ignore all enrollment events, since they don't count as a form of activity.
-    if event_type.startswith('edx.course.enrollment.'):
-        return []
-
-    labels = [ACTIVE_LABEL]
-
-    if event_source == 'server':
-        if event_type == 'problem_check':
-            labels.append(PROBLEM_LABEL)
-
-        if event_type.endswith("threads/create"):
-            labels.append(POST_FORUM_LABEL)
-
-    if event_source == 'browser':
-        if event_type == 'play_video':
-            labels.append(PLAY_VIDEO_LABEL)
-
-    return labels
-
-
-class UserActivityPerIntervalTask(UserActivityBaseTask):
-    """Make a basic task to gather activity per user for a single time interval."""
-
-    def output(self):
-        return get_target_from_url(
-            url_path_join(
-                self.output_root,
-                'user-activity-per-interval-{interval}.tsv/'.format(interval=self.interval),
-            )
-        )
-
-    def get_predicate_labels(self, event):
-        return extract_predicate_labels(event)
-
-    def get_mapper_key(self, course_id, username, _date_string):
-        # For daily output, do reduction on all of these.
-        return (course_id, username, str(self.interval))
-
-    def get_mapper_value(self, _course_id, _username, _date_string, label):
-        return label
-
     def reducer(self, key, values):
         """Outputs labels and usernames for a given course and interval."""
-        course_id, username, interval_string = key
-        interval_nums = interval_string.split('-')
-        interval_start = '-'.join(interval_nums[0:3])
-        interval_end = '-'.join(interval_nums[3:6])
-        # Dedupe the output values.
-        output_values = []
-        for value in values:
-            if value not in output_values:
-                yield course_id, interval_start, interval_end, value, username
-                output_values.append(value)
+        course_id, username, date_string = key
+        category_counts = defaultdict(int)
+        for category in values:
+            category_counts[category] += 1
+        for category, count in category_counts.iteritems():
+            yield date_string, course_id, username, category, count
+
+    def output(self):
+        return get_target_from_url(self.output_root)
 
 
-class CountLastElementMixin(object):
-    """Replaces the last element in a tuple with the count of values."""
-    def mapper(self, line):
-        """Counts number of values of last element."""
-        values = line.split('\t')
-        yield tuple(values[0:-1]), 1
+class UserActivityDailyTask(ImportIntoHiveTableTask):
+    """
+    Creates a Hive Table that points to Hadoop output of CategorizeUserActivityTask task.
+    """
 
-    def reducer(self, key, values):
-        """Sums values for the given key. """
-        count = sum(int(v) for v in values)
-        yield key, count
+    @property
+    def table_name(self):
+        return 'user_activity_daily'
 
+    @property
+    def columns(self):
+        return [
+            ('date', 'STRING'),
+            ('course_id', 'STRING'),
+            ('username', 'STRING'),
+            ('category', 'STRING'),
+            ('count', 'INT')
+        ]
 
-class CountUserActivityPerIntervalTask(
-        CountLastElementMixin,
-        MapReduceJobTask,
-        UserActivityBaseTaskDownstreamMixin,
-        EventLogSelectionDownstreamMixin):
-    """Counts the number of users for each course/interval/label combination."""
+    @property
+    def table_format(self):
+        """Provides structure of Hive external table data."""
+        return TABLE_FORMAT_TSV
+
+    @property
+    def partition(self):
+        return HivePartition('interval', str(self.interval))
 
     def requires(self):
-        return UserActivityPerIntervalTask(
-            mapreduce_engine=self.mapreduce_engine,
-            n_reduce_tasks=self.n_reduce_tasks,
-            output_root=self.output_root,
+        return ExternalURL(self.partition_location)
+
+
+class UserActivityDailyWorkflow(
+    EventLogSelectionDownstreamMixin,
+    MapReduceJobTaskMixin,
+    UserActivityDailyTask):
+
+    def requires(self):
+        return CategorizeUserActivityTask(
             source=self.source,
             interval=self.interval,
             pattern=self.pattern,
-        )
-
-    def output(self):
-        return get_target_from_url(
-            url_path_join(
-                self.output_root,
-                'count-user-activity-per-interval-{interval}.tsv/'.format(interval=self.interval),
-            )
+            n_reduce_tasks=self.n_reduce_tasks,
+            output_root=self.partition_location,
+            overwrite=self.overwrite,
         )
 
 
-class InsertToMysqlCourseActivityTableMixin(MysqlInsertTask):
+class UserActivityWeeklyTask(HiveTableFromQueryTask):
+
+    interval = luigi.Parameter()
+
+    @property
+    def insert_query(self):
+        return """
+            SELECT
+                act.course_id as course_id,
+                cal.iso_week_start as interval_start,
+                cal.iso_week_end as interval_end,
+                act.category as category,
+                COUNT(DISTINCT username) as num_users
+            FROM calendar cal
+            LEFT OUTER JOIN user_activity_daily act ON act.date = cal.date
+            WHERE category IS NOT NULL
+            GROUP BY cal.iso_week_start, cal.iso_week_end, act.course_id, act.category;
+        """
+
+    @property
+    def table_name(self):
+        return 'user_activity_weekly'
+
+    @property
+    def columns(self):
+        return [
+            ('course_id', 'STRING'),
+            ('interval_start', 'STRING'),
+            ('interval_end', 'STRING'),
+            ('label', 'STRING'),
+            ('count', 'INT'),
+        ]
+
+    @property
+    def partition(self):
+        return HivePartition('interval', str(self.interval))
+
+    def requires(self):
+        yield (
+            ExternalHiveTask(table='calendar', database=hive_database_name()),
+            ExternalHiveTask(table='user_activity_daily', database=hive_database_name()),
+        )
+
+
+class UserActivityWeeklyWorkflow(
+        EventLogSelectionDownstreamMixin,
+        MapReduceJobTaskMixin,
+        UserActivityWeeklyTask):
+
+    def requires(self):
+        yield (
+            ImportCalendarToHiveTask(
+                warehouse_path=self.warehouse_path,
+                overwrite=self.overwrite,
+            ),
+            UserActivityDailyWorkflow(
+                mapreduce_engine=self.mapreduce_engine,
+                n_reduce_tasks=self.n_reduce_tasks,
+                source=self.source,
+                interval=self.interval,
+                pattern=self.pattern,
+                warehouse_path=self.warehouse_path,
+                overwrite=self.overwrite,
+            ),
+        )
+
+
+class UserActivityMysqlInsertTask(MysqlInsertTask):
     """
     Define course_activity table.
     """
     @property
     def table(self):
-        return "course_activity"
+        return 'course_activity'
 
     @property
     def columns(self):
@@ -253,36 +281,38 @@ class InsertToMysqlCourseActivityTableMixin(MysqlInsertTask):
     def indexes(self):
         return [
             ('course_id', 'label'),
+            ('interval_end',)
         ]
 
 
-class InsertToMysqlCourseActivityTable(InsertToMysqlCourseActivityTableMixin):
-    """
-    Write to course_activity table from specified source.
-    """
-    insert_source = luigi.Parameter()
-
-    @property
-    def insert_source_task(self):
-        return ExternalURL(url=self.insert_source)
-
-
-class CountUserActivityPerIntervalTaskWorkflow(
-        InsertToMysqlCourseActivityTableMixin,
-        UserActivityBaseTaskDownstreamMixin,
+class UserActivityWorkflow(
+        EventLogSelectionDownstreamMixin,
         MapReduceJobTaskMixin,
-        EventLogSelectionDownstreamMixin):
+        WarehouseDownstreamMixin,
+        OverwriteOutputMixin,
+        UserActivityMysqlInsertTask):
     """
-    Write to course_activity table from CountUserActivityPerInterval.
+    Write to course_activity table to mysql.
     """
 
     @property
     def insert_source_task(self):
-        return CountUserActivityPerIntervalTask(
+        return UserActivityWeeklyWorkflow(
             mapreduce_engine=self.mapreduce_engine,
             n_reduce_tasks=self.n_reduce_tasks,
-            output_root=self.output_root,
             source=self.source,
             interval=self.interval,
             pattern=self.pattern,
+            warehouse_path=self.warehouse_path,
+            overwrite=self.overwrite,
         )
+
+    def init_copy(self, connection):
+        if self.overwrite:
+            query = "DELETE FROM {table} WHERE interval_start >= {start} AND interval_start < {end}".format(
+                    table=self.table,
+                    start=self.interval.date_a.isoformat(),
+                    end=self.interval.date_b.isoformat()
+                )
+            log.info('Removing stale data with query: %s', query)
+            connection.cursor().execute(query)

--- a/edx/analytics/tasks/util/hive.py
+++ b/edx/analytics/tasks/util/hive.py
@@ -1,3 +1,4 @@
+"""Various helper utilities that are commonly used when working with Hive"""
 
 import logging
 import textwrap
@@ -11,10 +12,16 @@ from edx.analytics.tasks.util.overwrite import OverwriteOutputMixin
 
 
 log = logging.getLogger(__name__)
+
+# TODO: create a format class that allows records to be written using this format, as well as providing a mechanism for
+# storing this string so that it can be passed to Hive to tell it how to interpret the data. Or perhaps a complete "data
+# table" abstraction that can be written to from map-reduce and/or hive, created/dropped in hive and transfered into the
+# result store.
 TABLE_FORMAT_TSV = "ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t'"
 
 
 def hive_database_name():
+    """The name of the database where all metadata is being stored in Hive"""
     return get_config().get('hive', 'database', 'default')
 
 
@@ -22,7 +29,7 @@ class WarehouseDownstreamMixin(object):
     """Defines output_root parameter with appropriate default."""
 
     warehouse_path = luigi.Parameter(
-       default_from_config={'section': 'hive', 'name': 'warehouse_path'}
+        default_from_config={'section': 'hive', 'name': 'warehouse_path'}
     )
 
 
@@ -30,10 +37,20 @@ class ImportIntoHiveTableTask(WarehouseDownstreamMixin, OverwriteOutputMixin, Hi
     """
     Abstract class to import data into a Hive table.
 
-    Requires four properties and a requires() method to be defined.
+    Currently supports a single partition that represents the version of the table data. This allows us to use a
+    consistent location for the table and swap out the data in the tables by simply pointing at different partitions
+    within the folder that contain different "versions" of the table data. For example, if a snapshot is taken of an
+    RDBMS table, we might store that in a partition with today's date. Any subsequent jobs that need to join against
+    that table will continue to use the data snapshot from the beginning of the day (since that is the "live"
+    partition). However, the next time a snapshot is taken a new partition is created and loaded and becomes the "live"
+    partition that is used in all joins etc.
+
+    Important note: this code currently does *not* clean up old unused partitions, they will just continue to exist
+    until they are cleaned up by some external process.
     """
 
     def query(self):
+        # Ideally this would be added to the query by the custom runner, however, this is easier.
         drop_on_overwrite = ''
         if self.overwrite:
             drop_on_overwrite = 'DROP TABLE IF EXISTS {0};'.format(self.table_name)
@@ -118,6 +135,7 @@ class ImportIntoHiveTableTask(WarehouseDownstreamMixin, OverwriteOutputMixin, Hi
 
 
 class OverwriteAwareHiveQueryRunner(HiveQueryRunner):
+    """A custom hive query runner that logs the query being executed and is aware of the "overwrite" option."""
 
     def run_job(self, job):
         if hasattr(job, 'remove_output_on_overwrite'):
@@ -128,16 +146,23 @@ class OverwriteAwareHiveQueryRunner(HiveQueryRunner):
 
 
 class HivePartition(object):
+    """
+    Represents a particular partition in Hive.
+
+    Can produce strings in the formats that are used to represent it in queries, file paths etc.
+    """
 
     def __init__(self, key, value):
         self.key = key
         self.value = value
 
     def as_dict(self):
+        """This is the format that luigi uses internally to represent partitions"""
         return {self.key: self.value}
 
     @property
     def query_spec(self):
+        """This format is used when a partition needs to be referred to in a query"""
         return "{key}='{value}'".format(
             key=self.key,
             value=self.value,
@@ -145,6 +170,7 @@ class HivePartition(object):
 
     @property
     def path_spec(self):
+        """This is the format that should be used when dealing with a partition-specific file path"""
         return "{key}={value}".format(
             key=self.key,
             value=self.value,
@@ -152,6 +178,7 @@ class HivePartition(object):
 
 
 class HiveTableFromQueryTask(ImportIntoHiveTableTask):
+    """Creates a hive table from the results of a hive query."""
 
     def query(self):
         create_table_statements = super(HiveTableFromQueryTask, self).query()
@@ -169,6 +196,7 @@ class HiveTableFromQueryTask(ImportIntoHiveTableTask):
 
     @property
     def insert_query(self):
+        """The query to execute to populate the table."""
         raise NotImplementedError
 
     def output(self):

--- a/edx/analytics/tasks/util/hive.py
+++ b/edx/analytics/tasks/util/hive.py
@@ -1,6 +1,180 @@
 
+import logging
+import textwrap
+
+import luigi
 from luigi.configuration import get_config
+from luigi.hive import HiveQueryTask, HivePartitionTarget, HiveQueryRunner
+
+from edx.analytics.tasks.url import url_path_join, get_target_from_url
+from edx.analytics.tasks.util.overwrite import OverwriteOutputMixin
+
+
+log = logging.getLogger(__name__)
+TABLE_FORMAT_TSV = "ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t'"
 
 
 def hive_database_name():
     return get_config().get('hive', 'database', 'default')
+
+
+class WarehouseDownstreamMixin(object):
+    """Defines output_root parameter with appropriate default."""
+
+    warehouse_path = luigi.Parameter(
+       default_from_config={'section': 'hive', 'name': 'warehouse_path'}
+    )
+
+
+class ImportIntoHiveTableTask(WarehouseDownstreamMixin, OverwriteOutputMixin, HiveQueryTask):
+    """
+    Abstract class to import data into a Hive table.
+
+    Requires four properties and a requires() method to be defined.
+    """
+
+    def query(self):
+        drop_on_overwrite = ''
+        if self.overwrite:
+            drop_on_overwrite = 'DROP TABLE IF EXISTS {0};'.format(self.table_name)
+
+        # TODO: Figure out how to clean up old data. This just cleans
+        # out old metastore info, and doesn't actually remove the table
+        # data.
+
+        # Ensure there is exactly one available partition in the table.
+        query_format = """
+            USE {database_name};
+            {drop_on_overwrite}
+            CREATE EXTERNAL TABLE {table_name} (
+                {col_spec}
+            )
+            PARTITIONED BY ({partition.key} STRING)
+            {table_format}
+            LOCATION '{location}';
+            ALTER TABLE {table_name} ADD PARTITION ({partition.query_spec});
+        """
+
+        query = query_format.format(
+            database_name=hive_database_name(),
+            drop_on_overwrite=drop_on_overwrite,
+            table_name=self.table_name,
+            col_spec=','.join([' '.join(c) for c in self.columns]),
+            location=self.table_location,
+            table_format=self.table_format,
+            partition=self.partition,
+        )
+
+        query = textwrap.dedent(query)
+
+        return query
+
+    @property
+    def partition(self):
+        """Provides name of Hive database table partition."""
+        raise NotImplementedError
+
+    @property
+    def partition_location(self):
+        """Provides location of Hive database table's partition data."""
+        # Make sure that input path ends with a slash, to indicate a directory.
+        # (This is necessary for S3 paths that are output from Hadoop jobs.)
+        return url_path_join(self.table_location, self.partition.path_spec + '/')
+
+    @property
+    def table_name(self):
+        """Provides name of Hive database table."""
+        raise NotImplementedError
+
+    @property
+    def table_format(self):
+        """Provides format of Hive database table's data."""
+        return ''
+
+    @property
+    def table_location(self):
+        """Provides root location of Hive database table's data."""
+        return url_path_join(self.warehouse_path, self.table_name) + '/'
+
+    @property
+    def columns(self):
+        """
+        Provides definition of columns in Hive.
+
+        This should define a list of (name, definition) tuples, where
+        the definition defines the Hive type to use. For example,
+        ('first_name', 'STRING').
+
+        """
+        raise NotImplementedError
+
+    def output(self):
+        return HivePartitionTarget(
+            self.table_name, self.partition.as_dict(), database=hive_database_name(), fail_missing_table=False
+        )
+
+    def job_runner(self):
+        return OverwriteAwareHiveQueryRunner()
+
+
+class OverwriteAwareHiveQueryRunner(HiveQueryRunner):
+
+    def run_job(self, job):
+        if hasattr(job, 'remove_output_on_overwrite'):
+            job.remove_output_on_overwrite()
+
+        log.debug('Executing hive query: %s', job.query())
+        return super(OverwriteAwareHiveQueryRunner, self).run_job(job)
+
+
+class HivePartition(object):
+
+    def __init__(self, key, value):
+        self.key = key
+        self.value = value
+
+    def as_dict(self):
+        return {self.key: self.value}
+
+    @property
+    def query_spec(self):
+        return "{key}='{value}'".format(
+            key=self.key,
+            value=self.value,
+        )
+
+    @property
+    def path_spec(self):
+        return "{key}={value}".format(
+            key=self.key,
+            value=self.value,
+        )
+
+
+class HiveTableFromQueryTask(ImportIntoHiveTableTask):
+
+    def query(self):
+        create_table_statements = super(HiveTableFromQueryTask, self).query()
+        full_insert_query = """
+            INSERT INTO TABLE {table_name}
+            PARTITION ({partition.query_spec})
+            {insert_query}
+        """.format(
+            table_name=self.table_name,
+            partition=self.partition,
+            insert_query=self.insert_query.strip(),
+        )
+
+        return create_table_statements + textwrap.dedent(full_insert_query)
+
+    @property
+    def insert_query(self):
+        raise NotImplementedError
+
+    def output(self):
+        return get_target_from_url(self.partition_location)
+
+    @property
+    def table_format(self):
+        """Provides format of Hive external table data."""
+        return TABLE_FORMAT_TSV

--- a/edx/analytics/tasks/util/overwrite.py
+++ b/edx/analytics/tasks/util/overwrite.py
@@ -24,7 +24,7 @@ class OverwriteOutputMixin(object):
     Note that this should be included in a task definition *before*
     the Task base class, so that the complete() method is overridden.
     """
-    overwrite = luigi.BooleanParameter(default=False)
+    overwrite = luigi.BooleanParameter(default=False, significant=False)
     attempted_removal = False
 
     def complete(self):
@@ -52,5 +52,9 @@ class OverwriteOutputMixin(object):
         if self.overwrite:
             self.attempted_removal = True
             if self.output().exists():
-                log.info("Removing existing output for task %s", str(self))
-                self.output().remove()
+                output_target = self.output()
+                if hasattr(output_target, 'remove'):
+                    log.info("Removing existing output for task %s", str(self))
+                    self.output().remove()
+                else:
+                    log.info("Unable to remove output for task %s. Skipping removal.", str(self))

--- a/logging.cfg
+++ b/logging.cfg
@@ -13,7 +13,7 @@ keys=root,edx_analytics,luigi_interface
 keys=stderrHandler,luigiHandler,localHandler
 
 [formatters]
-keys=standard,luigi_default
+keys=standard
 
 [logger_root]
 level=INFO
@@ -28,7 +28,7 @@ propagate=0
 
 [logger_luigi_interface]
 # Errors from luigi-interface get routed to stdout.
-level=INFO
+level=DEBUG
 handlers=luigiHandler
 qualname=luigi-interface
 propagate=0
@@ -41,7 +41,7 @@ args=(sys.stderr,)
 [handler_luigiHandler]
 # Define as in luigi/interface.py.
 class=StreamHandler
-formatter=luigi_default
+formatter=standard
 args=(sys.stdout,)
 
 [handler_localHandler]
@@ -55,7 +55,3 @@ args=('edx_analytics.log', 'w')
 [formatter_standard]
 # Define as in edx-platform/common/lib/logsettings.py (for dev logging, not syslog).
 format=%(asctime)s %(levelname)s %(process)d [%(name)s] %(filename)s:%(lineno)d - %(message)s
-
-[formatter_luigi_default]
-# Define as in luigi/interface.py.
-format=%(levelname)s: %(message)s

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -8,6 +8,7 @@ ecdsa==0.11 		# MIT
 filechunkio==1.5	# MIT
 html5lib==1.0b3 	# MIT
 httplib2==0.9 		# MIT
+isoweek==1.3.0      # BSD
 luigi==1.0.16 		# Apache License 2.0
 mechanize==0.2.5	# BSD
 mysql-connector-python==1.2.2  	# GPL v2 with FOSS License Exception

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,11 +32,12 @@ edx.analytics.tasks =
     export-student-module = edx.analytics.tasks.database_exports:StudentModulePerCourseAfterImportWorkflow
     last-country = edx.analytics.tasks.user_location:LastCountryForEachUser
     export-events = edx.analytics.tasks.event_exports:EventExportTask
-    user-activity = edx.analytics.tasks.user_activity:UserActivityBaseTask
+    user-activity = edx.analytics.tasks.user_activity:UserActivityWorkflow
     insert-into-table = edx.analytics.tasks.mysql_load:MysqlInsertTask
     database-import = edx.analytics.tasks.database_imports:ImportAllDatabaseTablesTask
     location-per-course = edx.analytics.tasks.location_per_course:LastCountryOfUser
     course-facts-to-mysql = edx.analytics.tasks.daily_enrollment_trends:ImportCourseDailyFactsIntoMysql
+    calendar = edx.analytics.tasks.calendar:ImportCalendarToHiveTask
 
 mapreduce.engine =
     hadoop = edx.analytics.tasks.mapreduce:MapReduceJobRunner

--- a/share/ec2.ini
+++ b/share/ec2.ini
@@ -1,7 +1,7 @@
 [ec2]
 regions=us-east-1
 destination_variable=route53_domain_name
-backup_destination_variable=public_dns_name
+backup_destination_variable=private_ip_address
 cache_path=/tmp
 cache_max_age=300
 regions_exclude=

--- a/share/logging.cfg.j2
+++ b/share/logging.cfg.j2
@@ -13,7 +13,7 @@ keys=root,edx_analytics,luigi_interface
 keys=stderrHandler,luigiHandler,localHandler
 
 [formatters]
-keys=standard,luigi_default
+keys=standard
 
 [logger_root]
 level=INFO
@@ -28,7 +28,7 @@ propagate=0
 
 [logger_luigi_interface]
 # Errors from luigi-interface get routed to stdout.
-level=INFO
+level=DEBUG
 handlers=luigiHandler
 qualname=luigi-interface
 propagate=0
@@ -41,7 +41,7 @@ args=(sys.stderr,)
 [handler_luigiHandler]
 # Define as in luigi/interface.py.
 class=StreamHandler
-formatter=luigi_default
+formatter=standard
 args=(sys.stdout,)
 
 [handler_localHandler]
@@ -55,7 +55,3 @@ args=('{{ log_dir }}/edx_analytics.log', 'w')
 [formatter_standard]
 # Define as in edx-platform/common/lib/logsettings.py (for dev logging, not syslog).
 format=%(asctime)s %(levelname)s %(process)d [%(name)s] %(filename)s:%(lineno)d - %(message)s
-
-[formatter_luigi_default]
-# Define as in luigi/interface.py.
-format=%(levelname)s: %(message)s


### PR DESCRIPTION
Support computation of multiple weeks of user activity

Includes:
- Removal of dead code related to activity computation
- Significant refactor of hive task structure
- Generic handling of "overwrite" for mapreduce tasks and hive tasks
- Lots of pylint violation fixes

Outstanding work:
- Update docstrings and comments
- Run and fix acceptance tests
- Update the acceptance test for activity

Validation already completed (all matched 100%):
- Ran historical enrollments, geolocation per course, and compared with existing values for each in production.
- Re-ran a few weeks of user activity using the release branch using week boundaries that align with ISO week boundaries. Ran the same weeks using the code on this branch. Compared the results.

Given the large(ish) number of pylint fixes in this patch, I recommend reviewing it at the commit level, I've tried to fold most of the changes into two separate commits, however, there is one bug fix that is interleaved.

Reviewer: @brianhw
Secondary Reviewer: @rocha
FYI: @jbau, @clintonb 
