### PR TITLE
Update get_filename_safe_course_id to be more restrictive.

### DIFF
--- a/edx/analytics/tasks/enrollments.py
+++ b/edx/analytics/tasks/enrollments.py
@@ -160,7 +160,7 @@ class DaysEnrolledForEvents(object):
         if self.first_event.event_type == DEACTIVATED:
             # First event was an unenrollment event, assume the user was enrolled before that moment in time.
             log.warning('First event is an unenrollment for user %d in course %s on %s',
-                self.user_id, self.course_id, self.first_event.datestamp)
+                        self.user_id, self.course_id, self.first_event.datestamp)
 
         # Before we start processing events, we can assume that their current state is the same as it has been for all
         # time before the first event.

--- a/edx/analytics/tasks/util/opaque_key_util.py
+++ b/edx/analytics/tasks/util/opaque_key_util.py
@@ -64,13 +64,15 @@ def get_filename_safe_course_id(course_id, replacement_char='_'):
     """
     try:
         course_key = CourseKey.from_string(course_id)
-        filename = replacement_char.join([course_key.org, course_key.course, course_key.run])
-        return filename.replace(':', replacement_char)
+        filename = unicode(replacement_char).join([course_key.org, course_key.course, course_key.run])
     except InvalidKeyError:
         # If the course_id doesn't parse, we will still return a value here.
-        # Validation should have been done elsewhere, but do the minimum
-        # here to make a valid filename.
-        return course_id.replace('/', replacement_char).replace(':', replacement_char)
+        filename = course_id
+
+    # The safest characters are A-Z, a-z, 0-9, <underscore>, <period> and <hyphen>.
+    # We represent the first four with \w.
+    # TODO: Once we support courses with unicode characters, we will need to revisit this.
+    return re.sub(r'[^\w\.\-]', unicode(replacement_char), filename)
 
 
 def get_course_key_from_url(url):


### PR DESCRIPTION
Instead of hardcoding knowledge about colons, just replace all
but a well-defined set of supported characters.

And fix a PEP8 violation.

Also the start of adding some testing for unicode characters that are permitted in opaque key identifiers.

@mulby @rocha 
