### PR TITLE
Include alternate names for orgs when selected for event export.

### DIFF
--- a/edx/analytics/tasks/event_exports.py
+++ b/edx/analytics/tasks/event_exports.py
@@ -79,6 +79,10 @@ class EventExportTask(EventLogSelectionMixin, MultiOutputMapReduceJobTask):
         self.recipients_for_org_id = {}
         self.primary_org_ids_for_org_id = {}
         for org_id, org_config in self.organizations.iteritems():
+            # If org_ids are specified, restrict the processed files to that set of primary org ids.
+            if len(self.org_id) > 0 and org_id not in self.org_id:
+                continue
+
             recipients = org_config.get('recipients')
             if not recipients:
                 # provide fallback to legacy parameter name:
@@ -96,10 +100,6 @@ class EventExportTask(EventLogSelectionMixin, MultiOutputMapReduceJobTask):
                     self.primary_org_ids_for_org_id[alias] = [org_id]
 
         self.org_id_whitelist = set(self.recipients_for_org_id.keys())
-
-        # If org_ids are specified, restrict the processed files to that set.
-        if len(self.org_id) > 0:
-            self.org_id_whitelist.intersection_update(self.org_id)
 
         log.debug('Using org_id whitelist ["%s"]', '", "'.join(self.org_id_whitelist))
 

--- a/edx/analytics/tasks/tests/test_event_exports.py
+++ b/edx/analytics/tasks/tests/test_event_exports.py
@@ -70,11 +70,23 @@ class EventExportTestCase(InitializeOpaqueKeysMixin, unittest.TestCase):
     def test_org_whitelist_capture(self):
         self.task.init_local()
         self.assertItemsEqual(self.task.org_id_whitelist, ['FooX', 'BarX', 'BazX', 'Bar2X', 'bar'])
+        expected_primary_org_id_map = {
+            'FooX': ['FooX'],
+            'BarX': ['BarX'],
+            'BazX': ['BarX'],
+            'Bar2X': ['Bar2X'],
+            'bar': ['BarX', 'Bar2X'],
+        }
+        # Compare contents of dicts, but allowing for different order within list values.
+        self.assertItemsEqual(self.task.primary_org_ids_for_org_id, expected_primary_org_id_map)
+        for key in expected_primary_org_id_map:
+            self.assertItemsEqual(self.task.primary_org_ids_for_org_id[key], expected_primary_org_id_map[key])
 
     def test_limited_orgs(self):
-        task = self._create_export_task(org_id=['FooX', 'bar'])
+        task = self._create_export_task(org_id=['Bar2X'])
         task.init_local()
-        self.assertItemsEqual(task.org_id_whitelist, ['FooX', 'bar'])
+        self.assertItemsEqual(task.org_id_whitelist, ['Bar2X', 'bar'])
+        self.assertEqual(task.primary_org_ids_for_org_id, {'Bar2X': ['Bar2X'], 'bar': ['Bar2X']})
 
     def test_mapper(self):
         # The following should produce one output per input:


### PR DESCRIPTION
Selection of org names for event export should select the primary org
names used, not the white list.

@mulby @rocha 
