### PR TITLE
Fix check for zero row insertion.

### DIFF
--- a/edx/analytics/tasks/mysql_load.py
+++ b/edx/analytics/tasks/mysql_load.py
@@ -278,10 +278,11 @@ class MysqlInsertTask(MysqlInsertTaskMixin, luigi.Task):
                             % (self.columns[0],))
 
         value_list = []
-        for row_count, row in enumerate(self.rows()):
+        row_count = 0
+        for row_count, row in enumerate(self.rows(), start=1):
             entry = tuple([coerce_for_mysql_connect(elem) for elem in row])
             value_list.append(entry)
-            if (row_count + 1) % self.insert_chunk_size == 0:
+            if row_count % self.insert_chunk_size == 0:
                 self._execute_insert_query(cursor, value_list, column_names)
                 value_list = []
 

--- a/edx/analytics/tasks/tests/test_mysql_load.py
+++ b/edx/analytics/tasks/tests/test_mysql_load.py
@@ -260,9 +260,10 @@ class MysqlInsertTaskTestCase(unittest.TestCase):
             "INDEX (course_id),INDEX (interval_start,interval_end))"
         )
 
-    def test_overwrite_with_emtpy_results(self):
-        task = self.create_task(source='', overwrite=True)
-        with self.assertRaises(Exception):
+    def test_overwrite_with_empty_results(self):
+        # A source of '' will result in a default source of one row, so add whitespace.
+        task = self.create_task(source='   ', overwrite=True)
+        with self.assertRaisesRegexp(Exception, 'Cannot overwrite a table with an empty result set.'):
             task.insert_rows(MagicMock())
 
 


### PR DESCRIPTION
Production hit this condition, but returned "UnboundLocalError: local variable 'row_count' referenced before assignment".  Fail more gracefully.

@jab5569 
