### PR TITLE
Support log analysis for performance benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ override.cfg
 
 
 .DS_Store
+
+*.trace

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ coverage-local: test-local
 
 	# Compute style violations
 	pep8 edx > pep8.report || echo "Not pep8 clean"
-	pylint -f parseable edx > pylint.report || echo "Not pylint clean"
+	pylint -f parseable -s y edx > pylint.report || echo "Not pylint clean"
 
 coverage: test coverage-local
 

--- a/edx/analytics/tasks/launchers/analyze/main.py
+++ b/edx/analytics/tasks/launchers/analyze/main.py
@@ -1,0 +1,258 @@
+"""Analyze log files produced by launch-task"""
+
+import argparse
+from collections import namedtuple
+import datetime
+import re
+import sys
+
+from edx.analytics.tasks.launchers.analyze.parser import LogFileParser
+from edx.analytics.tasks.launchers.analyze.measure import Measurement
+from edx.analytics.tasks.launchers.analyze.report import text_report, json_report, html_report
+
+
+MESSAGE_START_PATTERN = r'(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}) (?P<level>\w+) (?P<pid>\d+) \[(?P<module>.*?)\] (?P<filename>.*?):(?P<line_no>\d+) - (?P<content>.*)'
+LogMessage = namedtuple('LogMessage', 'timestamp level pid module filename line_no content')  # pylint: disable=invalid-name
+
+
+def analyze():
+    arg_parser = argparse.ArgumentParser(description='Analyze log files.')
+    arg_parser.add_argument(
+        '-o', '--output',
+        help='Save the results of the analysis to a file that can be read later.'
+    )
+    arg_parser.add_argument(
+        '-r', '--report',
+        choices=['text', 'json', 'html'],
+        help='Generate a report in the requested format and stream it to stdout.'
+    )
+    arg_parser.add_argument(
+        '--threshold-percent',
+        type=float,
+        default=None,
+        help="Don't include entries that accounted for less than this amount of time relative to the total execution"
+             " time in the report."
+    )
+    group = arg_parser.add_argument_group('Input File')
+    group_ex = group.add_mutually_exclusive_group()
+    group_ex.add_argument(
+        '-l', '--log',
+        default='edx_analytics.log',
+        help='A log file to analyze. Defaults to "edx_analytics.log" in the current directory.'
+    )
+    group_ex.add_argument(
+        '-i', '--input',
+        help='Reads a previously saved result file.'
+    )
+    group_ex.add_argument(
+        '-t', '--trace',
+        help='Path to an execution trace of the launch-task process captured by pyinstrument and saved as JSON.'
+    )
+
+    args = arg_parser.parse_args()
+
+    if args.input:
+        root = Measurement.from_json(args.input)
+    elif args.trace:
+        root = Measurement.from_pyinstrument_trace(args.trace)
+    else:
+        root = analyze_log_file(args.log)
+
+    if args.output:
+        json_report(root, args.output, pretty=False, threshold_percent=args.threshold_percent)
+
+    if args.report == 'json':
+        json_report(root, threshold_percent=args.threshold_percent)
+    elif args.report == 'text':
+        text_report(root, threshold_percent=args.threshold_percent)
+    elif args.report == 'html':
+        html_report(root, threshold_percent=args.threshold_percent)
+
+
+def analyze_log_file(filename):
+    with open(filename, 'rb') as log_file:
+        parser = LogFileParser(log_file, message_pattern=MESSAGE_START_PATTERN, message_factory=create_log_message)
+        try:
+            return analyze_log(parser)
+        except:
+            sys.stderr.write('Exception on line {0}\n'.format(parser.line_number))
+            raise
+
+
+def create_log_message(matched_groups):
+    timestamp_str = matched_groups['timestamp']
+    matched_groups['timestamp'] = datetime.datetime.strptime(timestamp_str, '%Y-%m-%d %H:%M:%S,%f')
+    for field_name in ('pid', 'line_no'):
+        matched_groups[field_name] = int(matched_groups[field_name])
+
+    return LogMessage(**matched_groups)
+
+
+def analyze_log(parser):
+    root = Measurement('Luigi Worker')
+    scheduling_time = analyze_overall_scheduling(parser)
+    root.add_child(scheduling_time)
+    execution_time = analyze_overall_execution(parser)
+    root.add_child(execution_time)
+    return root
+
+
+def analyze_overall_scheduling(parser):
+    all_scheduling = Measurement('Scheduling Tasks')
+
+    start_scheduling_pattern = r'Checking if (?P<task_id>.*?) is complete'
+    message = True
+    start_scheduling_timestamp = None
+
+    while message:
+        message = parser.next_message()
+
+        if message.content == 'Done scheduling tasks':
+            all_scheduling.set_time_from_range(message.timestamp, start_scheduling_timestamp)
+            return all_scheduling
+
+        start_match = re.match(start_scheduling_pattern, message.content, (re.MULTILINE | re.DOTALL))
+        if start_match:
+            if start_scheduling_timestamp is None:
+                start_scheduling_timestamp = message.timestamp
+
+            measurement = analyze_task_scheduling(message, start_match, parser)
+            if measurement:
+                all_scheduling.add_child(measurement)
+
+
+def analyze_task_scheduling(start_message, start_match, parser):
+    scheduled_pattern = r'Scheduled (?P<task_id>.*?) \((?P<status>\w+)\)'
+
+    task = LuigiTaskDescription.from_string(start_match.group('task_id'))
+    start_timestamp = start_message.timestamp
+    message = start_message
+    while message:
+        message = parser.peek_message()
+
+        if message.content == 'Done scheduling tasks':
+            break
+
+        if re.match(scheduled_pattern, message.content, (re.MULTILINE | re.DOTALL)):
+            break
+
+        parser.next_message()
+
+    if not task.name == 'UncheckedExternalURL':
+        return Measurement('Scheduling {}'.format(task), message.timestamp - start_timestamp)
+    else:
+        return None
+
+
+def analyze_overall_execution(parser):
+    all_execution = Measurement('Executing Tasks')
+
+    pattern = r'.*? Worker Worker.* (?P<state>running|done|failed)\s+(?P<task_id>.*)'
+    message = True
+    overall_start_timestamp = None
+    running_measurement = None
+
+    while message:
+        message = parser.next_message()
+
+        if message.content == 'Done':
+            if overall_start_timestamp:
+                all_execution.set_time_from_range(message.timestamp, overall_start_timestamp)
+            return all_execution
+
+        match = re.match(pattern, message.content, (re.MULTILINE | re.DOTALL))
+        if not match:
+            if 'Running job:' in message.content or 'Starting Job =' in message.content:
+                for measurement in analyze_hadoop_job(message, parser):
+                    running_measurement.add_child(measurement)
+
+            continue
+
+        task = LuigiTaskDescription.from_string(match.group('task_id'))
+        state = match.group('state')
+        if state == 'running':
+            start_timestamp = message.timestamp
+            running_measurement = Measurement('Executing {}'.format(task))
+            if not overall_start_timestamp:
+                overall_start_timestamp = start_timestamp
+        else:
+            running_measurement.set_time_from_range(message.timestamp, start_timestamp)
+            all_execution.add_child(running_measurement)
+
+
+def analyze_hadoop_job(starting_message, parser):
+    match = re.match(r'.*?(?P<job_id>job_\d{12}_\d{4})', starting_message.content)
+    job_id = match.group('job_id')
+    start_timestamp = starting_message.timestamp
+
+    message = starting_message
+    while message:
+        message = parser.next_message()
+
+        if 'Job complete:' in message.content or 'Ended Job = ' in message.content:
+            if 'Job complete:' in message.content:
+                move_measure = analyze_output_move(parser)
+                if move_measure:
+                    yield move_measure
+
+            yield Measurement('Hadoop ' + job_id, message.timestamp - start_timestamp)
+            return
+
+
+def analyze_output_move(parser):
+    output_message = parser.peek_message()
+    if re.match(r'.*?Output:.*-temp-', output_message.content):
+        start_timestamp = output_message.timestamp
+        parser.next_message()
+        next_message = parser.peek_message()
+        return Measurement('Moving Job Output', next_message.timestamp - start_timestamp)
+
+
+class LuigiTaskDescription(object):
+
+    PATTERN = r'(?P<name>\w+)\((?P<params>.*)\)'
+
+    def __init__(self, name, params=None):
+        self.name = name
+        self.params = params or {}
+
+    def __str__(self):
+        param_string = ', '.join(['='.join((k, str(v)[:100])) for k, v in self.params.iteritems()])
+        return '{name}{params}'.format(
+            name=self.name,
+            params='(' + param_string + ')' if len(self.params) > 0 else ''
+        )
+
+    @staticmethod
+    def from_string(id_str):
+        match = re.match(LuigiTaskDescription.PATTERN, id_str, (re.MULTILINE | re.DOTALL))
+        if match:
+            task_name = match.group('name')
+            raw_params = match.group('params')
+            param_parser = default_parameter_parser
+            if task_name == 'HiveTableFromQueryTask':
+                param_parser = hive_parameter_parser
+            if task_name == 'SqoopImportFromMysql':
+                param_parser = sqoop_parameter_parser
+            return LuigiTaskDescription(task_name, param_parser(raw_params))
+        else:
+            raise ValueError('Unable to parse task id "%s"', id_str)
+
+
+def default_parameter_parser(_raw_params):
+    return {}
+
+
+def hive_parameter_parser(raw_params):
+    table_param_match = re.search(r'table=(?P<name>[\w_]+)', raw_params)
+    if table_param_match:
+        return {'table': table_param_match.group('name')}
+
+
+def sqoop_parameter_parser(raw_params):
+    table_param_match = re.search(r'table_name=(?P<name>[\w_]+)', raw_params)
+    if table_param_match:
+        return {'table': table_param_match.group('name')}
+
+if __name__ == '__main__':
+    analyze()

--- a/edx/analytics/tasks/launchers/analyze/measure.py
+++ b/edx/analytics/tasks/launchers/analyze/measure.py
@@ -1,0 +1,159 @@
+
+import datetime
+import json
+from operator import methodcaller
+
+
+class Measurement(object):
+    """
+    Represents a node in a tree of measurements.
+
+    Note that a particular measurement may be the parent for several child measurements. Those child measurements
+    further break down the time spent in the parent. The time spent in the parent itself is referred to as "self_time".
+    The overall time spent in that activity is (self_time + time spent in all children).
+
+    Timing of multiple parallel processes is not captured here (yet). Although it could be extended to represent those
+    types of measurements as well.
+    """
+
+    SERIALIZATION_VERSION = 1
+    UNACCOUNTED_FOR_TIME_DESC = 'Other'
+
+    def __init__(self, description, self_time=None, parent=None):
+        self.description = description
+        self.self_time = self_time or datetime.timedelta()
+        self.children = []
+        self.parent = parent
+        self.enable_cache = False
+
+    def add_child(self, child):
+        child.parent = self
+        self.children.append(child)
+
+    def set_time_from_range(self, end_time, start_time):
+        time_including_children = end_time - start_time
+        unaccounted_for_time = time_including_children - self.time_from_children()
+        if len(self.children) > 0:
+            unaccounted_for_child = Measurement(self.UNACCOUNTED_FOR_TIME_DESC, self_time=unaccounted_for_time)
+            self.add_child(unaccounted_for_child)
+        else:
+            self.self_time = unaccounted_for_time
+
+    def time_including_children(self):
+        return self.self_time + self.time_from_children()
+
+    def time_from_children(self):
+        total = datetime.timedelta()
+        for child in self.children:
+            total += child.time_including_children()
+        return total
+
+    def total_time_of_root(self):
+        cur = self
+        while cur.parent is not None:
+            cur = cur.parent
+
+        return cur.time_including_children()
+
+    def percentage_of_total(self):
+        return (self.time_including_children().total_seconds() / self.total_time_of_root().total_seconds()) * 100
+
+    def categorize(self):
+        percentage = self.percentage_of_total()
+        if percentage > 50:
+            return 'large'
+        elif percentage > 10:
+            return 'medium'
+        elif percentage > 5:
+            return 'small'
+        else:
+            return 'tiny'
+
+    def sorted_children(self):
+        return sorted(self.children, key=methodcaller('time_including_children'), reverse=True)
+
+    def sorted_filtered_children(self, threshold_percent=None):
+        if threshold_percent is None:
+            return self.sorted_children()
+        else:
+            return [c for c in self.sorted_children() if c.percentage_of_total() > threshold_percent]
+
+    def serializable(self, threshold_percent=None):
+        serialized = {
+            'version': self.SERIALIZATION_VERSION,
+            'description': self.description,
+            'self_time': self.self_time.total_seconds(),
+        }
+        filtered_children = self.sorted_filtered_children(threshold_percent=threshold_percent)
+        if len(filtered_children) > 0:
+            serialized['children'] = [c.serializable() for c in filtered_children]
+
+        return serialized
+
+    @staticmethod
+    def from_serialized(serialized):
+        root = Measurement(
+            description=serialized['description'],
+            self_time=datetime.timedelta(seconds=serialized['self_time'])
+        )
+        for child_ser in serialized.get('children', []):
+            root.add_child(Measurement.from_serialized(child_ser))
+
+        return root
+
+    def to_json(self, file_ref, pretty=False, threshold_percent=None):
+        serialized = self.serializable(threshold_percent=threshold_percent)
+        if pretty:
+            kwargs = {
+                'indent': 4,
+                'separators': (',', ': ')
+            }
+        else:
+            kwargs = {}
+        if hasattr(file_ref, 'write'):
+            json.dump(serialized, file_ref, **kwargs)
+        else:
+            with open(file_ref, 'w') as output_file:
+                json.dump(serialized, output_file, **kwargs)
+
+    @staticmethod
+    def from_json(file_ref):
+        if hasattr(file_ref, 'write'):
+            serialized = json.load(file_ref)
+        else:
+            with open(file_ref, 'rb') as input_file:
+                serialized = json.load(input_file)
+
+        return Measurement.from_serialized(serialized)
+
+    @staticmethod
+    def from_pyinstrument_trace(file_ref):
+        import pyinstrument
+        profiler = pyinstrument.Profiler()
+        profiler.add(file_ref)
+
+        root_frame = profiler.root_frame()
+
+        def visit_frame(frame):
+            code_pos = frame.code_position_short
+            if code_pos is None:
+                code_pos = ''
+
+            index = code_pos.find('site-packages')
+            if index > 0:
+                code_pos = code_pos[index + (len('site-packages') + 1):]
+
+            measurement = Measurement(
+                '{function} {code_pos}'.format(
+                    function=frame.function or '',
+                    code_pos=code_pos
+                ),
+                self_time=datetime.timedelta(seconds=frame.self_time)
+            )
+
+            for child_frame in frame.children:
+                measurement.add_child(visit_frame(child_frame))
+
+            return measurement
+
+        return visit_frame(root_frame)

--- a/edx/analytics/tasks/launchers/analyze/parser.py
+++ b/edx/analytics/tasks/launchers/analyze/parser.py
@@ -1,0 +1,66 @@
+
+import re
+
+
+class LogFileParser(object):
+
+    def __init__(self, log_file_obj, message_pattern, message_factory=dict, content_group_name='content'):
+        self.log_file = log_file_obj
+        self.message_pattern = message_pattern
+        self.message_factory = message_factory
+        self.content_group_name = content_group_name
+        self.line_number = 0
+        self.messages = self.parse_messages()
+
+    def parse_messages(self):
+        message = self.read_line()
+        while message:
+            message_match = re.match(self.message_pattern, message)
+            if not message_match:
+                raise ValueError('Unable to parse message "%s"', message)
+
+            matched_groups = dict(message_match.groupdict())
+            first_line_content = matched_groups.get(self.content_group_name, '')
+            matched_groups[self.content_group_name] = self.read_content(first_line_content)
+
+            yield self.message_factory(matched_groups)
+
+            message = self.read_line()
+
+    def read_content(self, first_line_content):
+        content = first_line_content
+        next_message_match = None
+        while not next_message_match:
+            next_line = self.peek_line()
+            if not next_line:
+                break
+            next_message_match = re.match(self.message_pattern, next_line)
+            if not next_message_match:
+                self.read_line()
+                content += next_line
+
+        return content
+
+    def peek_line(self):
+        pos = self.log_file.tell()
+        line = self.log_file.readline()
+        self.log_file.seek(pos)
+        return line
+
+    def read_line(self):
+        line = self.log_file.readline()
+        if line:
+            self.line_number += 1
+        return line
+
+    def next_message(self):
+        try:
+            return next(self.messages)
+        except StopIteration:
+            return None
+
+    def peek_message(self):
+        pos = self.log_file.tell()
+        message = self.next_message()
+        self.log_file.seek(pos)
+        return message

--- a/edx/analytics/tasks/launchers/analyze/report.py
+++ b/edx/analytics/tasks/launchers/analyze/report.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+import json
+import os
+import subprocess
+import sys
+from string import Template  # pylint: disable=deprecated-module
+import uuid
+
+
+STATIC_FILES_PATH = os.path.join(sys.prefix, 'share', 'edx.analytics.tasks')
+
+
+def text_report(measurement, file_obj=None, indent=u'', child_indent=u'', threshold_percent=None):
+    file_obj = file_obj or sys.stdout
+    is_a_tty = hasattr(file_obj, 'isatty') and file_obj.isatty()
+    total_time = measurement.time_including_children()
+    file_obj.write(
+        u'{indent}{time} {percentage:.1f}% {desc}\n'.format(
+            indent=indent,
+            time=total_time,
+            percentage=measurement.percentage_of_total(),
+            desc=measurement.description
+        )
+    )
+    visible_children = measurement.sorted_filtered_children(threshold_percent=threshold_percent)
+    last_child_index = len(visible_children) - 1
+    for index, child in enumerate(visible_children):
+        if index < last_child_index:
+            c_indent = child_indent + (u'├─ ' if is_a_tty else '|- ')
+            cc_indent = child_indent + (u'│  ' if is_a_tty else '|  ')
+        else:
+            c_indent = child_indent + (u'└─ ' if is_a_tty else '`- ')
+            cc_indent = child_indent + u'   '
+        text_report(
+            child, file_obj=file_obj, indent=c_indent, child_indent=cc_indent, threshold_percent=threshold_percent)
+
+
+def json_report(measurement, file_obj=None, pretty=True, threshold_percent=None):
+    file_obj = file_obj or sys.stdout
+    measurement.to_json(file_obj, pretty=pretty, threshold_percent=threshold_percent)
+
+
+def html_report(measurement, file_obj=None, threshold_percent=None):
+    file_obj = file_obj or sys.stdout
+    path_to_template = os.path.join(STATIC_FILES_PATH, 'report.html')
+    with open(path_to_template, 'r') as template_file:
+        template = Template(template_file.read())
+
+    def visit_measurement(node):
+        data = node.serializable()
+        serialized = {
+            'name': data['description'],
+            'value': data['self_time'],
+            'percentage': node.percentage_of_total(),
+            'time_delta': str(node.time_including_children()),
+            'bucket': node.categorize(),
+        }
+        if len(node.children) > 0:
+            serialized['children'] = []
+            for child in node.sorted_filtered_children(threshold_percent=threshold_percent):
+                serialized['children'].append(visit_measurement(child))
+
+        return serialized
+
+    treemap_data = json.dumps(visit_measurement(measurement))
+    file_obj.write(
+        template.safe_substitute(
+            data=treemap_data,
+            call_graph_svg=get_call_graph_svg(measurement, threshold_percent)
+        )
+    )
+
+
+def get_call_graph_svg(measurement, threshold_percent=None):
+
+    def generate_dot_entries(node, node_id=None):
+        node_id = node_id or generate_node_id()
+        dot = []
+        bucket = node.categorize()
+        if bucket == 'large':
+            bg_color = '#ff000026'
+        elif bucket == 'medium':
+            bg_color = '#ffff0026'
+        elif bucket == 'small':
+            bg_color = '#00ff0013'
+        else:
+            bg_color = '#ffffffff'
+
+        text = '{percentage:.1f}%\n{desc}'.format(percentage=node.percentage_of_total(), desc=node.description)
+        dot.append(
+            '{id} [label="{desc}" fillcolor="{color}" style="filled"];'.format(
+                id=node_id,
+                desc=text,
+                color=bg_color
+            )
+        )
+
+        for child in node.sorted_filtered_children(threshold_percent=threshold_percent):
+            child_id = generate_node_id()
+            dot.append('{parent} -> {child};'.format(parent=node_id, child=child_id))
+            dot.extend(generate_dot_entries(child, child_id))
+
+        return dot
+
+    content = generate_dot_entries(measurement)
+    dot_data = '\n'.join(['digraph calls {'] + ['    ' + l for l in content] + ['}'])
+
+    dot_proc = subprocess.Popen(['dot', '-Tsvg'], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+    return dot_proc.communicate(input=dot_data)[0]
+
+
+def generate_node_id():
+    return 'id' + str(uuid.uuid4()).replace('-', '')

--- a/edx/analytics/tasks/performance.py
+++ b/edx/analytics/tasks/performance.py
@@ -1,0 +1,34 @@
+
+import luigi
+
+from edx.analytics.tasks.mapreduce import MapReduceJobTask
+from edx.analytics.tasks.pathutil import EventLogSelectionMixin
+from edx.analytics.tasks.url import get_target_from_url
+
+
+class ParseEventLogPerformanceTask(EventLogSelectionMixin, MapReduceJobTask):
+    """
+    This represents the smallest possible task that parses events for a particular date range.
+
+    Many of our tasks follow this pattern, so this represents the smallest amount of useful work. To maintain a short
+    development cycle we want to make this as fast as possible.
+    """
+
+    output_root = luigi.Parameter()
+
+    def __init__(self, *args, **kwargs):
+        super(ParseEventLogPerformanceTask, self).__init__(*args, **kwargs)
+        target = self.output()
+        if target.exists():
+            target.remove()
+
+    def mapper(self, line):
+        value = self.get_event_and_date_string(line)
+        if value is None:
+            return
+        event, date_string = value
+
+        yield (date_string, line)
+
+    def output(self):
+        return get_target_from_url(self.output_root)

--- a/edx/analytics/tasks/s3_util.py
+++ b/edx/analytics/tasks/s3_util.py
@@ -199,7 +199,6 @@ class S3HdfsTarget(HdfsTarget):
 
     def __init__(self, path=None, format=Plain, is_tmp=False):
         super(S3HdfsTarget, self).__init__(path=path, format=format, is_tmp=is_tmp)
-        self.s3_client = ScalableS3Client()
 
     def open(self, mode='r'):
         if mode not in ('r', 'w'):
@@ -209,4 +208,6 @@ class S3HdfsTarget(HdfsTarget):
             return super(S3HdfsTarget, self).open(mode=mode)
         else:
             safe_path = self.path.replace('s3n://', 's3://')
+            if not hasattr(self, 's3_client'):
+                self.s3_client = ScalableS3Client()
             return AtomicS3File(safe_path, self.s3_client)

--- a/logging.cfg
+++ b/logging.cfg
@@ -1,19 +1,15 @@
 #
 # Define logging for use with analytics tasks.
 #
-# This defines handlers for logging coming from
-# edx/analytics code, and from luigi code.
-# Luigi messages go to stdout, while edx messages
-# are routed to stderr.
 
 [loggers]
 keys=root,edx_analytics,luigi_interface
 
 [handlers]
-keys=stderrHandler,luigiHandler,localHandler
+keys=stdoutHandler,localHandler
 
 [formatters]
-keys=standard,luigi_default
+keys=standard
 
 [logger_root]
 level=INFO
@@ -22,26 +18,22 @@ handlers=localHandler
 [logger_edx_analytics]
 # Errors from edx/analytics get routed to stderr.
 level=DEBUG
-handlers=stderrHandler,localHandler
+handlers=stdoutHandler,localHandler
 qualname=edx.analytics
 propagate=0
 
 [logger_luigi_interface]
 # Errors from luigi-interface get routed to stdout.
-level=INFO
-handlers=luigiHandler
+level=DEBUG
+handlers=stdoutHandler,localHandler
 qualname=luigi-interface
 propagate=0
 
-[handler_stderrHandler]
-class=StreamHandler
-formatter=standard
-args=(sys.stderr,)
-
-[handler_luigiHandler]
+[handler_stdoutHandler]
 # Define as in luigi/interface.py.
 class=StreamHandler
-formatter=luigi_default
+level=INFO
+formatter=standard
 args=(sys.stdout,)
 
 [handler_localHandler]
@@ -55,7 +47,3 @@ args=('edx_analytics.log', 'w')
 [formatter_standard]
 # Define as in edx-platform/common/lib/logsettings.py (for dev logging, not syslog).
 format=%(asctime)s %(levelname)s %(process)d [%(name)s] %(filename)s:%(lineno)d - %(message)s
-
-[formatter_luigi_default]
-# Define as in luigi/interface.py.
-format=%(levelname)s: %(message)s

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
-Jinja2==2.7.3		# BSD License
+Jinja2==2.7.3		# BSD
 MarkupSafe==0.23	# BSD
 PyYAML==3.10		# MIT License
 ansible==1.4.5		# GPL v3 License
@@ -27,5 +27,6 @@ six==1.6.1		# MIT
 stevedore==0.14.1 	# Apache 2.0
 tornado==3.1.1 		# Apache 2.0
 wsgiref==0.1.2 		# ZPL
--e git+https://github.com/edx/luigi.git@v1.0.17-fork.edx.1#egg=luigi 		# Apache License 2.0
--e git+https://github.com/edx/opaque-keys.git@33f2b099e92957046a866a9b6d48a71c484bb475#egg=opaque-keys
+git+https://github.com/edx/luigi.git@v1.0.17-fork.edx.1#egg=luigi 		# Apache License 2.0
+git+https://github.com/edx/opaque-keys.git@33f2b099e92957046a866a9b6d48a71c484bb475#egg=opaque-keys
+git+https://github.com/edx/pyinstrument.git@a35ff76df4c3d5ff9a2876d859303e33d895e78f#egg=pyinstrument     # BSD

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ data_files =
 console_scripts =
     launch-task = edx.analytics.tasks.launchers.local:main
     remote-task = edx.analytics.tasks.launchers.remote:main
+    analyze-log = edx.analytics.tasks.launchers.analyze.main:analyze
 
 edx.analytics.tasks =
     enrollments-report = edx.analytics.tasks.reports.enrollments:EnrollmentsByWeek
@@ -42,6 +43,7 @@ edx.analytics.tasks =
     calendar = edx.analytics.tasks.calendar:CalendarTableTask
     overall_events = edx.analytics.tasks.overall_events:TotalEventsDailyTask
     all_events_report = edx.analytics.tasks.reports.total_events_report:TotalEventsReportWorkflow
+    noop = edx.analytics.tasks.performance:ParseEventLogPerformanceTask
 
 mapreduce.engine =
     hadoop = edx.analytics.tasks.mapreduce:MapReduceJobRunner

--- a/share/logging.cfg.j2
+++ b/share/logging.cfg.j2
@@ -1,19 +1,15 @@
 #
 # Define logging for use with analytics tasks.
 #
-# This defines handlers for logging coming from
-# edx/analytics code, and from luigi code.
-# Luigi messages go to stdout, while edx messages
-# are routed to stderr.
 
 [loggers]
 keys=root,edx_analytics,luigi_interface
 
 [handlers]
-keys=stderrHandler,luigiHandler,localHandler
+keys=stdoutHandler,localHandler
 
 [formatters]
-keys=standard,luigi_default
+keys=standard
 
 [logger_root]
 level=INFO
@@ -22,26 +18,22 @@ handlers=localHandler
 [logger_edx_analytics]
 # Errors from edx/analytics get routed to stderr.
 level=DEBUG
-handlers=stderrHandler,localHandler
+handlers=stdoutHandler,localHandler
 qualname=edx.analytics
 propagate=0
 
 [logger_luigi_interface]
 # Errors from luigi-interface get routed to stdout.
-level=INFO
-handlers=luigiHandler
+level=DEBUG
+handlers=stdoutHandler,localHandler
 qualname=luigi-interface
 propagate=0
 
-[handler_stderrHandler]
-class=StreamHandler
-formatter=standard
-args=(sys.stderr,)
-
-[handler_luigiHandler]
+[handler_stdoutHandler]
 # Define as in luigi/interface.py.
 class=StreamHandler
-formatter=luigi_default
+level=INFO
+formatter=standard
 args=(sys.stdout,)
 
 [handler_localHandler]
@@ -55,7 +47,3 @@ args=('{{ log_dir }}/edx_analytics.log', 'w')
 [formatter_standard]
 # Define as in edx-platform/common/lib/logsettings.py (for dev logging, not syslog).
 format=%(asctime)s %(levelname)s %(process)d [%(name)s] %(filename)s:%(lineno)d - %(message)s
-
-[formatter_luigi_default]
-# Define as in luigi/interface.py.
-format=%(levelname)s: %(message)s

--- a/share/report.html
+++ b/share/report.html
@@ -1,0 +1,384 @@
+<html>
+<head>
+<!-- copied from http://bost.ocks.org/mike/treemap/ -->
+<style>
+body {
+    font-family: 'Consolas', 'Lucida Console', 'Monaco', monospace;
+}
+
+#chart {
+  width: 2000px;
+  height: 768px;
+  background: #ddd;
+}
+
+text {
+  pointer-events: none;
+  font: 10px monospace;
+}
+
+.grandparent text {
+  font-weight: bold;
+}
+
+rect {
+  fill: none;
+  stroke: #fff;
+}
+
+rect.parent,
+.grandparent rect {
+  stroke-width: 2px;
+}
+
+.grandparent rect {
+  fill: orange;
+}
+
+.grandparent:hover rect {
+  fill: #ee9700;
+}
+
+.children rect.parent,
+.grandparent rect {
+  cursor: pointer;
+}
+
+.children rect.parent {
+  fill: #bbb;
+  fill-opacity: .5;
+}
+
+.children:hover rect.child {
+  fill: #bbb;
+}
+</style>
+
+<style>
+.frame {
+    margin-left: 0;
+    font-size: 10pt;
+    border-left: 1px solid #eee;
+    padding-left: 15px;
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAALCAMAAAB8rpxtAAAARVBMVEUAAAD9/f5xe4R1fYZ1fIf////O0NWzs7OysrJ2fYh2fYh2fIf///+FjJaxtbv////n6Or///+VmqP///92fYh5gYyCiJLu0pBqAAAAFHRSTlMAghs7SSu2CgTirXMj/M9EnhHqZ/jLwbwAAABGSURBVAjXY0ABHOxQwAHkMIqJQAAnkMPKBuWwgNQJC4HZXGBNggKiIA4TxAh+PiCbG2YeI68IJwfMdB42EWaEXawsDJgAACnNA3xj5yn5AAAAAElFTkSuQmCC);
+    background-repeat: no-repeat;
+    cursor: default;
+    pointer-events: fill;
+    background-color: rgba(255,255,255,0.2);
+}
+.frame.collapse {
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAMCAMAAACDd7esAAAARVBMVEUAAAD9/f51fYZxe4R2fYjO0NX///+zs7OysrJ1fId2fYh2fIf///+xtbuFjJb////n6Or///+VmqP///92fYh5gYyCiJLiCCvVAAAAFHRSTlMAgjsb4rYrCgRJrXMjz/xEnhHqZ/fev68AAAA+SURBVAjXY8AJOFg44Wx2EREuZjgbCLg5EGwRFiYIGwI44Ww+VjYoW5SXkQeqRkiAH6pXjFVYEGYXIxuUBQDVJAN8ddpNUwAAAABJRU5ErkJggg==);
+}
+.frame.collapse > .frame-children {
+    display: none;
+}
+.frame.no_children {
+    background-image: none !important;
+}
+
+.frame:hover .frame {
+    color: #888;
+}
+.frame:hover {
+    color: black !important;
+    background-color: rgba(188,213,255,0.02);
+}
+.frame.last-hover {
+    border-left-color: #a66 !important;
+    color: black !important;
+}
+.frame.last-hover .frame {
+    color: black !important;
+}
+.function {
+    font-weight: bold;
+}
+.code-position {
+    opacity: 0.5;
+}
+.frame-info span {
+    margin-right: 10px;
+}
+.high-tier {
+    background-color: rgba(255,0,0,0.15);
+}
+.mid-tier {
+    background-color: rgba(255,255,0,0.15);
+}
+.low-tier {
+    background-color: rgba(0,255,0,0.05);
+}
+</style>
+</head>
+<body>
+<div>
+  Trace
+  <div id="tree"></div>
+<div>
+<hr />
+<div>
+  <div class="callgraph-label">Call Graph (Click to Toggle)</div>
+  <div id="callgraph" style="display: none;">$call_graph_svg</div>
+</div>
+<hr />
+<div>
+  <div class="treemap-label">Tree Map (Click to Toggle)</div>
+  <div id="chart" style="display: none;"></div>
+</div>
+<hr />
+<script src="http://d3js.org/d3.v3.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+<script src=""></script>
+<script>
+// copied from http://bost.ocks.org/mike/treemap/
+
+var margin = {top: 20, right: 0, bottom: 0, left: 0},
+    width = 2000,
+    height = 768 - margin.top - margin.bottom,
+    formatNumber = d3.format(",d"),
+    transitioning;
+
+var x = d3.scale.linear()
+    .domain([0, width])
+    .range([0, width]);
+
+var y = d3.scale.linear()
+    .domain([0, height])
+    .range([0, height]);
+
+var treemap = d3.layout.treemap()
+    .children(function(d, depth) { return depth ? null : d._children; })
+    .sort(function(a, b) { return a.value - b.value; })
+    .ratio(height / width * 0.5 * (1 + Math.sqrt(5)))
+    .round(false);
+
+var svg = d3.select("#chart").append("svg")
+    .attr("width", width + margin.left + margin.right)
+    .attr("height", height + margin.bottom + margin.top)
+    .style("margin-left", -margin.left + "px")
+    .style("margin.right", -margin.right + "px")
+  .append("g")
+    .attr("transform", "translate(" + margin.left + "," + margin.top + ")")
+    .style("shape-rendering", "crispEdges");
+
+var grandparent = svg.append("g")
+    .attr("class", "grandparent");
+
+grandparent.append("rect")
+    .attr("y", -margin.top)
+    .attr("width", width)
+    .attr("height", margin.top);
+
+grandparent.append("text")
+    .attr("x", 6)
+    .attr("y", 6 - margin.top)
+    .attr("dy", ".75em");
+
+function renderTreemap(root) {
+  initialize(root);
+  accumulate(root);
+  layout(root);
+  display(root);
+
+  function initialize(root) {
+    root.x = root.y = 0;
+    root.dx = width;
+    root.dy = height;
+    root.depth = 0;
+  }
+
+  // Aggregate the values for internal nodes. This is normally done by the
+  // treemap layout, but not here because of our custom implementation.
+  // We also take a snapshot of the original children (_children) to avoid
+  // the children being overwritten when when layout is computed.
+  function accumulate(d) {
+    return (d._children = d.children)
+        ? d.value = d.children.reduce(function(p, v) { return p + accumulate(v); }, 0)
+        : d.value;
+  }
+
+  // Compute the treemap layout recursively such that each group of siblings
+  // uses the same size (1×1) rather than the dimensions of the parent cell.
+  // This optimizes the layout for the current zoom state. Note that a wrapper
+  // object is created for the parent node for each group of siblings so that
+  // the parent’s dimensions are not discarded as we recurse. Since each group
+  // of sibling was laid out in 1×1, we must rescale to fit using absolute
+  // coordinates. This lets us use a viewport to zoom.
+  function layout(d) {
+    if (d._children) {
+      treemap.nodes({_children: d._children});
+      d._children.forEach(function(c) {
+        c.x = d.x + c.x * d.dx;
+        c.y = d.y + c.y * d.dy;
+        c.dx *= d.dx;
+        c.dy *= d.dy;
+        c.parent = d;
+        layout(c);
+      });
+    }
+  }
+
+  function display(d) {
+    grandparent
+        .datum(d.parent)
+        .on("click", transition)
+      .select("text")
+        .text(name(d));
+
+    var g1 = svg.insert("g", ".grandparent")
+        .datum(d)
+        .attr("class", "depth");
+
+    var g = g1.selectAll("g")
+        .data(d._children)
+      .enter().append("g");
+
+    g.filter(function(d) { return d._children; })
+        .classed("children", true)
+        .on("click", transition);
+
+    g.selectAll(".child")
+        .data(function(d) { return d._children || [d]; })
+      .enter().append("rect")
+        .attr("class", "child")
+        .call(rect);
+
+    g.append("rect")
+        .attr("class", "parent")
+        .call(rect)
+      .append("title")
+        .text(function(d) { return formatNumber(d.value); });
+
+    g.append("text")
+        .attr("dy", ".75em")
+        .text(function(d) { return d.name })
+        .call(text);
+
+    function transition(d) {
+      if (transitioning || !d) return;
+      transitioning = true;
+
+      var g2 = display(d),
+          t1 = g1.transition().duration(750),
+          t2 = g2.transition().duration(750);
+
+      // Update the domain only after entering new elements.
+      x.domain([d.x, d.x + d.dx]);
+      y.domain([d.y, d.y + d.dy]);
+
+      // Enable anti-aliasing during the transition.
+      svg.style("shape-rendering", null);
+
+      // Draw child nodes on top of parent nodes.
+      svg.selectAll(".depth").sort(function(a, b) { return a.depth - b.depth; });
+
+      // Fade-in entering text.
+      g2.selectAll("text").style("fill-opacity", 0);
+
+      // Transition to the new view.
+      t1.selectAll("text").call(text).style("fill-opacity", 0);
+      t2.selectAll("text").call(text).style("fill-opacity", 1);
+      t1.selectAll("rect").call(rect);
+      t2.selectAll("rect").call(rect);
+
+      // Remove the old node when the transition is finished.
+      t1.remove().each("end", function() {
+        svg.style("shape-rendering", "crispEdges");
+        transitioning = false;
+      });
+    }
+
+    return g;
+  }
+
+  function text(text) {
+    text.attr("x", function(d) { return x(d.x) + 6; })
+        .attr("y", function(d) { return y(d.y) + 6; });
+  }
+
+  function rect(rect) {
+    rect.attr("x", function(d) { return x(d.x); })
+        .attr("y", function(d) { return y(d.y); })
+        .attr("width", function(d) { return x(d.x + d.dx) - x(d.x); })
+        .attr("height", function(d) { return y(d.y + d.dy) - y(d.y); });
+  }
+
+  function name(d) {
+    return d.parent
+        ? name(d.parent) + "." + d.name
+        : d.name;
+  }
+}
+</script>
+<script>
+var performanceData = $data;
+
+$(function() {
+    $('#tree').append(convertNode(performanceData));
+    $('.frame, body').mousemove(function (event) {
+        $('.frame.last-hover').removeClass('last-hover');
+        $(this).addClass('last-hover');
+        event.stopPropagation();
+    });
+
+    $('.callgraph-label').click(function() {
+      $('#callgraph').toggle()
+    });
+    $('.treemap-label').click(function() {
+      $('#chart').toggle()
+    });
+    renderTreemap(performanceData)
+
+    function convertNode(node) {
+        var classes = 'frame';
+        var numChildren = 0;
+        if ('children' in node) {
+            numChildren = node.children.length;
+        }
+        if (numChildren == 0) {
+            classes += ' no_children';
+        }
+        var container = $('<div></div>', {class: classes});
+        container.click(function (event) {
+            $(this).toggleClass('collapse');
+            event.stopPropagation();
+        });
+
+        var frame_info = $('<div></div>', {class: "frame-info"});
+        
+        percentage = node.percentage.toFixed(2);
+        if (node.bucket === "large") {
+            frame_info.addClass('high-tier');
+        } else if(node.bucket === "medium") {
+            frame_info.addClass('mid-tier');
+        } else if(node.bucket === "low") {
+            frame_info.addClass('low-tier');
+        } else {
+            container.addClass('collapse')
+        }
+
+        var time_span = $('<span></span>', {class: "time"});
+        time_span.text(node.time_delta);
+        frame_info.append(time_span);
+        var percent_span = $('<span></span>', {class: "total-percent"});
+        percent_span.text(percentage + '%');
+        frame_info.append(percent_span);
+        var function_span = $('<span></span>', {class: "function"});
+        function_span.text(node.name);
+        frame_info.append(function_span);
+
+        container.append(frame_info);
+
+        var child_container = $('<div></div>', {class: "frame-children"});
+        if ('children' in node) {
+            for (var i = 0; i < numChildren; i++) {
+                child_container.append(convertNode(node.children[i]));
+            }
+        }
+        container.append(child_container);
+        return container;
+    }
+});
+</script>
+</body>
+</html>

--- a/share/task.yml
+++ b/share/task.yml
@@ -14,19 +14,17 @@
   vars:
     - repo: git@github.com:edx/edx-analytics-pipeline.git
     - branch: master
-    - root_data_dir: /var/lib/analytics-tasks
-    - root_log_dir: /var/log/analytics-tasks
+    # - root_data_dir: /var/lib/analytics-tasks
+    # - root_log_dir: /var/log/analytics-tasks
     - working_dir: "{{ root_data_dir }}/{{ uuid }}"
     - log_dir: "{{ root_log_dir }}/{{ uuid}}"
     - working_repo_dir: "{{ working_dir }}/repo"
     - working_venv_dir: "{{ working_dir }}/venv"
     - virtualenv_python: "/usr/bin/python2.7"
-    - task_arguments: ''
     - git_servers:
         # Analytics repositories are currently hosted on github.
       - hostname: github.com
         public_key: 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
-    - wait_for_task: False
     - local_log_dir: build/logs
     - install_env:
         # EMR runs a modified version of Debian 6 (squeeze)
@@ -134,47 +132,5 @@
       copy: src={{ override_config }} dest={{ working_repo_dir }}/override.cfg mode=644
       when: override_config is defined
 
-    - name: show command to execute
-      debug: msg=". /home/hadoop/.bashrc && {{ working_venv_dir }}/bin/launch-task {{ task_arguments }} >{{ log_dir }}/stdout 2>{{ log_dir }}/stderr"
-
     - name: show working directory
       debug: var=working_repo_dir
-
-    # Unfortunately, we cannot make the poll value a variable because of this open issue:
-    # https://github.com/ansible/ansible/issues/255
-    # As a workaround, we define two versions of this play, then choose
-    # which one to run based on the boolean `wait_for_task`
-    # By default, `wait_for_task` is False, so we can "fire and forget" long-running tasks.
-    # In the integration tests, we will wait for tasks to complete before verifying results.
-    - name: task run (fire and forget)
-      shell: >
-        . /home/hadoop/.bashrc && {{ working_venv_dir }}/bin/launch-task {{ task_arguments }} >{{ log_dir }}/stdout 2>{{ log_dir }}/stderr chdir={{ working_repo_dir }}
-      async: 10000000000
-      poll: 0
-      sudo: True
-      sudo_user: hadoop
-      when: not wait_for_task
-
-    - name: task run (wait for completion)
-      shell: >
-        . /home/hadoop/.bashrc && {{ working_venv_dir }}/bin/launch-task {{ task_arguments }} >{{ log_dir }}/stdout 2>{{ log_dir }}/stderr chdir={{ working_repo_dir }}
-      async: 10000000000
-      poll: 10
-      sudo: True
-      sudo_user: hadoop
-      ignore_errors: yes
-      register: task_result
-      when: wait_for_task
-
-    - name: fetch logs
-      fetch: src={{ log_dir }}/{{ item }} dest={{ local_log_dir }}/{{ item }} flat=yes
-      with_items:
-        - stdout
-        - stderr
-        - edx_analytics.log
-      ignore_errors: yes
-      when: wait_for_task
-
-    - name: fail the play if the task failed
-      fail: msg="The task failed with exit code {{ task_result.rc }}"
-      when: wait_for_task and task_result.rc != 0


### PR DESCRIPTION
This patch includes the following changes:
- Write all luigi log messages to the edx_analytics.log file. This allows us to analyze a single log file.
- Set the luigi log threshold to DEBUG instead of INFO. This makes it much easier to analyze the log.
- Support profiling launch-task using a custom version of pyinstrument (https://github.com/mulby/pyinstrument/tree/gabe/json-output)
- Write a script that can generate reports from the edx_analytics.log file as well as pyinstrument execution traces.

It has no tests (this was a deliberate tactical decision), does some hacky stuff (also deliberate), and is generally thrown together in the interest of getting some useful output.

Since this can now generate pretty (yet self-contained) HTML reports given output from a job, it might be nice to modify the scheduler jobs to do so and save the reports so we can review them.

Sample reports:

Gist: https://gist.github.com/mulby/05ec2fc4d401a852d3bd#file-enrollment-log-html
ImportEnrollmentsIntoMysql report from edx_analytics.log: https://rawgit.com/mulby/05ec2fc4d401a852d3bd/raw/9f3c69b7fedebe3618dedec12de04239d6bb3e84/enrollment-log.html
StartupTimeTestTask report from edx_analytics.log: https://rawgit.com/mulby/05ec2fc4d401a852d3bd/raw/4643c5eadc0c4cc738e46ce7a9b54834c2bfc15e/start-time-log.html
StartupTimeTestTask report from pyinstrument execution trace:  https://rawgit.com/mulby/05ec2fc4d401a852d3bd/raw/fa4f37fa6df37799f217ffa2583f31166e74db67/start-time-trace.html

Also note that the analysis script may want to live somewhere else, it's not inherently tied to edx-analytics-pipeline in any way other than the fact that it makes assumptions about the log file format and the version of pyinstrument that was used to capturet he performance info.

Reviewers: @rocha @benpatterson @brianhw 
FYI: @cpennington 
