### PR TITLE
Use an ansible version that is on PyPi

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,7 +1,7 @@
 Jinja2==2.7.3		# BSD License
 MarkupSafe==0.23	# BSD
 PyYAML==3.10		# MIT License
-ansible==1.4.4		# GPL v3 License
+ansible==1.4.5		# GPL v3 License
 argparse==1.2.1 	# Python Software Foundation License
 boto==2.22.1 		# MIT
 ecdsa==0.11 		# MIT


### PR DESCRIPTION
For some reason 1.4.4 cannot be found. Not sure if it got pulled down or what.

Coincidentally a new version of the wheel was uploaded to S3. Ansible cannot be installed correctly from wheels, so any new virtualenvs built after the wheel was uploaded will break with the error "ERROR: file is not a legal parameter in an Ansible task or handler".

@brianhw 
