### PR TITLE
Ensure export reports progress

### DIFF
--- a/client.cfg
+++ b/client.cfg
@@ -21,6 +21,7 @@ hdfs-tmp-dir=/tmp/luigi/partial
 
 [map-reduce]
 engine = hadoop
+remote_log_level = INFO
 
 [event-logs]
 expand_interval = 2 days

--- a/config/test.cfg
+++ b/config/test.cfg
@@ -17,6 +17,7 @@ destination = s3://fake/warehouse/
 [map-reduce]
 engine = hadoop
 marker = s3://fake/marker/
+remote_log_level = DEBUG
 
 [event-logs]
 pattern = .*tracking.log-(?P<date>\d{8}).*\.gz


### PR DESCRIPTION
If a hadoop task does not either write output or reports status for 10 minutes it is killed. Make sure we check back in periodically with hadoop to ensure it doesn't kill our export processes.

@brianhw @rocha
