### PR TITLE
Add coveralls capability.

### DIFF
--- a/scripts/report-build-stats.sh
+++ b/scripts/report-build-stats.sh
@@ -8,7 +8,7 @@
 if [ -n "${DATADOG_API_KEY}" ];
 
     then
-        echo "Reporting coverage stats to datadog"
+        echo "Reporting coverage stats to datadog..."
 
         rm -rf test-metrics
         git clone https://github.com/wedaly/test-metrics
@@ -23,8 +23,18 @@ if [ -n "${DATADOG_API_KEY}" ];
 END
         python -m metrics.coverage unit_test_groups.json ../coverage.xml
 
+        cd..
+
     else
         echo "Skipping sending stats to datadog. DATADOG_API_KEY not set."
 
 fi
 
+# Report coverage to Coveralls
+if [ -n "${COVERALLS_REPO_TOKEN}" ];
+    then
+    echo "Sending coverage to Coveralls.io..."
+    pip install coveralls
+    coveralls
+
+fi


### PR DESCRIPTION
@mulby @brianhw @jab5569 

In a bit of de-scoping or re-scoping, I'm suggesting we implement this independently of any Travis integration. Posting to Coveralls will make it easier to produce the coverage stat on a dashboard, and can be continued if we end up going onto Travis (or not :) ).
