### PR TITLE
Compute cumulative enrollments

### DIFF
--- a/edx/analytics/tasks/location_per_course.py
+++ b/edx/analytics/tasks/location_per_course.py
@@ -203,7 +203,8 @@ class QueryLastCountryPerCourseTask(
                 date STRING,
                 course_id STRING,
                 country_code STRING,
-                count INT
+                count INT,
+                cumulative_count INT
             )
             ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t'
             LOCATION '{location}';
@@ -213,11 +214,11 @@ class QueryLastCountryPerCourseTask(
                 sce.dt,
                 sce.course_id,
                 uc.country_code,
+                sum(if(sce.is_active, 1, 0)),
                 count(sce.user_id)
             FROM student_courseenrollment sce
             LEFT OUTER JOIN auth_user au on sce.user_id = au.id
             LEFT OUTER JOIN last_country_of_user uc on au.username = uc.username
-            WHERE sce.is_active > 0
             GROUP BY sce.dt, sce.course_id, uc.country_code;
         """)
 
@@ -298,6 +299,7 @@ class InsertToMysqlCourseEnrollByCountryTaskBase(MysqlInsertTask):
             ('course_id', 'VARCHAR(255) NOT NULL'),
             ('country_code', 'VARCHAR(10) NOT NULL'),
             ('count', 'INT(11) NOT NULL'),
+            ('cumulative_count', 'INT(11) NOT NULL'),
         ]
 
     @property

--- a/edx/analytics/tasks/tests/acceptance/test_enrollments.py
+++ b/edx/analytics/tasks/tests/acceptance/test_enrollments.py
@@ -26,6 +26,8 @@ class EnrollmentAcceptanceTest(AcceptanceTestCase):
             '--n-reduce-tasks', str(self.NUM_REDUCERS),
         ])
 
+        self.maxDiff = None
+
         self.validate_base()
         self.validate_gender()
         self.validate_birth_year()
@@ -36,22 +38,25 @@ class EnrollmentAcceptanceTest(AcceptanceTestCase):
         """Ensure the gender breakdown is correct."""
         with self.export_db.cursor() as cursor:
             cursor.execute(
-                'SELECT date, course_id, gender, count FROM course_enrollment_gender_daily'
+                'SELECT date, course_id, gender, count, cumulative_count FROM course_enrollment_gender_daily'
                 ' ORDER BY date, course_id, gender ASC'
             )
             results = cursor.fetchall()
 
         expected = [
-            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', None, 2),
-            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 'm', 1),
-            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', None, 2),
-            (datetime.date(2014, 8, 3), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'm', 1),
-            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', None, 2),
-            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 'm', 1),
-            (datetime.date(2014, 8, 4), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'm', 1),
-            (datetime.date(2014, 8, 4), 'edX/Open_DemoX/edx_demo_course', None, 2),
-            (datetime.date(2014, 8, 5), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'm', 2),
-            (datetime.date(2014, 8, 5), 'edX/Open_DemoX/edx_demo_course', None, 1),
+            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', None, 2, 2),
+            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 'm', 1, 2),
+            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', None, 2, 2),
+            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', 'm', 0, 2),
+            (datetime.date(2014, 8, 3), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'm', 1, 1),
+            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', None, 2, 2),
+            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 'm', 1, 2),
+            (datetime.date(2014, 8, 4), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'm', 1, 1),
+            (datetime.date(2014, 8, 4), 'edX/Open_DemoX/edx_demo_course', None, 2, 2),
+            (datetime.date(2014, 8, 4), 'edX/Open_DemoX/edx_demo_course', 'm', 0, 2),
+            (datetime.date(2014, 8, 5), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'm', 2, 2),
+            (datetime.date(2014, 8, 5), 'edX/Open_DemoX/edx_demo_course', None, 1, 2),
+            (datetime.date(2014, 8, 5), 'edX/Open_DemoX/edx_demo_course', 'm', 0, 2),
         ]
         self.assertItemsEqual(expected, results)
 
@@ -59,23 +64,31 @@ class EnrollmentAcceptanceTest(AcceptanceTestCase):
         """Ensure the birth year breakdown is correct."""
         with self.export_db.cursor() as cursor:
             cursor.execute(
-                'SELECT date, course_id, birth_year, count FROM course_enrollment_birth_year_daily'
+                'SELECT date, course_id, birth_year, count, cumulative_count FROM course_enrollment_birth_year_daily'
                 ' ORDER BY date, course_id, birth_year ASC'
             )
             results = cursor.fetchall()
 
         expected = [
-            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 1975, 1),
-            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 2000, 2),
-            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', 2000, 2),
-            (datetime.date(2014, 8, 3), 'course-v1:edX+Open_DemoX+edx_demo_course2', 1975, 1),
-            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 1975, 1),
-            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 2000, 2),
-            (datetime.date(2014, 8, 4), 'course-v1:edX+Open_DemoX+edx_demo_course2', 1975, 1),
-            (datetime.date(2014, 8, 4), 'edX/Open_DemoX/edx_demo_course', 2000, 2),
-            (datetime.date(2014, 8, 5), 'course-v1:edX+Open_DemoX+edx_demo_course2', 1975, 1),
-            (datetime.date(2014, 8, 5), 'course-v1:edX+Open_DemoX+edx_demo_course2', 1984, 1),
-            (datetime.date(2014, 8, 5), 'edX/Open_DemoX/edx_demo_course', 2000, 1),
+            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 1975, 1, 1),
+            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 1984, 0, 1),
+            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 2000, 2, 2),
+            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', 1975, 0, 1),
+            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', 1984, 0, 1),
+            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', 2000, 2, 2),
+            (datetime.date(2014, 8, 3), 'course-v1:edX+Open_DemoX+edx_demo_course2', 1975, 1, 1),
+            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 1975, 1, 1),
+            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 1984, 0, 1),
+            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 2000, 2, 2),
+            (datetime.date(2014, 8, 4), 'course-v1:edX+Open_DemoX+edx_demo_course2', 1975, 1, 1),
+            (datetime.date(2014, 8, 4), 'edX/Open_DemoX/edx_demo_course', 1975, 0, 1),
+            (datetime.date(2014, 8, 4), 'edX/Open_DemoX/edx_demo_course', 1984, 0, 1),
+            (datetime.date(2014, 8, 4), 'edX/Open_DemoX/edx_demo_course', 2000, 2, 2),
+            (datetime.date(2014, 8, 5), 'course-v1:edX+Open_DemoX+edx_demo_course2', 1975, 1, 1),
+            (datetime.date(2014, 8, 5), 'course-v1:edX+Open_DemoX+edx_demo_course2', 1984, 1, 1),
+            (datetime.date(2014, 8, 5), 'edX/Open_DemoX/edx_demo_course', 1975, 0, 1),
+            (datetime.date(2014, 8, 5), 'edX/Open_DemoX/edx_demo_course', 1984, 0, 1),
+            (datetime.date(2014, 8, 5), 'edX/Open_DemoX/edx_demo_course', 2000, 1, 2),
         ]
         self.assertItemsEqual(expected, results)
 
@@ -83,25 +96,31 @@ class EnrollmentAcceptanceTest(AcceptanceTestCase):
         """Ensure the education level breakdown is correct."""
         with self.export_db.cursor() as cursor:
             cursor.execute(
-                'SELECT date, course_id, education_level, count FROM course_enrollment_education_level_daily'
+                'SELECT date, course_id, education_level, count, cumulative_count FROM course_enrollment_education_level_daily'
                 ' ORDER BY date, course_id, education_level ASC'
             )
             results = cursor.fetchall()
 
         expected = [
-            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', None, 1),
-            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 'bachelors', 2),
-            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', None, 1),
-            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', 'bachelors', 1),
-            (datetime.date(2014, 8, 3), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'bachelors', 1),
-            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', None, 1),
-            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 'bachelors', 2),
-            (datetime.date(2014, 8, 4), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'bachelors', 1),
-            (datetime.date(2014, 8, 4), 'edX/Open_DemoX/edx_demo_course', None, 1),
-            (datetime.date(2014, 8, 4), 'edX/Open_DemoX/edx_demo_course', 'bachelors', 1),
-            (datetime.date(2014, 8, 5), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'associates', 1),
-            (datetime.date(2014, 8, 5), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'bachelors', 1),
-            (datetime.date(2014, 8, 5), 'edX/Open_DemoX/edx_demo_course', None, 1),
+            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', None, 1, 1),
+            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 'associates', 0, 1),
+            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 'bachelors', 2, 2),
+            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', None, 1, 1),
+            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', 'associates', 0, 1),
+            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', 'bachelors', 1, 2),
+            (datetime.date(2014, 8, 3), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'bachelors', 1, 1),
+            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', None, 1, 1),
+            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 'associates', 0, 1),
+            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 'bachelors', 2, 2),
+            (datetime.date(2014, 8, 4), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'bachelors', 1, 1),
+            (datetime.date(2014, 8, 4), 'edX/Open_DemoX/edx_demo_course', None, 1, 1),
+            (datetime.date(2014, 8, 4), 'edX/Open_DemoX/edx_demo_course', 'associates', 0, 1),
+            (datetime.date(2014, 8, 4), 'edX/Open_DemoX/edx_demo_course', 'bachelors', 1, 2),
+            (datetime.date(2014, 8, 5), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'associates', 1, 1),
+            (datetime.date(2014, 8, 5), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'bachelors', 1, 1),
+            (datetime.date(2014, 8, 5), 'edX/Open_DemoX/edx_demo_course', None, 1, 1),
+            (datetime.date(2014, 8, 5), 'edX/Open_DemoX/edx_demo_course', 'associates', 0, 1),
+            (datetime.date(2014, 8, 5), 'edX/Open_DemoX/edx_demo_course', 'bachelors', 0, 2),
         ]
         self.assertItemsEqual(expected, results)
 
@@ -109,42 +128,44 @@ class EnrollmentAcceptanceTest(AcceptanceTestCase):
         """Ensure the mode breakdown is correct."""
         with self.export_db.cursor() as cursor:
             cursor.execute(
-                'SELECT date, course_id, mode, count FROM course_enrollment_mode_daily'
+                'SELECT date, course_id, mode, count, cumulative_count FROM course_enrollment_mode_daily'
                 ' ORDER BY date, course_id, mode ASC'
             )
             results = cursor.fetchall()
 
         expected = [
-            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 'audit', 1),
-            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 'honor', 1),
-            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 'verified', 1),
-            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', 'honor', 1),
-            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', 'verified', 1),
-            (datetime.date(2014, 8, 3), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'verified', 1),
-            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 'audit', 1),
-            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 'honor', 1),
-            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 'verified', 1),
-            (datetime.date(2014, 8, 4), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'verified', 1),
-            (datetime.date(2014, 8, 4), 'edX/Open_DemoX/edx_demo_course', 'honor', 1),
-            (datetime.date(2014, 8, 4), 'edX/Open_DemoX/edx_demo_course', 'verified', 1),
-            (datetime.date(2014, 8, 5), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'honor', 1),
-            (datetime.date(2014, 8, 5), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'verified', 1),
-            (datetime.date(2014, 8, 5), 'edX/Open_DemoX/edx_demo_course', 'honor', 1),
+            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 'audit', 1, 1),
+            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 'honor', 1, 2),
+            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 'verified', 1, 1),
+            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', 'audit', 0, 1),
+            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', 'honor', 1, 2),
+            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', 'verified', 1, 1),
+            (datetime.date(2014, 8, 3), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'verified', 1, 1),
+            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 'audit', 1, 1),
+            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 'honor', 1, 2),
+            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 'verified', 1, 1),
+            (datetime.date(2014, 8, 4), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'verified', 1, 1),
+            (datetime.date(2014, 8, 4), 'edX/Open_DemoX/edx_demo_course', 'honor', 1, 3),
+            (datetime.date(2014, 8, 4), 'edX/Open_DemoX/edx_demo_course', 'verified', 1, 1),
+            (datetime.date(2014, 8, 5), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'honor', 1, 1),
+            (datetime.date(2014, 8, 5), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'verified', 1, 1),
+            (datetime.date(2014, 8, 5), 'edX/Open_DemoX/edx_demo_course', 'honor', 1, 3),
+            (datetime.date(2014, 8, 5), 'edX/Open_DemoX/edx_demo_course', 'verified', 0, 1),
         ]
         self.assertItemsEqual(expected, results)
 
     def validate_base(self):
         with self.export_db.cursor() as cursor:
-            cursor.execute('SELECT date, course_id, count FROM course_enrollment_daily ORDER BY date, course_id ASC')
+            cursor.execute('SELECT date, course_id, count, cumulative_count FROM course_enrollment_daily ORDER BY date, course_id ASC')
             results = cursor.fetchall()
 
         self.assertItemsEqual(results, [
-            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 3),
-            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', 2),
-            (datetime.date(2014, 8, 3), 'course-v1:edX+Open_DemoX+edx_demo_course2', 1),
-            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 3),
-            (datetime.date(2014, 8, 4), 'course-v1:edX+Open_DemoX+edx_demo_course2', 1),
-            (datetime.date(2014, 8, 4), 'edX/Open_DemoX/edx_demo_course', 2),
-            (datetime.date(2014, 8, 5), 'course-v1:edX+Open_DemoX+edx_demo_course2', 2),
-            (datetime.date(2014, 8, 5), 'edX/Open_DemoX/edx_demo_course', 1),
+            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 3, 4),
+            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', 2, 4),
+            (datetime.date(2014, 8, 3), 'course-v1:edX+Open_DemoX+edx_demo_course2', 1, 1),
+            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 3, 4),
+            (datetime.date(2014, 8, 4), 'course-v1:edX+Open_DemoX+edx_demo_course2', 1, 1),
+            (datetime.date(2014, 8, 4), 'edX/Open_DemoX/edx_demo_course', 2, 4),
+            (datetime.date(2014, 8, 5), 'course-v1:edX+Open_DemoX+edx_demo_course2', 2, 2),
+            (datetime.date(2014, 8, 5), 'edX/Open_DemoX/edx_demo_course', 1, 4),
         ])

--- a/edx/analytics/tasks/tests/acceptance/test_location_per_course.py
+++ b/edx/analytics/tasks/tests/acceptance/test_location_per_course.py
@@ -46,12 +46,13 @@ class LocationByCourseAcceptanceTest(AcceptanceTestCase):
         today = datetime.utcnow().date()
 
         self.assertItemsEqual([
-            row[1:5] for row in results
+            row[1:6] for row in results
         ], [
-            (today, self.COURSE_ID, '', 1),
-            (today, self.COURSE_ID, 'IE', 1),
-            (today, self.COURSE_ID2, 'TH', 1),
-            (today, self.COURSE_ID, 'TH', 1),
+            (today, self.COURSE_ID, '', 1, 1),
+            (today, self.COURSE_ID, 'UNKNOWN', 0, 1),
+            (today, self.COURSE_ID, 'IE', 1, 1),
+            (today, self.COURSE_ID2, 'TH', 1, 1),
+            (today, self.COURSE_ID, 'TH', 1, 1),
         ])
         with self.export_db.cursor() as cursor:
             cursor.execute('SELECT username, country_name, country_code FROM last_country_of_user ORDER BY username, country_code')

--- a/edx/analytics/tasks/tests/test_enrollments.py
+++ b/edx/analytics/tasks/tests/test_enrollments.py
@@ -182,6 +182,8 @@ class CourseEnrollmentTaskReducerTest(unittest.TestCase):
         ]
         expected = (
             ('2013-01-01', self.course_id, self.user_id, 0, 0, 'honor'),
+            ('2013-01-02', self.course_id, self.user_id, 0, 0, 'honor'),
+            ('2013-01-03', self.course_id, self.user_id, 0, 0, 'honor'),
         )
         self._check_output(inputs, expected)
 
@@ -209,6 +211,7 @@ class CourseEnrollmentTaskReducerTest(unittest.TestCase):
             ('2013-01-02', self.course_id, self.user_id, 1, 0, 'honor'),
             ('2013-01-03', self.course_id, self.user_id, 1, 0, 'honor'),
             ('2013-01-04', self.course_id, self.user_id, 0, -1, 'honor'),
+            ('2013-01-05', self.course_id, self.user_id, 0, 0, 'honor'),
             ('2013-01-06', self.course_id, self.user_id, 1, 1, 'honor'),
         )
         self._check_output(inputs, expected)
@@ -301,9 +304,26 @@ class CourseEnrollmentTaskReducerTest(unittest.TestCase):
         ]
         expected = (
             ('2013-01-01', self.course_id, self.user_id, 0, 0, 'honor'),
+            ('2013-01-02', self.course_id, self.user_id, 0, 0, 'honor'),
             ('2013-01-03', self.course_id, self.user_id, 1, 1, 'honor'),
             ('2013-01-04', self.course_id, self.user_id, 1, 0, 'honor'),
             ('2013-01-05', self.course_id, self.user_id, 1, 0, 'honor'),
+        )
+        self._check_output(inputs, expected)
+
+    def test_oversized_interval_both_sides_unenrolled_at_end(self):
+        self.create_task('2012-12-30-2013-01-06')
+        inputs = [
+            ('2013-01-01T00:00:01', DEACTIVATED, 'honor'),
+            ('2013-01-03T00:00:01', ACTIVATED, 'honor'),
+            ('2013-01-04T00:00:01', DEACTIVATED, 'honor'),
+        ]
+        expected = (
+            ('2013-01-01', self.course_id, self.user_id, 0, 0, 'honor'),
+            ('2013-01-02', self.course_id, self.user_id, 0, 0, 'honor'),
+            ('2013-01-03', self.course_id, self.user_id, 1, 1, 'honor'),
+            ('2013-01-04', self.course_id, self.user_id, 0, -1, 'honor'),
+            ('2013-01-05', self.course_id, self.user_id, 0, 0, 'honor'),
         )
         self._check_output(inputs, expected)
 

--- a/edx/analytics/tasks/tests/test_location_per_course.py
+++ b/edx/analytics/tasks/tests/test_location_per_course.py
@@ -226,7 +226,8 @@ class QueryLastCountryPerCourseTaskTestCase(unittest.TestCase):
                 date STRING,
                 course_id STRING,
                 country_code STRING,
-                count INT
+                count INT,
+                cumulative_count INT
             )
             ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t'
             LOCATION 's3://output/path';
@@ -236,11 +237,11 @@ class QueryLastCountryPerCourseTaskTestCase(unittest.TestCase):
                 sce.dt,
                 sce.course_id,
                 uc.country_code,
+                sum(if(sce.is_active, 1, 0)),
                 count(sce.user_id)
             FROM student_courseenrollment sce
             LEFT OUTER JOIN auth_user au on sce.user_id = au.id
             LEFT OUTER JOIN last_country_of_user uc on au.username = uc.username
-            WHERE sce.is_active > 0
             GROUP BY sce.dt, sce.course_id, uc.country_code;
             """
         )


### PR DESCRIPTION
In addition to simply computing the number of students currently enrolled in the course, we add support for displaying the number of students who have ever been in the course.

Open to suggestions about removing the left outer join since it's going to create quite a performance hit.

Also - note this change requires a schema change, so the result store database will need to be regenerated in order for this new column to appear.

Reviewer: @brianhw 

FYI: @dylanrhodes @jab5569 @shnayder 
