### PR TITLE
Add handling for answer strings that convert to float inf and nan

### DIFF
--- a/edx/analytics/tasks/answer_dist.py
+++ b/edx/analytics/tasks/answer_dist.py
@@ -2,6 +2,7 @@
 Luigi tasks for extracting problem answer distribution statistics from
 tracking log files.
 """
+import math
 import csv
 import hashlib
 import html5lib
@@ -861,7 +862,11 @@ class AnswerDistributionToMySQLTaskWorkflow(
 ################################
 def try_str_to_float(value_str):
     try:
-        return float(value_str)
+        float_val = float(value_str)
+        # infinity values and NaN actually break mysql-connector (because they look like a string), so make those None
+        if math.isinf(float_val) or math.isnan(float_val):
+            return None
+        return float_val
     except (ValueError, TypeError):
         return None
 


### PR DESCRIPTION
@mulby @brianhw 

This fixes a very interesting bug we ran into.  The symptom was the following SQL query error on insert

```
1054 (42S22): Unknown column 'inf' in 'field list'
```

which turned out to be caused by the following data:

```
(u'Education/EDUC115-S/Spring2014', u'i4x://Education/EDUC115-S/problem/1008ec10508c4b2c99930e47b1f92532', u'i4x-Education-EDUC115-S-problem-1008ec10508c4b2c99930e47b1f92532_2_1', u'1', 1, None, u'infinity', inf, None, u'Quiz - Fractions: Big Ideas', None)
```

What's going on is that `float(u"infinity")` evaluates to `inf`, which breaks the mysql connector prepared statement.  So this converts the output of any `inf` or `nan` to `None`
