### PR TITLE
Revert to using Python 2.6 for the time being

### DIFF
--- a/client.cfg
+++ b/client.cfg
@@ -1,6 +1,5 @@
 [hadoop]
 version = apache1
-python-executable=/usr/bin/python2.7
 
 [hive]
 release = apache

--- a/share/task.yml
+++ b/share/task.yml
@@ -20,7 +20,6 @@
     - log_dir: "{{ root_log_dir }}/{{ uuid}}"
     - working_repo_dir: "{{ working_dir }}/repo"
     - working_venv_dir: "{{ working_dir }}/venv"
-    - virtualenv_python: "/usr/bin/python2.7"
     - task_arguments: ''
     - git_servers:
         # Analytics repositories are currently hosted on github.
@@ -31,8 +30,8 @@
     - install_env:
         # EMR runs a modified version of Debian 6 (squeeze)
         WHEEL_URL: http://edx-wheelhouse.s3-website-us-east-1.amazonaws.com/Debian/squeeze
-        # EMR ships with python 2.7
-        WHEEL_PYVER: 2.7
+        # EMR ships with python 2.6 (unfortunately)
+        WHEEL_PYVER: 2.6
 
     # - override_config: path/to/config.cfg (optionally adds a luigi config override)
 
@@ -96,7 +95,7 @@
 
     - name: virtualenv created
       command: >
-        virtualenv --python={{ virtualenv_python }} {{ working_venv_dir }}
+        virtualenv {{ working_venv_dir }}
 
     - name: update pip
       command: >

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27
+envlist=py26,py27
 
 # tox does not update the virtualenv after changes to requirement files.
 # http://bitbucket.org/hpk42/tox/issue/149/virtualenv-is-not-recreated-when-deps
@@ -10,6 +10,9 @@ deps=-r{toxinidir}/requirements/default.txt
 setenv =
     LUIGI_CONFIG_PATH = {toxinidir}/config/test.cfg
 commands=nosetests -A 'not acceptance'
+
+[testenv:py26]
+install_command=pip install --download-cache=/tmp/tox/cache {env:TOX_PY26_USE_WHEEL} --pre --allow-external argparse --allow-external mysql-connector-python {opts} {packages}
 
 [testenv:py27]
 install_command=pip install --download-cache=/tmp/tox/cache {env:TOX_PY27_USE_WHEEL} --pre --allow-external argparse --allow-external mysql-connector-python {opts} {packages}


### PR DESCRIPTION
Since we don't yet have wheels and we don't actually need 2.7 yet, I'd like to defer this patch until after the release so that we don't kill the performance of our existing jobs.
