### PR TITLE
Modify EventLogSelectionTask to accept multiple values for source parameter.

### DIFF
--- a/config/test.cfg
+++ b/config/test.cfg
@@ -21,6 +21,7 @@ marker = s3://fake/marker/
 pattern = .*tracking.log-(?P<date>\d{8}).*\.gz
 expand_interval = 2 days
 source = s3://fake/input/
+         s3://fake/input2/
 
 [event-export]
 output_root = s3://fake/

--- a/edx/analytics/tasks/tests/test_event_exports.py
+++ b/edx/analytics/tasks/tests/test_event_exports.py
@@ -50,7 +50,7 @@ class EventExportTestCase(InitializeOpaqueKeysMixin, unittest.TestCase):
             mapreduce_engine='local',
             output_root='test://output/',
             config='test://config/default.yaml',
-            source='test://input/',
+            source=['test://input/'],
             environment='prod',
             interval=Year.parse('2014'),
             gpg_key_dir='test://config/gpg-keys/',
@@ -293,7 +293,7 @@ class EventExportTestCase(InitializeOpaqueKeysMixin, unittest.TestCase):
         self.assertEquals(1, len(requirements))
 
         task = requirements[0]
-        self.assertEquals('test://input/', task.source)
+        self.assertEquals(('test://input/',), task.source)
         # Pattern is difficult to validate since it's read from the config
         # Interval is also difficult to validate since it is expanded by the initializer
 


### PR DESCRIPTION
Values in config files may be specified on separate lines.  E.g.:

``` code
  [event-logs]
  source = s3://fake/input/
           s3://fake/input2/
```
