### PR TITLE
Ensure answer distribution always overwrites DB records

### DIFF
--- a/edx/analytics/tasks/answer_dist.py
+++ b/edx/analytics/tasks/answer_dist.py
@@ -809,14 +809,9 @@ class AnswerDistributionToMySQLTaskWorkflow(
     AnswerDistributionDownstreamMixin,
     MapReduceJobTaskMixin
 ):
-    def init_copy(self, connection):
-        """
-        Truncate the table before re-writing
-        """
-        # Use "DELETE" instead of TRUNCATE since TRUNCATE forces an implicit commit before it executes which would
-        # commit the currently open transaction before continuing with the copy.
-        query = "DELETE FROM {table}".format(table=self.table)
-        connection.cursor().execute(query)
+
+    # Override the parameter that normally defaults to false. This ensures that the table will always be overwritten.
+    overwrite = luigi.BooleanParameter(default=True)
 
     @property
     def insert_source_task(self):


### PR DESCRIPTION
Reviewer: @brianhw

Answer distribution has been running at the same time each day. It has not been removing records from the "table_updates" table and the unique key for the parameters is the hour of the day. Since it runs during the same hour every day, it hasn't been overwriting the records in the database.

This sets the default to overwrite the DB records, which forces it to run even if the parameters haven't changed and their is a record in table_updates.

FYI: @jab5569
