### PR TITLE
Support validation of enrollment.

### DIFF
--- a/edx/analytics/tasks/answer_dist.py
+++ b/edx/analytics/tasks/answer_dist.py
@@ -586,7 +586,7 @@ class BaseAnswerDistributionTask(MapReduceJobTask):
         manifest: a URL to a file location that can store the complete set of input files.
     """
     name = luigi.Parameter()
-    src = luigi.Parameter()
+    src = luigi.Parameter(is_list=True)
     dest = luigi.Parameter()
     include = luigi.Parameter(is_list=True, default=('*',))
     # A manifest file is required by hadoop if there are too many input paths. It hits an operating system limit on the
@@ -674,7 +674,7 @@ class AnswerDistributionOneFilePerCourseTask(MultiOutputMapReduceJobTask):
         delete_output_root: if True, recursively deletes the output_root at task creation.
     """
 
-    src = luigi.Parameter()
+    src = luigi.Parameter(is_list=True)
     dest = luigi.Parameter()
     include = luigi.Parameter(is_list=True, default=('*',))
     name = luigi.Parameter(default='periodic')
@@ -814,7 +814,7 @@ class InsertToMysqlAnswerDistributionTableBase(MysqlInsertTask):
 
 class AnswerDistributionToMySQLParamsMixin(object):
     name = luigi.Parameter()
-    src = luigi.Parameter()
+    src = luigi.Parameter(is_list=True)
     dest = luigi.Parameter()
     include = luigi.Parameter(is_list=True, default=('*',))
     # A manifest file is required by hadoop if there are too many input paths. It hits an operating system limit on the

--- a/edx/analytics/tasks/course_enroll.py
+++ b/edx/analytics/tasks/course_enroll.py
@@ -178,7 +178,7 @@ class BaseCourseEnrollmentTaskDownstreamMixin(OverwriteOutputMixin, MapReduceJob
       run_date: the date to use as the partition version
     """
     name = luigi.Parameter()
-    src = luigi.Parameter()
+    src = luigi.Parameter(is_list=True)
     dest = luigi.Parameter()
     include = luigi.Parameter(is_list=True, default=('*',))
     manifest = luigi.Parameter(default=None)

--- a/edx/analytics/tasks/enrollment_validation.py
+++ b/edx/analytics/tasks/enrollment_validation.py
@@ -95,9 +95,14 @@ class CourseEnrollmentValidationTask(
             return
 
         mode = event_data.get('mode')
+        # TODO: update synthetic events with mode information.
+        # (For now, permit synthetic events to be processed without mode info for validation purposes.)
         if mode is None:
-            log.error("encountered explicit enrollment event with no mode: %s", event)
-            return
+            if 'synthesized' in event:
+                mode = "honor"
+            else:
+                log.error("encountered explicit enrollment event with no mode: %s", event)
+                return
 
         # Pull in extra properties provided only by synthetic enrollment validation events.
         validation_info = None

--- a/edx/analytics/tasks/enrollment_validation.py
+++ b/edx/analytics/tasks/enrollment_validation.py
@@ -551,6 +551,8 @@ class CourseEnrollmentValidationPerDateTask(
             output_root=self.intermediate_output,
             event_output=self.event_output,
             generate_before=self.generate_before,
+            include_nonstate_changes=self.include_nonstate_changes,
+            earliest_timestamp=self.earliest_timestamp,
         )
 
     def mapper(self, line):

--- a/edx/analytics/tasks/enrollment_validation.py
+++ b/edx/analytics/tasks/enrollment_validation.py
@@ -1,0 +1,566 @@
+"""Compute metrics related to user enrollments in courses"""
+
+import datetime
+import gzip
+import json
+import logging
+import os
+import re
+
+import luigi
+
+from edx.analytics.tasks.mapreduce import MultiOutputMapReduceJobTask, MapReduceJobTask, MapReduceJobTaskMixin
+from edx.analytics.tasks.pathutil import EventLogSelectionMixin, EventLogSelectionDownstreamMixin
+from edx.analytics.tasks.url import get_target_from_url, url_path_join, ExternalURL
+from edx.analytics.tasks.util import eventlog, opaque_key_util
+from edx.analytics.tasks.util.event_factory import SyntheticEventFactory
+
+log = logging.getLogger(__name__)
+
+DEACTIVATED = 'edx.course.enrollment.deactivated'
+ACTIVATED = 'edx.course.enrollment.activated'
+VALIDATED = 'edx.course.enrollment.validated'
+SENTINEL = 'edx.course.enrollment.sentinel'
+
+
+class CourseEnrollmentValidationDownstreamMixin(EventLogSelectionDownstreamMixin, MapReduceJobTaskMixin):
+    """
+    Defines parameters for passing upstream to tasks that use CourseEnrollmentValidationTask.
+
+    Parameters:
+
+        output_root: A URL to a path where output event files will be written.
+
+        event_output:  A flag indicating that output should be in the form of events.
+            Default = tuples.
+
+        generate_before:  A flag indicating that events should be created preceding the specified interval.
+            Default behavior is to suppress the generation of events before the specified interval.
+
+    """
+    # location to write output
+    output_root = luigi.Parameter()
+
+    # flag indicating whether to output synthetic events or tuples
+    event_output = luigi.BooleanParameter(default=False)
+
+    # If set, generates events that occur before the start of the specified interval.
+    # Default is incremental validation.
+    generate_before = luigi.BooleanParameter(default=False)
+
+    # if set, expects that every user/course combination will have a validation event
+    # TODO: implement.  Decide what happens if event is missing. (Output missing validation event.)
+    require_validation = luigi.BooleanParameter(default=False)
+
+
+class CourseEnrollmentValidationTask(
+        CourseEnrollmentValidationDownstreamMixin, EventLogSelectionMixin, MapReduceJobTask):
+    """Produce a data set that shows which days each user was enrolled in each course."""
+
+    def mapper(self, line):
+        value = self.get_event_and_date_string(line)
+        if value is None:
+            return
+        event, _date_string = value
+
+        event_type = event.get('event_type')
+        if event_type is None:
+            log.error("encountered event with no event_type: %s", event)
+            return
+
+        # TODO: add in mode changes as well...
+        if event_type not in (DEACTIVATED, ACTIVATED, VALIDATED):
+            return
+
+        timestamp = eventlog.get_event_time_string(event)
+        if timestamp is None:
+            log.error("encountered event with bad timestamp: %s", event)
+            return
+
+        event_data = eventlog.get_event_data(event)
+        if event_data is None:
+            return
+
+        course_id = event_data.get('course_id')
+        if course_id is None or not opaque_key_util.is_valid_course_id(course_id):
+            log.error("encountered explicit enrollment event with invalid course_id: %s", event)
+            return
+
+        user_id = event_data.get('user_id')
+        if user_id is None:
+            log.error("encountered explicit enrollment event with no user_id: %s", event)
+            return
+
+        # Pull in extra properties provided only by synthetic enrollment validation events.
+        is_active = event_data.get('is_active')
+        created = event_data.get('created')
+
+        yield (course_id, user_id), (timestamp, event_type, is_active, created)
+
+    def reducer(self, key, values):
+        """Emit records for each day the user was enrolled in the course."""
+        course_id, user_id = key
+
+        options = {
+            'event_output': self.event_output,
+            'require_validation': self.require_validation,
+            'generate_before': self.generate_before,
+            'lower_bound_date_string': self.lower_bound_date_string,
+        }
+        event_stream_processor = ValidateEnrollmentForEvents(
+            course_id, user_id, self.interval, values, **options
+        )
+        for datestamp, missing_enroll_event in event_stream_processor.missing_enrolled():
+            yield datestamp, missing_enroll_event
+
+    def output(self):
+        return get_target_from_url(self.output_root)
+
+
+class EnrollmentEvent(object):
+    """The critical information necessary to process the event in the event stream."""
+
+    def __init__(self, timestamp, event_type, is_active, created):
+        self.timestamp = timestamp
+        self.event_type = event_type
+        self.is_active = is_active
+        self.created = created
+
+
+class ValidateEnrollmentForEvents(object):
+    """TODO: More to say...."""
+
+    def __init__(self, course_id, user_id, interval, events, **kwargs):
+        self.course_id = course_id
+        self.user_id = user_id
+        self.interval = interval
+        self.creation_timestamp = None
+        self.event_output = kwargs.get('event_output')
+        self.require_validation = kwargs.get('require_validation')
+        self.generate_before = kwargs.get('generate_before')
+        self.lower_bound_date_string = kwargs.get('lower_bound_date_string')
+
+        if self.event_output:
+            self.factory = SyntheticEventFactory(
+                event_source='server',
+                synthesizer='enrollment_validation',
+            )
+            self.generate_output = self.synthetic_event
+        else:
+            self.generate_output = self.create_tuple
+
+        # Create list of events in reverse order, as processing goes backwards
+        # from validation states.
+        self.sorted_events = [
+            EnrollmentEvent(timestamp, event_type, is_active, created)
+            for timestamp, event_type, is_active, created in sorted(events, reverse=True)
+        ]
+
+        # Add a marker event to signal the beginning of the interval.
+        initial_state = EnrollmentEvent(None, SENTINEL, is_active=False, created=None)
+        self.sorted_events.append(initial_state)
+
+    def missing_enrolled(self):
+        """
+        A synthetic event is yielded for each transition in user's events for which a real event is missing.
+
+        Yields:
+            json-encoded string representing a synthetic event.
+        """
+        # The last element of the list is a placeholder indicating the beginning of the interval.
+        # Don't process it.
+        num_events = len(self.sorted_events) - 1
+
+        all_missing_events = []
+        validation_found = False
+        for index in range(num_events):
+            event = self.sorted_events[index]
+            prev_event = self.sorted_events[index + 1]
+
+            if event.event_type == VALIDATED:
+                validation_found = True
+
+            missing_events = self.check_transition(prev_event, event)
+            if missing_events:
+                all_missing_events.extend(missing_events)
+
+            if self.require_validation and not validation_found:
+                log.error("No validation event found for user %s in course %s", self.user_id, self.course_id)
+        return all_missing_events
+
+    def create_tuple(self, timestamp, event_type, reason, after=None, before=None):
+        """TODO"""
+        datestamp = eventlog.timestamp_to_datestamp(timestamp)
+        return datestamp, (self.course_id, self.user_id, timestamp, event_type, reason, after, before)
+
+    def synthetic_event(self, timestamp, event_type, reason, after=None, before=None):
+        """Create a synthetic event."""
+        # data specific to course enrollment events:
+        event_data = {
+            'course_id': self.course_id,
+            'user_id': self.user_id,
+            # 'mode': mode,
+        }
+
+        event_properties = {
+            # main properties:
+            'time': timestamp,
+            'event_type': event_type,
+            # stuff for context:
+            'user_id': self.user_id,
+            'course_id': self.course_id,
+            'org_id': opaque_key_util.get_org_id_for_course(self.course_id),
+            # stuff for synthesized:
+            'reason': reason,
+        }
+
+        event = self.factory.create_event(event_data, **event_properties)
+        synthesized = event['synthesized']
+        if after:
+            synthesized['after_time'] = after
+        if before:
+            synthesized['before_time'] = before
+
+        datestamp = eventlog.timestamp_to_datestamp(timestamp)
+        return datestamp, json.dumps(event)
+
+    def _add_microseconds(self, timestamp, microseconds):
+        """
+        Add given microseconds to a timestamp.
+
+        Input and output are timestamps as ISO format strings.  Microseconds can be negative.
+        """
+        # First try to parse the timestamp string and do simple math, to avoid
+        # the high cost of using strptime to parse in most cases.
+        timestamp_base, _period, microsec_base = timestamp.partition('.')
+        if not microsec_base:
+            microsec_base = '0'
+            timestamp = '{datetime}.000000'.format(datetime=timestamp)
+        microsec_int = int(microsec_base) + microseconds
+        if microsec_int >= 0 and microsec_int < 1000000:
+            return "{}.{}".format(timestamp_base, str(microsec_int).zfill(6))
+
+        # If there's a carry, then just use the datetime library.
+        parsed_timestamp = datetime.datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S.%f')
+        newtimestamp = (parsed_timestamp + datetime.timedelta(microseconds=microseconds)).isoformat()
+        if '.' not in newtimestamp:
+            newtimestamp = '{datetime}.000000'.format(datetime=newtimestamp)
+        return newtimestamp
+
+    def _get_fake_timestamp(self, after, before):
+        """
+        Pick a time in an interval.
+
+        Picks a microsecond after `after`, else a microsecond before `before`.
+
+        Input and output values are ISO format strings.
+        """
+        # Just pick the time at the beginning of the interval.
+        if after:
+            # Add a microsecond to 'after'
+            return self._add_microseconds(after, 1)
+        else:
+            # Subtract a microsecond from 'before'
+            return self._add_microseconds(before, -1)
+
+    STATE_MAP = {
+        VALIDATED: "validate",
+        ACTIVATED: "activate",
+        DEACTIVATED: "deactivate",
+        SENTINEL: "start",
+    }
+
+    def _get_state_string(self, event):
+        """TODO"""
+        state_name = self.STATE_MAP.get(event.event_type, "unknown")
+        if event.event_type == VALIDATED:
+            state_name += "(active)" if event.is_active else "(inactive)"
+        return state_name
+
+    def _get_transition_string(self, prev_event, curr_event):
+        """TODO"""
+        return "{prev} => {curr}".format(
+            prev=self._get_state_string(prev_event),
+            curr=self._get_state_string(curr_event),
+        )
+
+    def check_transition(self, prev_event, curr_event):
+        """TODO: """
+        prev_type = prev_event.event_type
+        curr_type = curr_event.event_type
+        prev = prev_event.timestamp
+        curr = curr_event.timestamp
+        timestamp = self._get_fake_timestamp(prev, curr)
+        reason = self._get_transition_string(prev_event, curr_event)
+
+        if curr_type == VALIDATED:
+            if self.creation_timestamp:
+                # compare with previously-viewed (i.e. later-in-time) validation:
+                if curr_event.created != self.creation_timestamp:
+                    log.error("Encountered validation with different creation timestamp: %s => %s",
+                              curr_event.created, self.creation_timestamp)
+            # Use the earliest validation:
+            self.creation_timestamp = curr_event.created
+
+            if prev_type == VALIDATED:
+                if curr_event.is_active and not prev_event.is_active:
+                    return [self.generate_output(timestamp, ACTIVATED, reason, prev, curr)]
+                elif not curr_event.is_active and prev_event.is_active:
+                    return [self.generate_output(timestamp, DEACTIVATED, reason, prev, curr)]
+            elif prev_type == ACTIVATED:
+                if not curr_event.is_active:
+                    return [self.generate_output(timestamp, DEACTIVATED, reason, prev, curr)]
+            elif prev_type == DEACTIVATED:
+                if curr_event.is_active:
+                    return [self.generate_output(timestamp, ACTIVATED, reason, prev, curr)]
+            elif prev_type == SENTINEL:
+                # If we are validating only within an interval and the create_timestamp
+                # is outside this interval, we can't know whether the events are really
+                # missing or just not included.
+                if not self.generate_before and self.creation_timestamp < self.lower_bound_date_string:
+                    pass
+                elif curr_event.is_active:
+                    # TODO: check that creation_timestamp is before 'curr'
+                    return [self.generate_output(
+                        self.creation_timestamp, ACTIVATED, reason, self.creation_timestamp, curr
+                    )]
+                else:
+                    # missing Activate and Deactivate events
+                    # TODO: check that creation_timestamp is before 'curr'
+                    event1 = self.generate_output(
+                        self.creation_timestamp, ACTIVATED, reason, self.creation_timestamp, curr
+                    )
+                    timestamp2 = self._get_fake_timestamp(self.creation_timestamp, curr)
+                    event2 = self.generate_output(timestamp2, DEACTIVATED, reason, self.creation_timestamp, curr)
+                    return [event1, event2]
+
+        elif curr_type == ACTIVATED:
+            if prev_type == VALIDATED:
+                if prev_event.is_active:
+                    return [self.generate_output(timestamp, DEACTIVATED, reason, prev, curr)]
+            elif prev_type == ACTIVATED:
+                return [self.generate_output(timestamp, DEACTIVATED, reason, prev, curr)]
+            elif prev_type == DEACTIVATED:
+                pass  # normal case
+            elif prev_type == SENTINEL:
+                pass  # normal case
+
+        elif curr_type == DEACTIVATED:
+            if prev_type == VALIDATED:
+                if not prev_event.is_active:
+                    return [self.generate_output(timestamp, ACTIVATED, reason, prev, curr)]
+            elif prev_type == ACTIVATED:
+                pass  # normal case
+            elif prev_type == DEACTIVATED:
+                return [self.generate_output(timestamp, ACTIVATED, reason, prev, curr)]
+            elif prev_type == SENTINEL:
+                # TODO: check that creation_timestamp is before 'curr'
+                # Note:  we are getting a significant number of deactivate events
+                # without any later validation, so the creation timestamp is 'None'.
+
+                # If we had a validation after the deactivation,
+                # and it provided a creation_timestamp within the interval,
+                # then there should be an activate within the interval.
+                if self.creation_timestamp and (
+                        self.generate_before or
+                        self.creation_timestamp >= self.lower_bound_date_string):
+                    return [self.generate_output(
+                        self.creation_timestamp, ACTIVATED, reason, self.creation_timestamp, curr
+                    )]
+                elif self.generate_before:
+                    # For now, hack the timestamp by making it a little before the deactivate,
+                    # so that it at least has a value.
+                    timestamp2 = self._get_fake_timestamp(None, curr)
+                    return [self.generate_output(timestamp2, ACTIVATED, reason, None, curr)]
+
+
+class CourseEnrollmentValidationPerDateTask(
+        CourseEnrollmentValidationDownstreamMixin, MultiOutputMapReduceJobTask):
+    """
+    Outputs CourseEnrollmentValidationTask according to key (i.e. datestamp).
+
+    Parameters:
+        intermediate_output: a URL for the location to write intermediate output.
+
+        output_root: location where the one-file-per-date outputs
+            are written.
+
+    """
+
+    intermediate_output = luigi.Parameter()
+
+    def requires(self):
+        return CourseEnrollmentValidationTask(
+            mapreduce_engine=self.mapreduce_engine,
+            lib_jar=self.lib_jar,
+            n_reduce_tasks=self.n_reduce_tasks,
+            interval=self.interval,
+            source=self.source,
+            pattern=self.pattern,
+            output_root=self.intermediate_output,
+            event_output=self.event_output,
+            generate_before=self.generate_before,
+        )
+
+    def mapper(self, line):
+        datestamp, values = line.split('\t', 1)
+        yield datestamp, values
+
+    def multi_output_reducer(self, _key, values, output_file):
+        with gzip.GzipFile(mode='wb', fileobj=output_file) as outfile:
+            for value in values:
+                outfile.write(value)
+                outfile.write('\n')
+
+    def output_path_for_key(self, datestamp):
+        if self.event_output:
+            # Match tracking.log-{datestamp}.gz format.
+            filename = u'synthetic_enroll.log-{datestamp}.gz'.format(
+                datestamp=datestamp.replace('-', ''),
+            )
+        else:
+            # Want to have tsv as extension, rather than date.
+            filename = u'synthetic_enroll-{datestamp}.tsv.gz'.format(
+                datestamp=datestamp.replace('-', ''),
+            )
+
+        return url_path_join(self.output_root, filename)
+
+
+class CreateEnrollmentValidationEventsTask(MultiOutputMapReduceJobTask):
+    """
+    Convert a database dump of course enrollment into log files of validation events.
+
+    Read from a directory location that points to a Sqoop dump of student_courseenrollment
+    table.  Use map reduce simply because it allows the multiple file output to be read
+    uniformly.  But it allows us to also separate the enrollment results into separate
+    courses so that validation runs can be more fine-grained.
+
+    The date for the synthesized events is the start time of the Sqoop dump.  This
+    is when the particular enrollment states were observed.
+    """
+    # Note: we could just read the corresponding validation data into
+    # the reducer.  So this would just need to produce reducer input
+    # instead of mapper input.  Problem with that is that if there
+    # were courses for which there were database entries but no
+    # events, they wouldn't get validated.  So we put the events into
+    # the mapper to make sure all courses get processed.
+
+    # This defines the directory (with the dt=<date> partition) that contains
+    # the desired database dump.
+    source_dir = luigi.Parameter()
+
+    def requires_hadoop(self):
+        # Check first if running locally with Sqoop output.
+        target = get_target_from_url(self.source_dir)
+        if isinstance(target, luigi.LocalTarget) and os.path.isdir(self.source_dir):
+            files = [f for f in os.listdir(self.source_dir) if f.startswith("part")]
+            for filename in files:
+                yield ExternalURL(url_path_join(self.source_dir, filename))
+        else:
+            yield ExternalURL(self.source_dir)
+
+    def init_local(self):
+        super(CreateEnrollmentValidationEventsTask, self).init_local()
+
+        # need to determine the date of the input, by reading the appropriate
+        # metadata file.  File looks like this:
+        # {"start_time": "2014-10-08T04:52:48.154228", "end_time": "2014-10-08T04:55:18.269070"}
+
+        metadata_target = self._get_metadata_target()
+        with metadata_target.open('r') as metadata_file:
+            metadata = json.load(metadata_file)
+            self.dump_start_time = metadata["start_time"]
+            log.debug("Found self.dump_start_time = %s", self.dump_start_time)
+            self.dump_date = ''.join((self.dump_start_time.split('T')[0]).split('-'))
+
+        self.factory = SyntheticEventFactory(
+            timestamp=self.dump_start_time,
+            event_source='server',
+            event_type=VALIDATED,
+            synthesizer='enrollment_from_db',
+            reason='db entry'
+        )
+
+    def _get_metadata_target(self):
+        """TODO:"""
+        # find the .metadata file in the source directory.
+        # return url_path_join(self.source_dir, ".metadata")
+        metadata_path = url_path_join(self.source_dir, ".metadata")
+        print "calling metadata_target " + str(metadata_path)
+        return get_target_from_url(metadata_path)
+
+    def _mysql_datetime_to_isoformat(self, mysql_datetime):
+        """
+        Convert mysql datetime strings to isoformat standard.
+
+        Mysql outputs strings of the form '2012-07-25 12:26:22.0'.
+        Log files use isoformat strings for sorting.
+        """
+        # TODO: move this into utility, or into mysql-support file.
+        date_parts = [int(d) for d in re.split(r'[:\-\. ]', mysql_datetime)]
+        if len(date_parts) > 6:
+            tenths = date_parts[6]
+            date_parts[6] = tenths * 100000
+        timestamp = datetime.datetime(*date_parts).isoformat()
+        if '.' not in timestamp:
+            timestamp = '{datetime}.000000'.format(datetime=timestamp)
+        return timestamp
+
+    def mapper(self, line):
+        # print "calling mapper:  " + line
+        fields = line.split('\x01')
+        if len(fields) != 6:
+            log.error("Encountered bad input: %s", line)
+            return
+
+        (_db_id, user_id, encoded_course_id, mysql_created, mysql_is_active, mode) = fields
+
+        # 'created' is of the form '2012-07-25 12:26:22.0', coming out of
+        # mysql.  Convert it to isoformat.
+        created = self._mysql_datetime_to_isoformat(mysql_created)
+        is_active = (mysql_is_active == "true")
+
+        # Note that we do not have several standard properties that we
+        # might expect in such an event.  These include a username,
+        # host, session_id, agent.  These values will be stubbed by
+        # the factory.
+
+        course_id = encoded_course_id.decode('utf-8')
+        # data for the particular type of event:
+        event_data = {
+            'course_id': course_id,
+            'user_id': user_id,
+            'mode': mode,
+            'is_active': is_active,
+            'created': created,
+        }
+
+        # stuff for context:
+        event_properties = {
+            'user_id': user_id,
+            'course_id': course_id,
+            'org_id': opaque_key_util.get_org_id_for_course(course_id),
+        }
+
+        event = self.factory.create_event(event_data, **event_properties)
+
+        # Use the original utf-8 version of the course_id as the key.
+        # (Note that if we want everything zipped into a single file,
+        # then we can just pass a single dummy value for the key instead of
+        # breaking the output out by course_id.)
+        yield encoded_course_id, json.dumps(event)
+
+    def multi_output_reducer(self, _key, values, output_file):
+        with gzip.GzipFile(mode='wb', fileobj=output_file) as outfile:
+            for value in values:
+                outfile.write(value)
+                outfile.write('\n')
+
+    def output_path_for_key(self, course_id):
+        filename_safe_course_id = opaque_key_util.get_filename_safe_course_id(course_id, '_')
+        filename = u'{course_id}_enroll_validated_{dumpdate}.log.gz'.format(
+            course_id=filename_safe_course_id,
+            dumpdate=self.dump_date,
+        )
+        return url_path_join(self.output_root, filename)

--- a/edx/analytics/tasks/reports/enrollments.py
+++ b/edx/analytics/tasks/reports/enrollments.py
@@ -22,7 +22,10 @@ DEFAULT_NUM_DAYS = 28
 class CourseEnrollmentCountMixin(MapReduceJobTaskMixin):
     """ Provides common parameters used in executive report tasks """
     name = luigi.Parameter()
-    src = luigi.Parameter(default_from_config={'section': 'enrollment-reports', 'name': 'src'})
+    src = luigi.Parameter(
+        is_list=True,
+        default_from_config={'section': 'enrollment-reports', 'name': 'src'},
+    )
     include = luigi.Parameter(is_list=True, default=('*',))
     weeks = luigi.IntParameter(default=DEFAULT_NUM_WEEKS)
     days = luigi.Parameter(default=DEFAULT_NUM_DAYS)

--- a/edx/analytics/tasks/reports/tests/test_enrollments.py
+++ b/edx/analytics/tasks/reports/tests/test_enrollments.py
@@ -30,7 +30,7 @@ class TestEnrollmentsByWeek(unittest.TestCase):
 
         # Make offsets None if it was not specified.
         task = EnrollmentsByWeek(name='fake_name',
-                                 src='fake_source',
+                                 src=['fake_source'],
                                  offsets='fake_offsets' if offset else None,
                                  destination='fake_destination',
                                  date=parsed_date,
@@ -180,7 +180,7 @@ class TestEnrollmentsByWeek(unittest.TestCase):
         date = datetime.date(2013, 01, 20)
 
         task = EnrollmentsByWeek(name='fake_name',
-                                 src='s3://bucket/path/',
+                                 src=['s3://bucket/path/'],
                                  offsets='s3://bucket/file.txt',
                                  destination='file://path/file.txt',
                                  date=date)

--- a/edx/analytics/tasks/tests/test_enrollment_validation.py
+++ b/edx/analytics/tasks/tests/test_enrollment_validation.py
@@ -1,0 +1,560 @@
+"""Test enrollment computations"""
+
+import json
+
+import luigi
+
+from edx.analytics.tasks.enrollment_validation import (
+    CourseEnrollmentValidationTask,
+    DEACTIVATED,
+    ACTIVATED,
+    VALIDATED,
+)
+from edx.analytics.tasks.tests import unittest
+from edx.analytics.tasks.tests.opaque_key_mixins import InitializeOpaqueKeysMixin, InitializeLegacyKeysMixin
+
+
+class CourseEnrollmentValidationTaskMapTest(InitializeOpaqueKeysMixin, unittest.TestCase):
+    """
+    Tests to verify that event log parsing by mapper works correctly.
+    """
+    def setUp(self):
+        self.initialize_ids()
+
+        fake_param = luigi.DateIntervalParameter()
+        self.task = CourseEnrollmentValidationTask(
+            interval=fake_param.parse('2013-12-17'),
+            output_root='/fake/output'
+        )
+        self.task.init_local()
+
+        self.user_id = 21
+        self.timestamp = "2013-12-17T15:38:32.805444"
+
+    def _create_event_log_line(self, **kwargs):
+        """Create an event log with test values, as a JSON string."""
+        return json.dumps(self._create_event_dict(**kwargs))
+
+    def _create_event_dict(self, **kwargs):
+        """Create an event log with test values, as a dict."""
+        # Define default values for event log entry.
+        event_dict = {
+            "username": "test_user",
+            "host": "test_host",
+            "event_source": "server",
+            "event_type": "edx.course.enrollment.activated",
+            "context": {
+                "course_id": self.course_id,
+                "org_id": self.org_id,
+                "user_id": self.user_id,
+            },
+            "time": "{0}+00:00".format(self.timestamp),
+            "ip": "127.0.0.1",
+            "event": {
+                "course_id": self.course_id,
+                "user_id": self.user_id,
+                "mode": "honor",
+            },
+            "agent": "blah, blah, blah",
+            "page": None
+        }
+        event_dict.update(**kwargs)
+        return event_dict
+
+    def assert_no_output_for(self, line):
+        """Assert that an input line generates no output."""
+        self.assertEquals(tuple(self.task.mapper(line)), tuple())
+
+    def test_non_enrollment_event(self):
+        line = 'this is garbage'
+        self.assert_no_output_for(line)
+
+    def test_unparseable_enrollment_event(self):
+        line = 'this is garbage but contains edx.course.enrollment'
+        self.assert_no_output_for(line)
+
+    def test_missing_event_type(self):
+        event_dict = self._create_event_dict()
+        event_dict['old_event_type'] = event_dict['event_type']
+        del event_dict['event_type']
+        line = json.dumps(event_dict)
+        self.assert_no_output_for(line)
+
+    def test_nonenroll_event_type(self):
+        line = self._create_event_log_line(event_type='edx.course.enrollment.unknown')
+        self.assert_no_output_for(line)
+
+    def test_bad_datetime(self):
+        line = self._create_event_log_line(time='this is a bogus time')
+        self.assert_no_output_for(line)
+
+    def test_bad_event_data(self):
+        line = self._create_event_log_line(event=["not an event"])
+        self.assert_no_output_for(line)
+
+    def test_illegal_course_id(self):
+        line = self._create_event_log_line(event={"course_id": ";;;;bad/id/val", "user_id": self.user_id})
+        self.assert_no_output_for(line)
+
+    def test_missing_user_id(self):
+        line = self._create_event_log_line(event={"course_id": self.course_id})
+        self.assert_no_output_for(line)
+
+    def test_good_enroll_event(self):
+        line = self._create_event_log_line()
+        event = tuple(self.task.mapper(line))
+        expected = (((self.course_id, self.user_id), (self.timestamp, ACTIVATED, None, None)),)
+        self.assertEquals(event, expected)
+
+    def test_good_unenroll_event(self):
+        line = self._create_event_log_line(event_type=DEACTIVATED)
+        event = tuple(self.task.mapper(line))
+        expected = (((self.course_id, self.user_id), (self.timestamp, DEACTIVATED, None, None)),)
+        self.assertEquals(event, expected)
+
+    def test_good_validation_event(self):
+        line = self._create_event_log_line(event_type=VALIDATED)
+        event = tuple(self.task.mapper(line))
+        expected = (((self.course_id, self.user_id), (self.timestamp, VALIDATED, None, None)),)
+        self.assertEquals(event, expected)
+
+
+class CourseEnrollmentValidationTaskLegacyMapTest(InitializeLegacyKeysMixin, CourseEnrollmentValidationTaskMapTest):
+    """TODO:"""
+    pass
+
+
+class BaseCourseEnrollmentValidationTaskReducerTest(unittest.TestCase):
+    """Provide common methods for testing CourseEnrollmentValidationTask reducer."""
+
+    @property
+    def key(self):
+        """Returns key value to simulate output from mapper to pass to reducer."""
+        user_id = 0
+        course_id = 'foo/bar/baz'
+        return (course_id, user_id)
+
+    def create_task(self, generate_before=True, event_output=False):
+        """Create a task for testing purposes."""
+        interval = '2013-01-01-2014-10-10'
+        fake_param = luigi.DateIntervalParameter()
+        self.task = CourseEnrollmentValidationTask(
+            interval=fake_param.parse(interval),
+            output_root="/fake/output",
+            generate_before=generate_before,
+            event_output=event_output,
+        )
+        self.task.init_local()
+
+    def _get_reducer_output(self, values):
+        """Run reducer with provided values hardcoded key."""
+        return tuple(self.task.reducer(self.key, values))
+
+    def check_output(self, inputs, expected):
+        """Compare generated with expected output."""
+        expected_with_key = tuple([(key, self.key + value) for key, value in expected])
+        self.assertEquals(self._get_reducer_output(inputs), expected_with_key)
+
+
+class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTaskReducerTest):
+    """
+    Tests to verify that events-per-day-per-user reducer works correctly.
+    """
+    def setUp(self):
+        self.create_task(generate_before=True)
+
+    def test_no_events(self):
+        self.check_output([], tuple())
+
+    def test_missing_single_enrollment(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123456', VALIDATED, True, '2013-04-01T00:00:01.123456'),
+            # missing activation (4/1)
+        ]
+        expected = (
+            ('2013-04-01',
+             ('2013-04-01T00:00:01.123456', ACTIVATED, "start => validate(active)",
+              '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
+        )
+        self.check_output(inputs, expected)
+
+    def test_missing_enroll_unenroll(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123456', VALIDATED, False, '2013-04-01T00:00:01.123456'),
+            # missing deactivation (between 4/1 and 9/1)
+            # missing activation (4/1)
+        ]
+        expected = (
+            ('2013-04-01',
+             ('2013-04-01T00:00:01.123456', ACTIVATED, "start => validate(inactive)",
+              '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
+            ('2013-04-01',
+             ('2013-04-01T00:00:01.123457', DEACTIVATED, "start => validate(inactive)",
+              '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
+        )
+        self.check_output(inputs, expected)
+
+    def test_single_enrollment(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123456', VALIDATED, True, '2013-04-01T00:00:01.123456'),
+            ('2013-04-01T00:00:01.123456', ACTIVATED, None, None),
+        ]
+        # expect no event.
+        self.check_output(inputs, tuple())
+
+    def test_single_unenrollment(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123457', VALIDATED, False, '2013-04-01T00:00:01.123456'),
+            ('2013-05-01T00:00:01.123456', DEACTIVATED, None, None),
+            # missing activation
+        ]
+        expected = (
+            ('2013-04-01',
+             ('2013-04-01T00:00:01.123456', ACTIVATED, "start => deactivate",
+              '2013-04-01T00:00:01.123456', '2013-05-01T00:00:01.123456')),
+        )
+        self.check_output(inputs, expected)
+
+    def test_single_unenrollment_without_ms(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123457', VALIDATED, False, '2013-04-01T00:00:01'),
+            ('2013-05-01T00:00:01.123456', DEACTIVATED, None, None),
+            # missing activation
+        ]
+        expected = (
+            ('2013-04-01',
+             ('2013-04-01T00:00:01', ACTIVATED, "start => deactivate",
+              '2013-04-01T00:00:01', '2013-05-01T00:00:01.123456')),
+        )
+        self.check_output(inputs, expected)
+
+    def test_single_unvalidated_unenrollment(self):
+        inputs = [
+            ('2013-05-01T00:00:01.123456', DEACTIVATED, None, None),
+            # missing activation
+        ]
+        expected = (
+            ('2013-05-01',
+             ('2013-05-01T00:00:01.123455', ACTIVATED, "start => deactivate",
+              None, '2013-05-01T00:00:01.123456')),
+        )
+        self.check_output(inputs, expected)
+
+    def test_rollover_unvalidated_unenrollment(self):
+        inputs = [
+            ('2013-05-01T00:00:01.000000', DEACTIVATED, None, None),
+            # missing activation
+        ]
+        expected = (
+            ('2013-05-01',
+             ('2013-05-01T00:00:00.999999', ACTIVATED, "start => deactivate",
+              None, '2013-05-01T00:00:01.000000')),
+        )
+        self.check_output(inputs, expected)
+
+    def test_unvalidated_unenrollment_without_ms(self):
+        inputs = [
+            ('2013-05-01T00:00:01', DEACTIVATED, None, None),
+            # missing activation
+        ]
+        expected = (
+            ('2013-05-01',
+             ('2013-05-01T00:00:00.999999', ACTIVATED, "start => deactivate",
+              None, '2013-05-01T00:00:01')),
+        )
+        self.check_output(inputs, expected)
+
+    def test_single_enroll_unenroll(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123456', VALIDATED, False, '2013-04-01T00:00:01.123456'),
+            ('2013-05-01T00:00:01.123456', DEACTIVATED, None, None),
+            ('2013-04-01T00:00:01.123456', ACTIVATED, None, None),
+        ]
+        # expect no event.
+        self.check_output(inputs, tuple())
+
+    def test_single_unenroll_enroll(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123456', ACTIVATED, None, None),
+            ('2013-05-01T00:00:01.123456', DEACTIVATED, None, None),
+            ('2013-04-01T00:00:01.123456', ACTIVATED, None, None),
+        ]
+        # expect no event.
+        self.check_output(inputs, tuple())
+
+    def test_multiple_validation(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123456', VALIDATED, True, '2013-04-01T00:00:01.123456'),
+            ('2013-08-01T00:00:01.123456', VALIDATED, True, '2013-04-01T00:00:01.123456'),
+            ('2013-07-01T00:00:01.123456', VALIDATED, True, '2013-04-01T00:00:01.123456'),
+            ('2013-01-01T00:00:01.123456', ACTIVATED, None, None),
+        ]
+        # expect no event.
+        self.check_output(inputs, tuple())
+
+    def test_multiple_validation_without_enroll(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123456', VALIDATED, True, '2013-04-01T00:00:01.123456'),
+            ('2013-08-01T00:00:01.123456', VALIDATED, True, '2013-04-01T00:00:01.123456'),
+            ('2013-07-01T00:00:01.123456', VALIDATED, True, '2013-04-01T00:00:01.123456'),
+            # missing activation
+        ]
+        expected = (
+            ('2013-04-01',
+             ('2013-04-01T00:00:01.123456', ACTIVATED, "start => validate(active)",
+              '2013-04-01T00:00:01.123456', '2013-07-01T00:00:01.123456')),
+        )
+        self.check_output(inputs, expected)
+
+    def test_enroll_unenroll_with_validations(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123456', VALIDATED, False, '2013-04-01T00:00:01.123456'),
+            ('2013-08-01T00:00:01.123456', DEACTIVATED, None, None),
+            ('2013-07-01T00:00:01.123456', VALIDATED, True, '2013-04-01T00:00:01.123456'),
+            ('2013-04-01T00:00:01.123456', ACTIVATED, None, None),
+        ]
+        # expect no event.
+        self.check_output(inputs, tuple())
+
+    def test_missing_activate_between_validation(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123456', VALIDATED, True, '2013-04-01T00:00:01.123456'),
+            # missing activation
+            ('2013-08-01T00:00:01.123456', VALIDATED, False, '2013-04-01T00:00:01.123456'),
+            ('2013-05-01T00:00:01.123456', DEACTIVATED, None, None),
+            ('2013-04-01T00:00:01.123456', ACTIVATED, None, None),
+        ]
+        expected = (
+            ('2013-08-01',
+             ('2013-08-01T00:00:01.123457', ACTIVATED, "validate(inactive) => validate(active)",
+              '2013-08-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
+        )
+        self.check_output(inputs, expected)
+
+    def test_missing_deactivate_between_validation(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123456', VALIDATED, False, '2013-04-01T00:00:01.123456'),
+            # missing deactivation
+            ('2013-08-01T00:00:01.123456', VALIDATED, True, '2013-04-01T00:00:01.123456'),
+            ('2013-01-01T00:00:01.123456', ACTIVATED, None, None),
+        ]
+        expected = (
+            ('2013-08-01',
+             ('2013-08-01T00:00:01.123457', DEACTIVATED, "validate(active) => validate(inactive)",
+              '2013-08-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
+        )
+        self.check_output(inputs, expected)
+
+    def test_missing_deactivate_from_validation(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123456', ACTIVATED, None, None),
+            # missing deactivation
+            ('2013-08-01T00:00:01.123456', VALIDATED, True, '2013-04-01T00:00:01.123456'),
+            ('2013-04-01T00:00:01.123456', ACTIVATED, None, None),
+        ]
+        expected = (
+            ('2013-08-01',
+             ('2013-08-01T00:00:01.123457', DEACTIVATED, "validate(active) => activate",
+              '2013-08-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
+        )
+        self.check_output(inputs, expected)
+
+    def test_missing_deactivate_from_activation(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123456', VALIDATED, False, '2013-04-01T00:00:01.123456'),
+            # missing deactivation
+            ('2013-04-01T00:00:01.123456', ACTIVATED, None, None),
+        ]
+        expected = (
+            ('2013-04-01',
+             ('2013-04-01T00:00:01.123457', DEACTIVATED, "activate => validate(inactive)",
+              '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
+        )
+        self.check_output(inputs, expected)
+
+    def test_rollover_deactivate_from_activation(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123456', VALIDATED, False, '2013-04-01T00:00:01.999999'),
+            # missing deactivation
+            ('2013-04-01T00:00:01.999999', ACTIVATED, None, None),
+        ]
+        expected = (
+            ('2013-04-01',
+             ('2013-04-01T00:00:02.000000', DEACTIVATED, "activate => validate(inactive)",
+              '2013-04-01T00:00:01.999999', '2013-09-01T00:00:01.123456')),
+        )
+        self.check_output(inputs, expected)
+
+    def test_missing_activate_from_deactivation(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123456', VALIDATED, True, '2013-04-01T00:00:01.123456'),
+            # missing activation
+            ('2013-08-01T00:00:01.123456', DEACTIVATED, None, None),
+            ('2013-01-01T00:00:01.123456', ACTIVATED, None, None),
+        ]
+        expected = (
+            ('2013-08-01',
+             ('2013-08-01T00:00:01.123457', ACTIVATED, "deactivate => validate(active)",
+              '2013-08-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
+        )
+        self.check_output(inputs, expected)
+
+    def test_missing_activate_between_deactivation(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123456', DEACTIVATED, None, None),
+            # missing activation
+            ('2013-08-01T00:00:01.123456', DEACTIVATED, None, None),
+            ('2013-01-01T00:00:01.123456', ACTIVATED, None, None),
+        ]
+        expected = (
+            ('2013-08-01',
+             ('2013-08-01T00:00:01.123457', ACTIVATED, "deactivate => deactivate",
+              '2013-08-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
+        )
+        self.check_output(inputs, expected)
+
+    def test_missing_deactivate_between_activation(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123456', ACTIVATED, None, None),
+            # missing deactivation
+            ('2013-01-01T00:00:01.123456', ACTIVATED, None, None),
+        ]
+        expected = (
+            ('2013-01-01',
+             ('2013-01-01T00:00:01.123457', DEACTIVATED, "activate => activate",
+              '2013-01-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
+        )
+        self.check_output(inputs, expected)
+
+    def test_missing_activate_from_validation(self):
+        inputs = [
+            ('2013-10-01T00:00:01.123456', DEACTIVATED, None, None),
+            # missing activation
+            ('2013-09-01T00:00:01.123456', VALIDATED, False, '2013-04-01T00:00:01.123456'),
+            ('2013-08-01T00:00:01.123456', DEACTIVATED, None, None),
+            ('2013-04-01T00:00:01.123456', ACTIVATED, None, None),
+        ]
+        expected = (
+            ('2013-09-01',
+             ('2013-09-01T00:00:01.123457', ACTIVATED, "validate(inactive) => deactivate",
+              '2013-09-01T00:00:01.123456', '2013-10-01T00:00:01.123456')),
+        )
+        self.check_output(inputs, expected)
+
+
+class CourseEnrollmentValidationTaskEventReducerTest(BaseCourseEnrollmentValidationTaskReducerTest):
+    """
+    Tests to verify that events-per-day-per-user reducer works correctly.
+    """
+    def setUp(self):
+        self.create_task(event_output=True)
+
+    def test_missing_single_enrollment(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123456', VALIDATED, True, '2013-04-01T00:00:01.123456'),
+            # missing activation (4/1)
+        ]
+        events = self._get_reducer_output(inputs)
+        self.assertEquals(len(events), 1)
+        datestamp, encoded_event = events[0]
+        self.assertEquals(datestamp, '2013-04-01')
+        event = json.loads(encoded_event)
+
+        self.assertEquals(event.get('event_type'), ACTIVATED)
+        self.assertEquals(event.get('time'), '2013-04-01T00:00:01.123456')
+
+        synthesized = event.get('synthesized')
+        self.assertEquals(synthesized.get('reason'), "start => validate(active)")
+        self.assertEquals(synthesized.get('after_time'), '2013-04-01T00:00:01.123456')
+        self.assertEquals(synthesized.get('before_time'), '2013-09-01T00:00:01.123456')
+
+
+class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskReducerTest):
+    """
+    Tests to verify that events before first validation event are properly skipped.
+    """
+    def setUp(self):
+        self.create_task(generate_before=False)
+
+    def test_no_events(self):
+        self.check_output([], tuple())
+
+    def test_missing_single_enrollment(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123456', VALIDATED, True, '2013-04-01T00:00:01.123456'),
+            # missing activation (4/1)
+        ]
+        expected = (
+            ('2013-04-01',
+             ('2013-04-01T00:00:01.123456', ACTIVATED, "start => validate(active)",
+              '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
+        )
+        self.check_output(inputs, expected)
+
+    def test_missing_early_single_enrollment(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123456', VALIDATED, True, '2012-04-01T00:00:01.123456'),
+            # missing activation (4/1/12)
+        ]
+        # expect no event.
+        self.check_output(inputs, tuple())
+
+    def test_single_deactivation(self):
+        inputs = [
+            ('2013-10-01T00:00:01.123456', DEACTIVATED, None, None),
+            # missing activation
+        ]
+        # expect no event.
+        self.check_output(inputs, tuple())
+
+    def test_missing_deactivate_from_activation(self):
+        inputs = [
+            ('2013-09-01T00:00:01.123456', VALIDATED, False, '2013-04-01T00:00:01.123456'),
+            # missing deactivation
+            ('2013-04-01T00:00:01.123456', ACTIVATED, None, None),
+        ]
+        # NO LONGER expect no event.
+        # self.check_output(inputs, tuple())
+        expected = (
+            ('2013-04-01',
+             ('2013-04-01T00:00:01.123457', DEACTIVATED, "activate => validate(inactive)",
+              '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
+        )
+        self.check_output(inputs, expected)
+
+    def test_missing_activate_from_validation(self):
+        inputs = [
+            ('2013-10-01T00:00:01.123456', VALIDATED, False, '2013-04-01T00:00:01.123456'),
+            ('2013-09-01T00:00:01.123456', DEACTIVATED, None, None),
+            # missing activation (4/1)
+        ]
+        expected = (
+            ('2013-04-01',
+             ('2013-04-01T00:00:01.123456', ACTIVATED, "start => deactivate",
+              '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
+        )
+        self.check_output(inputs, expected)
+
+    def test_missing_early_activate_from_validation(self):
+        inputs = [
+            ('2013-10-01T00:00:01.123456', VALIDATED, False, '2012-04-01T00:00:01.123456'),
+            ('2013-09-01T00:00:01.123456', DEACTIVATED, None, None),
+            # missing activation (4/1/12)
+        ]
+        # expect no event.
+        self.check_output(inputs, tuple())
+
+    def test_missing_activate_after_validation(self):
+        inputs = [
+            ('2013-10-01T00:00:01.123456', DEACTIVATED, None, None),
+            # missing activation
+            ('2013-09-01T00:00:01.123456', VALIDATED, False, '2013-04-01T00:00:01.123456'),
+            ('2013-08-01T00:00:01.123456', DEACTIVATED, None, None),
+            ('2013-04-01T00:00:01.123456', ACTIVATED, None, None),
+        ]
+        expected = (
+            ('2013-09-01',
+             ('2013-09-01T00:00:01.123457', ACTIVATED, "validate(inactive) => deactivate",
+              '2013-09-01T00:00:01.123456', '2013-10-01T00:00:01.123456')),
+        )
+        self.check_output(inputs, expected)

--- a/edx/analytics/tasks/tests/test_enrollment_validation.py
+++ b/edx/analytics/tasks/tests/test_enrollment_validation.py
@@ -137,7 +137,7 @@ class BaseCourseEnrollmentValidationTaskReducerTest(unittest.TestCase):
     """Provide common methods for testing CourseEnrollmentValidationTask reducer."""
 
     def setUp(self):
-        self.mode = 'Honor'
+        self.mode = 'honor'
 
     @property
     def key(self):
@@ -206,7 +206,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
         ]
         expected = (
             ('2013-04-01',
-             ('2013-04-01T00:00:01.123456', ACTIVATED, "start => validate(active)",
+             ('2013-04-01T00:00:01.123456', ACTIVATED, "honor", "start => validate(active)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
         self.check_output(inputs, expected)
@@ -219,10 +219,10 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
         ]
         expected = (
             ('2013-04-01',
-             ('2013-04-01T00:00:01.123456', ACTIVATED, "start => validate(inactive)",
+             ('2013-04-01T00:00:01.123456', ACTIVATED, "honor", "start => validate(inactive)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
             ('2013-04-01',
-             ('2013-04-01T00:00:01.123457', DEACTIVATED, "start => validate(inactive)",
+             ('2013-04-01T00:00:01.123457', DEACTIVATED, "honor", "start => validate(inactive)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
         self.check_output(inputs, expected)
@@ -243,7 +243,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
         ]
         expected = (
             ('2013-04-01',
-             ('2013-04-01T00:00:01.123456', ACTIVATED, "start => deactivate",
+             ('2013-04-01T00:00:01.123456', ACTIVATED, "honor", "start => deactivate",
               '2013-04-01T00:00:01.123456', '2013-05-01T00:00:01.123456')),
         )
         self.check_output(inputs, expected)
@@ -256,7 +256,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
         ]
         expected = (
             ('2013-04-01',
-             ('2013-04-01T00:00:01', ACTIVATED, "start => deactivate",
+             ('2013-04-01T00:00:01', ACTIVATED, "honor", "start => deactivate",
               '2013-04-01T00:00:01', '2013-05-01T00:00:01.123456')),
         )
         self.check_output(inputs, expected)
@@ -268,7 +268,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
         ]
         expected = (
             ('2013-05-01',
-             ('2013-05-01T00:00:01.123455', ACTIVATED, "start => deactivate",
+             ('2013-05-01T00:00:01.123455', ACTIVATED, "honor", "start => deactivate",
               None, '2013-05-01T00:00:01.123456')),
         )
         self.check_output(inputs, expected)
@@ -280,7 +280,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
         ]
         expected = (
             ('2013-05-01',
-             ('2013-05-01T00:00:00.999999', ACTIVATED, "start => deactivate",
+             ('2013-05-01T00:00:00.999999', ACTIVATED, "honor", "start => deactivate",
               None, '2013-05-01T00:00:01.000000')),
         )
         self.check_output(inputs, expected)
@@ -292,7 +292,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
         ]
         expected = (
             ('2013-05-01',
-             ('2013-05-01T00:00:00.999999', ACTIVATED, "start => deactivate",
+             ('2013-05-01T00:00:00.999999', ACTIVATED, "honor", "start => deactivate",
               None, '2013-05-01T00:00:01')),
         )
         self.check_output(inputs, expected)
@@ -352,7 +352,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
         ]
         expected = (
             ('2013-04-01',
-             ('2013-04-01T00:00:01.123456', ACTIVATED, "start => validate(active)",
+             ('2013-04-01T00:00:01.123456', ACTIVATED, "honor", "start => validate(active)",
               '2013-04-01T00:00:01.123456', '2013-07-01T00:00:01.123456')),
         )
         self.check_output(inputs, expected)
@@ -377,7 +377,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
         ]
         expected = (
             ('2013-08-01',
-             ('2013-08-01T00:00:01.123457', ACTIVATED, "validate(inactive) => validate(active)",
+             ('2013-08-01T00:00:01.123457', ACTIVATED, "honor", "validate(inactive) => validate(active)",
               '2013-08-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
         self.check_output(inputs, expected)
@@ -391,7 +391,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
         ]
         expected = (
             ('2013-08-01',
-             ('2013-08-01T00:00:01.123457', DEACTIVATED, "validate(active) => validate(inactive)",
+             ('2013-08-01T00:00:01.123457', DEACTIVATED, "honor", "validate(active) => validate(inactive)",
               '2013-08-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
         self.check_output(inputs, expected)
@@ -405,7 +405,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
         ]
         expected = (
             ('2013-08-01',
-             ('2013-08-01T00:00:01.123457', DEACTIVATED, "validate(active) => activate",
+             ('2013-08-01T00:00:01.123457', DEACTIVATED, "honor", "validate(active) => activate",
               '2013-08-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
         self.check_output(inputs, expected)
@@ -418,7 +418,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
         ]
         expected = (
             ('2013-04-01',
-             ('2013-04-01T00:00:01.123457', DEACTIVATED, "activate => validate(inactive)",
+             ('2013-04-01T00:00:01.123457', DEACTIVATED, "honor", "activate => validate(inactive)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
         self.check_output(inputs, expected)
@@ -431,7 +431,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
         ]
         expected = (
             ('2013-04-01',
-             ('2013-04-01T00:00:02.000000', DEACTIVATED, "activate => validate(inactive)",
+             ('2013-04-01T00:00:02.000000', DEACTIVATED, "honor", "activate => validate(inactive)",
               '2013-04-01T00:00:01.999999', '2013-09-01T00:00:01.123456')),
         )
         self.check_output(inputs, expected)
@@ -445,7 +445,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
         ]
         expected = (
             ('2013-08-01',
-             ('2013-08-01T00:00:01.123457', ACTIVATED, "deactivate => validate(active)",
+             ('2013-08-01T00:00:01.123457', ACTIVATED, "honor", "deactivate => validate(active)",
               '2013-08-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
         self.check_output(inputs, expected)
@@ -459,7 +459,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
         ]
         expected = (
             ('2013-08-01',
-             ('2013-08-01T00:00:01.123457', ACTIVATED, "deactivate => deactivate",
+             ('2013-08-01T00:00:01.123457', ACTIVATED, "honor", "deactivate => deactivate",
               '2013-08-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
         self.check_output(inputs, expected)
@@ -472,7 +472,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
         ]
         expected = (
             ('2013-01-01',
-             ('2013-01-01T00:00:01.123457', DEACTIVATED, "activate => activate",
+             ('2013-01-01T00:00:01.123457', DEACTIVATED, "honor", "activate => activate",
               '2013-01-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
         self.check_output(inputs, expected)
@@ -487,7 +487,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
         ]
         expected = (
             ('2013-09-01',
-             ('2013-09-01T00:00:01.123457', ACTIVATED, "validate(inactive) => deactivate",
+             ('2013-09-01T00:00:01.123457', ACTIVATED, "honor", "validate(inactive) => deactivate",
               '2013-09-01T00:00:01.123456', '2013-10-01T00:00:01.123456')),
         )
         self.check_output(inputs, expected)
@@ -539,7 +539,7 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
         ]
         expected = (
             ('2013-04-01',
-             ('2013-04-01T00:00:01.123456', ACTIVATED, "start => validate(active)",
+             ('2013-04-01T00:00:01.123456', ACTIVATED, "honor", "start => validate(active)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
         self.check_output(inputs, expected)
@@ -570,7 +570,7 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
         # self.check_output(inputs, tuple())
         expected = (
             ('2013-04-01',
-             ('2013-04-01T00:00:01.123457', DEACTIVATED, "activate => validate(inactive)",
+             ('2013-04-01T00:00:01.123457', DEACTIVATED, "honor", "activate => validate(inactive)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
         self.check_output(inputs, expected)
@@ -583,7 +583,7 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
         ]
         expected = (
             ('2013-04-01',
-             ('2013-04-01T00:00:01.123456', ACTIVATED, "start => deactivate",
+             ('2013-04-01T00:00:01.123456', ACTIVATED, "honor", "start => deactivate",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
         self.check_output(inputs, expected)
@@ -607,7 +607,7 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
         ]
         expected = (
             ('2013-09-01',
-             ('2013-09-01T00:00:01.123457', ACTIVATED, "validate(inactive) => deactivate",
+             ('2013-09-01T00:00:01.123457', ACTIVATED, "honor", "validate(inactive) => deactivate",
               '2013-09-01T00:00:01.123456', '2013-10-01T00:00:01.123456')),
         )
         self.check_output(inputs, expected)
@@ -619,7 +619,7 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
         ]
         expected = (
             ('2013-04-01',
-             ('2013-04-01T00:00:01.123456', ACTIVATED, "start => validate(active)",
+             ('2013-04-01T00:00:01.123456', ACTIVATED, "honor", "start => validate(active)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:00.123455')),
         )
         self.check_output(inputs, expected)

--- a/edx/analytics/tasks/tests/test_enrollment_validation.py
+++ b/edx/analytics/tasks/tests/test_enrollment_validation.py
@@ -117,7 +117,7 @@ class CourseEnrollmentValidationTaskMapTest(InitializeOpaqueKeysMixin, unittest.
     def test_good_validation_event(self):
         validation_info = {
             'is_active': True,
-            'created':  '2012-07-24T12:37:32.000000',
+            'created': '2012-07-24T12:37:32.000000',
             'dump_start': '2014-10-08T04:52:48.154228',
             'dump_end': '2014-10-08T04:57:38.145282',
         }
@@ -164,17 +164,20 @@ class BaseCourseEnrollmentValidationTaskReducerTest(unittest.TestCase):
         self.task.init_local()
 
     def _activated(self, timestamp):
+        """Creates an ACTIVATED event."""
         return (timestamp, ACTIVATED, self.mode, None)
 
     def _deactivated(self, timestamp):
+        """Creates a DEACTIVATED event."""
         return (timestamp, DEACTIVATED, self.mode, None)
 
     def _validated(self, timestamp, is_active, created, dump_duration_in_secs=300):
+        """Creates a VALIDATED event."""
         dump_end = timestamp
         dump_start = add_microseconds(timestamp, int(dump_duration_in_secs) * -100000)
         validation_info = {
             'is_active': is_active,
-            'created':  created,
+            'created': created,
             'dump_start': dump_start,
             'dump_end': dump_end,
         }
@@ -625,4 +628,3 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:00.123455')),
         )
         self.check_output(inputs, expected)
-

--- a/edx/analytics/tasks/tests/test_pathutil.py
+++ b/edx/analytics/tasks/tests/test_pathutil.py
@@ -133,6 +133,23 @@ class EventLogSelectionTaskTest(unittest.TestCase):
             'FakeOldServerGroup3/tracking_14602.log.gz',
         ])
 
+    def test_multiple_filtering_of_urls(self):
+        task = EventLogSelectionTask(
+            source=self.SOURCE,
+            interval=Month.parse('2014-03'),
+            pattern=[
+                r'.*?FakeServerGroup/tracking.log-(?P<date>\d{8}).*\.gz',
+                r'.*?FakeEdgeServerGroup/tracking.log-(?P<date>\d{8}).*\.gz',
+            ],
+            expand_interval=datetime.timedelta(0),
+        )
+
+        self.assert_only_matched(task, [
+            'FakeServerGroup/tracking.log-20140318.gz',
+            'FakeServerGroup/tracking.log-20140319-1395256622.gz',
+            'FakeEdgeServerGroup/tracking.log-20140324-1395670621.gz',
+        ])
+
     def assert_only_matched(self, task, paths):
         """Assert that the task only includes the given paths in the selected set of files."""
         matched_urls = []

--- a/edx/analytics/tasks/tests/test_pathutil.py
+++ b/edx/analytics/tasks/tests/test_pathutil.py
@@ -133,23 +133,6 @@ class EventLogSelectionTaskTest(unittest.TestCase):
             'FakeOldServerGroup3/tracking_14602.log.gz',
         ])
 
-    def test_multiple_filtering_of_urls(self):
-        task = EventLogSelectionTask(
-            source=self.SOURCE,
-            interval=Month.parse('2014-03'),
-            pattern=[
-                r'.*?FakeServerGroup/tracking.log-(?P<date>\d{8}).*\.gz',
-                r'.*?FakeEdgeServerGroup/tracking.log-(?P<date>\d{8}).*\.gz',
-            ],
-            expand_interval=datetime.timedelta(0),
-        )
-
-        self.assert_only_matched(task, [
-            'FakeServerGroup/tracking.log-20140318.gz',
-            'FakeServerGroup/tracking.log-20140319-1395256622.gz',
-            'FakeEdgeServerGroup/tracking.log-20140324-1395670621.gz',
-        ])
-
     def assert_only_matched(self, task, paths):
         """Assert that the task only includes the given paths in the selected set of files."""
         matched_urls = []

--- a/edx/analytics/tasks/tests/test_user_location.py
+++ b/edx/analytics/tasks/tests/test_user_location.py
@@ -78,7 +78,7 @@ class LastCountryForEachUserMapperTestCase(BaseUserLocationEventTestCase):
         self.task = LastCountryForEachUser(
             mapreduce_engine='local',
             name='test',
-            src='test://input/',
+            src=['test://input/'],
             dest='test://output/',
             end_date=datetime.datetime.strptime('2014-04-01', '%Y-%m-%d').date(),
             geolocation_data='test://data/data.file',
@@ -135,7 +135,7 @@ class LastCountryForEachUserReducerTestCase(unittest.TestCase):
         self.task = LastCountryForEachUser(
             mapreduce_engine='local',
             name='test',
-            src='test://input/',
+            src=['test://input/'],
             dest='test://output/',
             end_date=datetime.datetime.strptime('2014-04-01', '%Y-%m-%d').date(),
             geolocation_data='test://data/data.file',
@@ -219,7 +219,7 @@ class UsersPerCountryTestCase(unittest.TestCase):
         self.task = UsersPerCountry(
             mapreduce_engine='local',
             name='test',
-            src='test://input/',
+            src=['test://input/'],
             dest='test://output/',
             end_date=self.end_date,
             geolocation_data='test://data/data.file',
@@ -325,7 +325,7 @@ class UsersPerCountryReportWorkflowTestCase(BaseUserLocationEventTestCase):
         task = UsersPerCountryReportWorkflow(
             mapreduce_engine='local',
             name='test',
-            src=src_path,
+            src=[src_path],
             end_date=datetime.datetime.strptime(end_date, '%Y-%m-%d').date(),
             geolocation_data=data_filepath,
             counts=counts_path,

--- a/edx/analytics/tasks/user_location.py
+++ b/edx/analytics/tasks/user_location.py
@@ -46,7 +46,7 @@ class BaseUserLocationTask(GeolocationMixin):
 
     """
     name = luigi.Parameter()
-    src = luigi.Parameter()
+    src = luigi.Parameter(is_list=True)
     dest = luigi.Parameter()
     include = luigi.Parameter(is_list=True, default=('*',))
 
@@ -351,7 +351,7 @@ class UsersPerCountryReportWorkflow(MapReduceJobTaskMixin, UsersPerCountryReport
     """
 
     name = luigi.Parameter()
-    src = luigi.Parameter()
+    src = luigi.Parameter(is_list=True)
     include = luigi.Parameter(is_list=True, default=('*',))
     manifest = luigi.Parameter(default=None)
     base_input_format = luigi.Parameter(default=None)

--- a/edx/analytics/tasks/util/datetime_util.py
+++ b/edx/analytics/tasks/util/datetime_util.py
@@ -1,8 +1,6 @@
 """Utility functions for manipulating datetime information."""
 import datetime
-import logging
-
-log = logging.getLogger(__name__)
+import re
 
 
 def add_microseconds(timestamp, microseconds):
@@ -26,5 +24,22 @@ def add_microseconds(timestamp, microseconds):
     newtimestamp = (parsed_timestamp + datetime.timedelta(microseconds=microseconds)).isoformat()
     if '.' not in newtimestamp:
         newtimestamp = '{datetime}.000000'.format(datetime=newtimestamp)
-    log.debug("Adding %d microseconds to timestamp %s yields %s", microseconds, timestamp, newtimestamp)
+
     return newtimestamp
+
+
+def mysql_datetime_to_isoformat(mysql_datetime):
+    """
+    Convert mysql datetime strings to isoformat standard.
+
+    Mysql outputs strings of the form '2012-07-25 12:26:22.0'.
+    Log files use isoformat strings for sorting.
+    """
+    date_parts = [int(d) for d in re.split(r'[:\-\. ]', mysql_datetime)]
+    if len(date_parts) > 6:
+        tenths = date_parts[6]
+        date_parts[6] = tenths * 100000
+    timestamp = datetime.datetime(*date_parts).isoformat()
+    if '.' not in timestamp:
+        timestamp = '{datetime}.000000'.format(datetime=timestamp)
+    return timestamp

--- a/edx/analytics/tasks/util/datetime_util.py
+++ b/edx/analytics/tasks/util/datetime_util.py
@@ -1,0 +1,31 @@
+"""Utility functions for manipulating datetime information."""
+import datetime
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def add_microseconds(timestamp, microseconds):
+    """
+    Add given microseconds to a timestamp.
+    
+    Input and output are timestamps as ISO format strings.  Microseconds can be negative.
+    """
+    # First try to parse the timestamp string and do simple math, to avoid
+    # the high cost of using strptime to parse in most cases.
+    timestamp_base, _period, microsec_base = timestamp.partition('.')
+    if not microsec_base:
+        microsec_base = '0'
+        timestamp = '{datetime}.000000'.format(datetime=timestamp)
+    microsec_int = int(microsec_base) + microseconds
+    if microsec_int >= 0 and microsec_int < 1000000:
+        return "{}.{}".format(timestamp_base, str(microsec_int).zfill(6))
+
+    # If there's a carry, then just use the datetime library.
+    parsed_timestamp = datetime.datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S.%f')
+    newtimestamp = (parsed_timestamp + datetime.timedelta(microseconds=microseconds)).isoformat()
+    if '.' not in newtimestamp:
+        newtimestamp = '{datetime}.000000'.format(datetime=newtimestamp)
+    log.debug("Adding %d microseconds to timestamp %s yields %s", microseconds, timestamp, newtimestamp)
+    return newtimestamp
+

--- a/edx/analytics/tasks/util/datetime_util.py
+++ b/edx/analytics/tasks/util/datetime_util.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 def add_microseconds(timestamp, microseconds):
     """
     Add given microseconds to a timestamp.
-    
+
     Input and output are timestamps as ISO format strings.  Microseconds can be negative.
     """
     # First try to parse the timestamp string and do simple math, to avoid
@@ -28,4 +28,3 @@ def add_microseconds(timestamp, microseconds):
         newtimestamp = '{datetime}.000000'.format(datetime=newtimestamp)
     log.debug("Adding %d microseconds to timestamp %s yields %s", microseconds, timestamp, newtimestamp)
     return newtimestamp
-

--- a/edx/analytics/tasks/util/event_factory.py
+++ b/edx/analytics/tasks/util/event_factory.py
@@ -1,5 +1,6 @@
 """Define factory class for creating synthetic events."""
 import datetime
+import json
 
 
 class SyntheticEventFactory(object):
@@ -13,11 +14,11 @@ class SyntheticEventFactory(object):
         self.user_id = kwargs.get('user_id', '')
         # define default values for event:
         self.username = kwargs.get('username', '')
-        self.hostname = kwargs.get('host', 'test_host')
+        self.hostname = kwargs.get('host', '')
         self.event_source = kwargs.get('event_source', 'server')
         self.event_type = kwargs.get('event_type', 'UNKNOWN')
         self.timestamp = kwargs.get('timestamp', '2012-01-01T00:00.000')
-        self.ip_address = kwargs.get('ip', '127.0.0.1')
+        self.ip_address = kwargs.get('ip', '')
         self.synthesizer = kwargs.get('synthesizer', 'UNKNOWN')
         self.reason = kwargs.get('reason', '')
 
@@ -49,7 +50,7 @@ class SyntheticEventFactory(object):
         return synthesized
 
     def create_event_dict(self, event_data_dict, **kwargs):
-        """Create an event log with test values, as a dict."""
+        """Create a synthetic event as a dict."""
         # Define default values for event log entry.
         event_dict = {
             "username": self.username,
@@ -60,7 +61,7 @@ class SyntheticEventFactory(object):
             "time": "{0}+00:00".format(self.timestamp),
             "ip": self.ip_address,
             "event": event_data_dict,
-            "agent": "blah, blah, blah",
+            "agent": "",
             "page": None,
             "synthesized": self._create_event_synthesized(**kwargs),
         }
@@ -68,4 +69,5 @@ class SyntheticEventFactory(object):
         return event_dict
 
     def create_event(self, event_data_dict, **kwargs):
-        return self.create_event_dict(event_data_dict, **kwargs)
+        """Create a synthetic event as a json-encoded dict."""
+        return json.dumps(self.create_event_dict(event_data_dict, **kwargs))

--- a/edx/analytics/tasks/util/event_factory.py
+++ b/edx/analytics/tasks/util/event_factory.py
@@ -1,0 +1,71 @@
+"""Define factory class for creating synthetic events."""
+import datetime
+
+
+class SyntheticEventFactory(object):
+    """Creates events from non-event data."""
+
+    def __init__(self, *args, **kwargs):
+        super(SyntheticEventFactory, self).__init__()
+        # define default values for context:
+        self.course_id = kwargs.get('course_id', '')
+        self.org_id = kwargs.get('org_id', '')
+        self.user_id = kwargs.get('user_id', '')
+        # define default values for event:
+        self.username = kwargs.get('username', '')
+        self.hostname = kwargs.get('host', 'test_host')
+        self.event_source = kwargs.get('event_source', 'server')
+        self.event_type = kwargs.get('event_type', 'UNKNOWN')
+        self.timestamp = kwargs.get('timestamp', '2012-01-01T00:00.000')
+        self.ip_address = kwargs.get('ip', '127.0.0.1')
+        self.synthesizer = kwargs.get('synthesizer', 'UNKNOWN')
+        self.reason = kwargs.get('reason', '')
+
+    @staticmethod
+    def _update_with_kwargs(data_dict, **kwargs):
+        """Updates a dict from kwargs only if it modifies a top-level value."""
+        for key, value in kwargs.iteritems():
+            if key in data_dict:
+                data_dict[key] = value
+
+    def _create_event_context(self, **kwargs):
+        """Returns context dict with test values."""
+        context = {
+            "course_id": self.course_id,
+            "org_id": self.org_id,
+            "user_id": self.user_id,
+        }
+        self._update_with_kwargs(context, **kwargs)
+        return context
+
+    def _create_event_synthesized(self, **kwargs):
+        """Returns synthesized dict with test values."""
+        synthesized = {
+            "created_at": datetime.datetime.utcnow().isoformat(),
+            "synthesizer": self.synthesizer,
+            "reason": self.reason,
+        }
+        self._update_with_kwargs(synthesized, **kwargs)
+        return synthesized
+
+    def create_event_dict(self, event_data_dict, **kwargs):
+        """Create an event log with test values, as a dict."""
+        # Define default values for event log entry.
+        event_dict = {
+            "username": self.username,
+            "host": self.hostname,
+            "event_source": self.event_source,
+            "event_type": self.event_type,
+            "context": self._create_event_context(**kwargs),
+            "time": "{0}+00:00".format(self.timestamp),
+            "ip": self.ip_address,
+            "event": event_data_dict,
+            "agent": "blah, blah, blah",
+            "page": None,
+            "synthesized": self._create_event_synthesized(**kwargs),
+        }
+        self._update_with_kwargs(event_dict, **kwargs)
+        return event_dict
+
+    def create_event(self, event_data_dict, **kwargs):
+        return self.create_event_dict(event_data_dict, **kwargs)

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ edx.analytics.tasks =
     course-facts-to-mysql = edx.analytics.tasks.daily_enrollment_trends:ImportCourseDailyFactsIntoMysql
     grade-dist = edx.analytics.tasks.studentmodule_dist:GradeDistFromSqoopToMySQLWorkflow
     enrollments = edx.analytics.tasks.enrollments:ImportDemographicsIntoMysql
+    enrollment_validation = edx.analytics.tasks.enrollment_validation:CourseEnrollmentValidationTask
 
 mapreduce.engine =
     hadoop = edx.analytics.tasks.mapreduce:MapReduceJobRunner


### PR DESCRIPTION
Includes:
- Synthesize validation events from Sqoop dumps of student_courseenrollment.
- Compare validation events with enroll/unenroll events.   Includes unit tests.
  Supports additional flags for:
  - Outputting tuples (for debugging) or synthetic events (for production)
  - Ignoring any events before the first validation event (for each user/course pair).  

The latter permits checking for errors in an incremental manner, by using an interval to specify a tighter period of time (e.g. a day or a few days) which includes a set of enrollment validation events.   The run can then test the consistency of events since the enrollment validation, up to the end of the interval (which selects all events included).  This could be set up to run on a daily basis, to help flag inconsistencies more quickly as well as to generate new synthetic events in an incremental manner.
