### PR TITLE
Make boto try harder when attempting to read credentials

### DIFF
--- a/share/boto.cfg
+++ b/share/boto.cfg
@@ -1,0 +1,3 @@
+[Boto]
+metadata_service_timeout = 60.0
+metadata_service_num_attempts = 60

--- a/share/task.yml
+++ b/share/task.yml
@@ -132,5 +132,8 @@
       copy: src={{ override_config }} dest={{ working_repo_dir }}/override.cfg mode=644
       when: override_config is defined
 
+    - name: boto configured
+      copy: src=boto.cfg dest={{ working_repo_dir }}/.boto mode=644
+
     - name: show working directory
       debug: var=working_repo_dir


### PR DESCRIPTION
This addresses one of the issues that contributed to the outage we experienced yesterday. Boto defaults to 1 attempt to retrieve metadata with a timeout of 1.0 seconds, this increases both of those parameters dramatically. It will try for an hour if necessary.

Reviewer: @brianhw
FYI: @jab5569 @e0d
