### PR TITLE
Send unit testing coverage stats to datadog.

### DIFF
--- a/scripts/report-build-stats.sh
+++ b/scripts/report-build-stats.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Using test-metrics, this script will post
+# stats to datadog.
+#
+#
+
+if [ -n "${DATADOG_API_KEY}" ];
+
+    then
+        echo "Reporting coverage stats to datadog"
+
+        rm -rf test-metrics
+        git clone https://github.com/wedaly/test-metrics
+
+        cd test-metrics
+        pip install -q -r requirements.txt
+
+        cat > unit_test_groups.json <<END
+{
+    "unit.analytics_pipeline": "edx/*.py"
+}
+END
+        python -m metrics.coverage unit_test_groups.json ../coverage.xml
+
+    else
+        echo "Skipping sending stats to datadog. DATADOG_API_KEY not set."
+
+fi
+


### PR DESCRIPTION
@jzoldak @mulby @brianhw @jab5569

This is currently being done on Jenkins...we'd replace the in-job bash with this (for the most part--ignoring the venv setup).
