### PR TITLE
updating to match exporter

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -26,4 +26,4 @@ stevedore==0.14.1 	# Apache 2.0
 tornado==3.1.1 		# Apache 2.0
 wsgiref==0.1.2 		# ZPL
 -e git+https://github.com/edx/luigi.git@v1.0.17-fork.edx.1#egg=luigi 		# Apache License 2.0
--e git+https://github.com/edx/opaque-keys.git@705cd2a5388579342d70e9d0a605bc9ef3533453#egg=opaque-keys
+-e git+https://github.com/edx/opaque-keys.git@33f2b099e92957046a866a9b6d48a71c484bb475#egg=opaque-keys


### PR DESCRIPTION
I'd like to create a new version of ok, and have submitted this:

https://github.com/edx/opaque-keys/pull/45

In the meantime this PR updates the pipeline to match the version of OK used by the exporter.

@brianhw @mulby 
