### PR TITLE
Incorrect variant for answer distribution bug fix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ Gabe Mulley <gabe@edx.org>
 Jason Bau <jbau@stanford.edu>
 Justin Helbert <jhelbert@edx.org>
 Will Daly <will@edx.org>
+Dylan Rhodes <dylanr@stanford.edu>

--- a/edx/analytics/tasks/answer_dist.py
+++ b/edx/analytics/tasks/answer_dist.py
@@ -279,9 +279,7 @@ class AnswerDistributionPerCourseMixin(object):
         # Now construct answer distribution for this input.
         problem_id = most_recent_answer.get('problem_id')
         problem_display_name = most_recent_answer.get('problem_display_name')
-        most_recent_question = most_recent_answer.get('question', '')
         answer_uses_value_id = ('answer_value_id' in most_recent_answer)
-        answer_uses_variant = (most_recent_answer.get('variant', '') != '')
         answer_dist = {}
         for _timestamp, value_string in reversed(values):
             answer = json.loads(value_string)
@@ -325,19 +323,12 @@ class AnswerDistributionPerCourseMixin(object):
                 answer_value_contains_html = (value_id is not None and value_id != '')
                 answer_value = self.stringify(answer_value, contains_html=answer_value_contains_html)
 
-                # If there is a variant, then the question might not be
-                # the same for all variants presented to students.  So
-                # we take the value (if any) provided in this variant.
-                # If there is no variant, then the question should be
-                # the same, and we want to go with the most recently
-                # defined value.
-                if answer_uses_variant:
-                    question = answer.get('question', '')
-                    variant = answer.get('variant') or ''
-                else:
-                    question = most_recent_question
-                    variant = ''
-
+                # Even if the most recent answer does not have a variant,
+                # the question could have been randomized earlier and then
+                # switched, so the variant must be checked for all answers.
+                question = answer.get('question', '')
+                variant = answer.get('variant') or ''
+                
                 # Key values here should match those used in get_column_order().
                 answer_dist[answer_grouping_key] = {
                     'ModuleID': problem_id,

--- a/edx/analytics/tasks/tests/test_answer_dist.py
+++ b/edx/analytics/tasks/tests/test_answer_dist.py
@@ -667,20 +667,24 @@ class AnswerDistributionPerCourseReduceTest(InitializeOpaqueKeysMixin, unittest.
         input_data_1 = (self.earlier_timestamp, json.dumps(answer_data_1))
         input_data_2 = (self.timestamp, json.dumps(answer_data_2))
         expected_output_2 = self._get_expected_output(answer_data_2)
-        # An older non-submission-based event should inherit some
+        # An older non-submission-based event should not inherit
         # information from a newer submission-based event.
-        # In particular, the Variant, the Question, and Problem Display Name.
-        expected_output_1 = self._get_expected_output(
-            answer_data_1,
-            Variant="",
-            Question=expected_output_2['Question'],
-        )
+        expected_output_1 = self._get_expected_output(answer_data_1)
         expected_output_1['Problem Display Name'] = expected_output_2['Problem Display Name']
         self._check_output([input_data_1, input_data_2], (expected_output_1, expected_output_2))
 
     def test_two_answer_event_different_variant(self):
         answer_data_1 = self._get_answer_data(variant=123)
         answer_data_2 = self._get_answer_data(variant=456)
+        input_data_1 = (self.earlier_timestamp, json.dumps(answer_data_1))
+        input_data_2 = (self.timestamp, json.dumps(answer_data_2))
+        expected_output_1 = self._get_expected_output(answer_data_1)
+        expected_output_2 = self._get_expected_output(answer_data_2)
+        self._check_output([input_data_1, input_data_2], (expected_output_1, expected_output_2))
+
+    def test_two_answer_event_different_variant_empty_new(self):
+        answer_data_1 = self._get_answer_data(variant=123)
+        answer_data_2 = self._get_answer_data(variant='')
         input_data_1 = (self.earlier_timestamp, json.dumps(answer_data_1))
         input_data_2 = (self.timestamp, json.dumps(answer_data_2))
         expected_output_1 = self._get_expected_output(answer_data_1)


### PR DESCRIPTION
This request fixes an issue we have noticed in which an answer's variant is not correctly reflected in the pipeline.  The cause of the bug is a conditional which assumes that an answer's variant cannot be changed over the duration of a course and therefore relies on the variant value for the most recent answer to fill in those of the rest.  This bug has been causing issues with inline analytics display (referenced <a href="https://github.com/Stanford-Online/edx-platform/pull/165">here</a>) specifically when questions which had had randomization enabled in the past and then disabled displayed incorrectly, as the older answers to the randomized version were reported to be non-randomized by the pipeline.

The changes include a small removal in the answer_dist task and alteration of a related test case.  There was a comment in the test case regarding the behavior which I have altered, so please let me know if the prior behavior was actually desired anywhere.  As always, feedback is encouraged.  @jbau @dcadams @mulby @sarina 
