### PR TITLE
Prevent overwriting with empty data sets

### DIFF
--- a/edx/analytics/tasks/mysql_load.py
+++ b/edx/analytics/tasks/mysql_load.py
@@ -285,6 +285,9 @@ class MysqlInsertTask(MysqlInsertTaskMixin, luigi.Task):
                 self._execute_insert_query(cursor, value_list, column_names)
                 value_list = []
 
+        if self.overwrite and row_count == 0:
+            raise Exception('Cannot overwrite a table with an empty result set.')
+
         if len(value_list) > 0:
             self._execute_insert_query(cursor, value_list, column_names)
 

--- a/edx/analytics/tasks/tests/test_mysql_load.py
+++ b/edx/analytics/tasks/tests/test_mysql_load.py
@@ -71,7 +71,7 @@ class MysqlInsertTaskTestCase(unittest.TestCase):
         self.mock_mysql_connector = patcher.start()
         self.addCleanup(patcher.stop)
 
-    def create_task(self, credentials=None, source=None, insert_chunk_size=100, cls=InsertToMysqlDummyTable):
+    def create_task(self, credentials=None, source=None, insert_chunk_size=100, overwrite=False, cls=InsertToMysqlDummyTable):
         """
          Emulate execution of a generic MysqlTask.
         """
@@ -80,7 +80,8 @@ class MysqlInsertTaskTestCase(unittest.TestCase):
         luigi.task.Register.clear_instance_cache()
         task = cls(
             credentials=sentinel.ignored,
-            insert_chunk_size=insert_chunk_size
+            insert_chunk_size=insert_chunk_size,
+            overwrite=overwrite
         )
 
         if not credentials:
@@ -258,6 +259,11 @@ class MysqlInsertTaskTestCase(unittest.TestCase):
             "count INT,created TIMESTAMP DEFAULT NOW(),PRIMARY KEY (id),"
             "INDEX (course_id),INDEX (interval_start,interval_end))"
         )
+
+    def test_overwrite_with_emtpy_results(self):
+        task = self.create_task(source='', overwrite=True)
+        with self.assertRaises(Exception):
+            task.insert_rows(MagicMock())
 
 
 class MySQLLoadHelperFuncTests(unittest.TestCase):


### PR DESCRIPTION
Fixes AN-4631

Since Luigi considers the presence of an empty folder as being a valid "complete" output, it is possible for the MySQL load task to read an empty input and delete all content in a table without replacing it with anything. This is a very basic sanity check that prevents that mitigates the risk of that specific edge case causing the table content to be deleted.
