### PR TITLE
Remove combiner from user activity job

### DIFF
--- a/edx/analytics/tasks/user_activity.py
+++ b/edx/analytics/tasks/user_activity.py
@@ -116,8 +116,6 @@ class UserActivityTask(EventLogSelectionMixin, MapReduceJobTask):
         if num_events > 0:
             yield key, num_events
 
-    combiner = reducer
-
     def output(self):
         return get_target_from_url(self.output_root)
 


### PR DESCRIPTION
This appears to be causing a significant performance problem. The user activity job on master took >9hrs when it previously took only ~3hrs.

@brianhw
