### PR TITLE
Jamesrowan/unit tests refactor

### DIFF
--- a/edx/analytics/tasks/course_enroll.py
+++ b/edx/analytics/tasks/course_enroll.py
@@ -162,6 +162,12 @@ class CourseEnrollmentChangesPerDayMixin(object):
         count = sum(int(v) for v in values)
         yield key, count
 
+    def init_local(self):
+        """
+        Empty local initialization method to make this mixin of the same form as other reducer-containing tasks
+        """
+        return
+
 
 class BaseCourseEnrollmentTaskDownstreamMixin(OverwriteOutputMixin, MapReduceJobTaskMixin):
     """

--- a/edx/analytics/tasks/tests/map_reduce_mixins.py
+++ b/edx/analytics/tasks/tests/map_reduce_mixins.py
@@ -1,7 +1,12 @@
 """Utility mixins that simplify tests for map reduce jobs."""
+import inspect
 import json
+import datetime
 
 import luigi
+from luigi.date_interval import Year
+from edx.analytics.tasks.location_per_course import LastCountryOfUser
+from edx.analytics.tasks.user_location import LastCountryForEachUser
 
 
 class MapperTestMixin(object):
@@ -20,16 +25,39 @@ class MapperTestMixin(object):
     def setUp(self):
         self.event_templates = {}
         self.default_event_template = ''
-        self.create_task()
+        if hasattr(self, 'interval') and self.interval is not None:
+            self.create_task(interval=self.interval)
+        else:
+            self.create_task()
 
     def create_task(self, interval=None):
         """Allow arguments to be passed to the task constructor."""
         if not interval:
             interval = self.DEFAULT_DATE
-        self.task = self.task_class(
-            interval=luigi.DateIntervalParameter().parse(interval),
-            output_root='/fake/output',
+        #LastCountryForEachUser is nonstandard (and slated for deprecation),
+        #not using the same interval and output_root args as the other classes,
+        #so we have a separate task initializer for it
+        if hasattr(self.task_class, 'interval') and hasattr(self.task_class, 'output_root'):
+            self.task = self.task_class(
+                interval=luigi.DateIntervalParameter().parse(interval),
+                output_root='/fake/output',
+            )
+        elif hasattr(self, 'interval'):
+            self.task = self.task_class(
+                interval=luigi.DateIntervalParameter().parse(interval),
+                output_root='/fake/output',
+            )
+        elif self.task_class == LastCountryForEachUser:
+            self.task = self.task_class(name='test', src=['test://input/'], dest='test://output/',
+                  end_date=datetime.datetime.strptime('2014-04-01', '%Y-%m-%d').date(),
+                  geolocation_data='test://data/data.file')
+        elif self.task_class == LastCountryOfUser:
+                    self.task = self.task_class(
+            mapreduce_engine='local',
+            user_country_output='test://output/',
+            interval=Year.parse('2013'),
         )
+
         self.task.init_local()
 
     def create_event_log_line(self, **kwargs):
@@ -54,6 +82,21 @@ class MapperTestMixin(object):
         self.assertEquals(expected_key, actual_key)
         self.assertEquals(expected_value, actual_value)
 
+    #TODO: talk about this issue with someone
+    def assert_single_map_output_weak(self, line, expected_key, expected_value):
+        """Assert that an input line generates exactly one output record with the expected key and value, but compares
+        dicts rather than JSON strings to avoid issues of inconsistent ordering arising from json.dumps()"""
+        mapper_output = tuple(self.task.mapper(line))
+        self.assertEquals(len(mapper_output), 1)
+        row = mapper_output[0]
+        self.assertEquals(len(row), 2)
+        actual_key, actual_value = row
+        self.assertEquals(expected_key, actual_key)
+        #actual_info = mapper_output[0][1][1]
+        actual_data = json.loads(actual_value[1])
+        self.assertEquals(actual_data, expected_value)
+
+
     def assert_no_map_output_for(self, line):
         """Assert that an input line generates no output."""
         self.assertEquals(
@@ -73,14 +116,34 @@ class ReducerTestMixin(object):
     COURSE_ID = 'foo/bar/baz'
     USERNAME = 'test_user'
 
+
     reduce_key = tuple()
     task_class = None
 
     def setUp(self):
-        self.task = self.task_class(
-            interval=luigi.DateIntervalParameter().parse(self.DATE),
-            output_root='/fake/output',
-        )
+        if hasattr(self.task_class, 'interval') and hasattr(self.task_class, 'output_root'):
+            if (not hasattr(self, 'interval')) or self.interval is None:
+                self.task = self.task_class(
+                    interval=luigi.DateIntervalParameter().parse('2013-12-17'),
+                    output_root='/fake/output',
+                )
+            else: #if we have a predifined interval already, use it
+                self.task = self.task_class(
+                    interval=luigi.DateIntervalParameter().parse(self.interval),
+                    output_root='/fake/output',
+                )
+        elif self.task_class == LastCountryForEachUser:
+            self.task = self.task_class(name='test', src=['test://input/'], dest='test://output/',
+                  end_date=datetime.datetime.strptime('2014-04-01', '%Y-%m-%d').date(),
+                  geolocation_data='test://data/data.file')
+        elif self.task_class == LastCountryOfUser:
+            self.task = self.task_class(
+                mapreduce_engine='local',
+                user_country_output='test://output/',
+                interval=Year.parse('2014'),
+            )
+
+        print self.task
         self.task.init_local()
         self.reduce_key = tuple()
 
@@ -92,6 +155,14 @@ class ReducerTestMixin(object):
     def _get_reducer_output(self, inputs):
         """Run the reducer and return the output"""
         return tuple(self.task.reducer(self.reduce_key, inputs))
+
+    # def _check_output(self, inputs, expected):
+    #     """Compare generated with expected output."""
+    #     self.assertEquals(self._get_reducer_output(inputs), expected)
+
+    # def _check_output(self, inputs, expected):
+    #     """Compare generated with expected output."""
+    #     self.assertEquals(self._get_reducer_output(inputs), expected)
 
     def _check_output(self, inputs, column_values):
         """Compare generated with expected output."""

--- a/edx/analytics/tasks/tests/test_answer_dist.py
+++ b/edx/analytics/tasks/tests/test_answer_dist.py
@@ -23,6 +23,7 @@ from edx.analytics.tasks.tests import unittest
 from edx.analytics.tasks.tests.config import with_luigi_config, OPTION_REMOVED
 from edx.analytics.tasks.tests.map_reduce_mixins import MapperTestMixin, ReducerTestMixin
 from edx.analytics.tasks.tests.opaque_key_mixins import InitializeOpaqueKeysMixin, InitializeLegacyKeysMixin
+from edx.analytics.tasks.util.event_factory import SyntheticEventFactory
 
 
 class ProblemCheckEventBaseTest(unittest.TestCase, MapperTestMixin, ReducerTestMixin):
@@ -42,6 +43,7 @@ class ProblemCheckEventBaseTest(unittest.TestCase, MapperTestMixin, ReducerTestM
         self.timestamp = "2013-12-17T15:38:32.805444"
         self.earlier_timestamp = "2013-12-15T15:38:32.805444"
         self.reduce_key = (self.course_id, self.problem_id, self.username)
+
         # self.event_templates = {
         #     'problem_check' : {
         #     "username": self.username,
@@ -135,6 +137,7 @@ class ProblemCheckEventBaseTest(unittest.TestCase, MapperTestMixin, ReducerTestM
             "agent": "blah, blah, blah",
             "page": None
         }
+
         self._update_with_kwargs(event_dict, **kwargs)
         return event_dict
 
@@ -204,7 +207,7 @@ class ProblemCheckEventMapTest(InitializeOpaqueKeysMixin, ProblemCheckEventBaseT
         mapper_output = tuple(self.task.mapper(line))
         expected_data = self._create_problem_data_dict()
         expected_key = self.reduce_key
-        #self.assert_single_map_output_weak(line, expected_key, expected_data) #does this supersede all this stuff?
+        #self.assert_single_map_output_weak_weak(line, expected_key, expected_data) #does this supersede all this stuff?
         self.assertEquals(len(mapper_output), 1)
         self.assertEquals(len(mapper_output[0]), 2)
         self.assertEquals(mapper_output[0][0], expected_key)
@@ -228,6 +231,7 @@ class ProblemCheckEventReduceTest(InitializeOpaqueKeysMixin, ProblemCheckEventBa
     Verify that ProblemCheckEventMixin.reduce() works correctly.
     """
 
+    #here, we define an explicit check_output to meet the needs of answer distribution checking
     def _check_output(self, inputs, expected):
         """
         Compare generated with expected output.

--- a/edx/analytics/tasks/tests/test_answer_dist.py
+++ b/edx/analytics/tasks/tests/test_answer_dist.py
@@ -668,8 +668,6 @@ class AnswerDistributionPerCourseReduceTest(InitializeOpaqueKeysMixin, unittest.
             response_type="nonsenseresponse",
         )
         input_data = (self.timestamp, json.dumps(answer_data))
-        #TODO: remove commented line
-        #self.assertEquals(self._get_reducer_output([input_data]), tuple())
         self.assert_no_output([input_data])
 
     @with_luigi_config('answer-distribution', 'valid_response_types', OPTION_REMOVED)
@@ -678,8 +676,6 @@ class AnswerDistributionPerCourseReduceTest(InitializeOpaqueKeysMixin, unittest.
             response_type="nonsenseresponse",
         )
         input_data = (self.timestamp, json.dumps(answer_data))
-        #TODO: remove commented line
-        # self.assertEquals(self._get_reducer_output([input_data]), tuple())
         self.assert_no_output([input_data])
 
     @with_luigi_config('answer-distribution', 'valid_response_types', OPTION_REMOVED)
@@ -913,11 +909,13 @@ class AnswerDistributionPerCourseLegacyReduceTest(InitializeLegacyKeysMixin, Ans
     pass
 
 #TODO: this class doesn't need to get changed?
-class AnswerDistributionOneFilePerCourseTaskTest(unittest.TestCase, ReducerTestMixin):
+class AnswerDistributionOneFilePerCourseTaskTest(MapperTestMixin, ReducerTestMixin, unittest.TestCase):
     """Tests for AnswerDistributionOneFilePerCourseTask class."""
 
     def setUp(self):
+        self.task_class = AnswerDistributionOneFilePerCourseTask
         super(AnswerDistributionOneFilePerCourseTaskTest, self).setUp()
+
         self.task = AnswerDistributionOneFilePerCourseTask(
             mapreduce_engine='local',
             src=None,
@@ -928,9 +926,7 @@ class AnswerDistributionOneFilePerCourseTaskTest(unittest.TestCase, ReducerTestM
         )
 
     def test_map_single_value(self):
-        key, value = next(self.task.mapper('foo\tbar'))
-        self.assertEquals(key, 'foo')
-        self.assertEquals(value, 'bar')
+        self.assert_single_map_output('foo\tbar', 'foo', 'bar')
 
     def test_reduce_multiple_values(self):
         field_names = AnswerDistributionPerCourseMixin.get_column_order()

--- a/edx/analytics/tasks/tests/test_answer_dist.py
+++ b/edx/analytics/tasks/tests/test_answer_dist.py
@@ -198,25 +198,14 @@ class ProblemCheckEventMapTest(InitializeOpaqueKeysMixin, ProblemCheckEventBaseT
         line = self._create_event_dict(context=None)
         self.assert_no_map_output_for(line)
 
-    #TODO: talk about this stuff
     def test_good_problem_check_event(self):
         event = self._create_event_dict()
         line = json.dumps(event)
-        mapper_output = tuple(self.task.mapper(line))
         expected_data = self._create_problem_data_dict()
-        expected_key = self.reduce_key
-        #self.assert_single_map_output_weak_weak(line, expected_key, expected_data) #does this supersede all this stuff?
-        self.assertEquals(len(mapper_output), 1)
-        self.assertEquals(len(mapper_output[0]), 2)
-        self.assertEquals(mapper_output[0][0], expected_key)
-        self.assertEquals(len(mapper_output[0][1]), 2)
-        self.assertEquals(mapper_output[0][1][0], self.timestamp)
         # apparently the output of json.dumps() is not consistent enough
         # to compare, due to ordering issues.  So compare the dicts
         # rather than the JSON strings.
-        actual_info = mapper_output[0][1][1]
-        actual_data = json.loads(actual_info)
-        self.assertEquals(actual_data, expected_data)
+        self.assert_single_map_output_load_jsons(line, self.reduce_key, (self.timestamp, expected_data))
 
 
 class ProblemCheckEventLegacyMapTest(InitializeLegacyKeysMixin, ProblemCheckEventMapTest):

--- a/edx/analytics/tasks/tests/test_answer_dist.py
+++ b/edx/analytics/tasks/tests/test_answer_dist.py
@@ -23,8 +23,6 @@ from edx.analytics.tasks.tests import unittest
 from edx.analytics.tasks.tests.config import with_luigi_config, OPTION_REMOVED
 from edx.analytics.tasks.tests.map_reduce_mixins import MapperTestMixin, ReducerTestMixin
 from edx.analytics.tasks.tests.opaque_key_mixins import InitializeOpaqueKeysMixin, InitializeLegacyKeysMixin
-from edx.analytics.tasks.util.event_factory import SyntheticEventFactory
-
 
 class ProblemCheckEventBaseTest(unittest.TestCase, MapperTestMixin, ReducerTestMixin):
     """Base test class for testing ProblemCheckEventMixin."""

--- a/edx/analytics/tasks/tests/test_course_enroll.py
+++ b/edx/analytics/tasks/tests/test_course_enroll.py
@@ -213,8 +213,6 @@ class CourseEnrollEventReduceTest(unittest.TestCase, ReducerTestMixin):
         )
         self._check_output(inputs, expected)
 
-#TODO: this class
-
 class CourseEnrollChangesReduceTest(ReducerTestMixin, unittest.TestCase):
     """
     Verify that CourseEnrollmentChangesPerDayMixin.reduce() works correctly.

--- a/edx/analytics/tasks/tests/test_course_enroll.py
+++ b/edx/analytics/tasks/tests/test_course_enroll.py
@@ -9,27 +9,23 @@ from edx.analytics.tasks.course_enroll import (
     CourseEnrollmentChangesPerDayMixin,
 )
 from edx.analytics.tasks.tests import unittest
+from edx.analytics.tasks.tests.map_reduce_mixins import MapperTestMixin, ReducerTestMixin
 from edx.analytics.tasks.tests.opaque_key_mixins import InitializeOpaqueKeysMixin
 
 
-class CourseEnrollEventMapTest(InitializeOpaqueKeysMixin, unittest.TestCase):
+class CourseEnrollEventMapTest(InitializeOpaqueKeysMixin, unittest.TestCase, MapperTestMixin):
     """
     Tests to verify that event log parsing by mapper works correctly.
     """
     def setUp(self):
+        super(CourseEnrollEventMapTest, self).setUp()
+
         self.initialize_ids()
         self.task = CourseEnrollmentEventsPerDayMixin()
         self.user_id = 21
         self.timestamp = "2013-12-17T15:38:32.805444"
-
-    def _create_event_log_line(self, **kwargs):
-        """Create an event log with test values, as a JSON string."""
-        return json.dumps(self._create_event_dict(**kwargs))
-
-    def _create_event_dict(self, **kwargs):
-        """Create an event log with test values, as a dict."""
-        # Define default values for event log entry.
-        event_dict = {
+        self.event_templates = {
+            'course_enroll' : {
             "username": "test_user",
             "host": "test_host",
             "event_source": "server",
@@ -49,79 +45,69 @@ class CourseEnrollEventMapTest(InitializeOpaqueKeysMixin, unittest.TestCase):
             "agent": "blah, blah, blah",
             "page": None
         }
-        event_dict.update(**kwargs)
-        return event_dict
-
-    def assert_no_output_for(self, line):
-        """Assert that an input line generates no output."""
-        self.assertEquals(tuple(self.task.mapper(line)), tuple())
+        }
+        self.default_event_template = 'course_enroll'
+        self.expected_key = (self.course_id, self.user_id)
 
     def test_non_enrollment_event(self):
         line = 'this is garbage'
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_unparseable_enrollment_event(self):
         line = 'this is garbage but contains edx.course.enrollment'
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_missing_event_type(self):
-        event_dict = self._create_event_dict()
+        event_dict = self.create_event_dict()
         event_dict['old_event_type'] = event_dict['event_type']
         del event_dict['event_type']
         line = json.dumps(event_dict)
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_nonenroll_event_type(self):
-        line = self._create_event_log_line(event_type='edx.course.enrollment.unknown')
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(event_type='edx.course.enrollment.unknown')
+        self.assert_no_map_output_for(line)
 
     def test_bad_datetime(self):
-        line = self._create_event_log_line(time='this is a bogus time')
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(time='this is a bogus time')
+        self.assert_no_map_output_for(line)
 
     def test_bad_event_data(self):
-        line = self._create_event_log_line(event=["not an event"])
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(event=["not an event"])
+        self.assert_no_map_output_for(line)
 
     def test_illegal_course_id(self):
-        line = self._create_event_log_line(event={"course_id": ";;;;bad/id/val", "user_id": self.user_id})
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(event={"course_id": ";;;;bad/id/val", "user_id": self.user_id})
+        self.assert_no_map_output_for(line)
 
     def test_missing_user_id(self):
-        line = self._create_event_log_line(event={"course_id": self.course_id})
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(event={"course_id": self.course_id})
+        self.assert_no_map_output_for(line)
 
     def test_good_enroll_event(self):
-        line = self._create_event_log_line()
-        event = tuple(self.task.mapper(line))
-        expected = (((self.course_id, self.user_id), (self.timestamp, 1)),)
-        self.assertEquals(event, expected)
+        line = self.create_event_log_line()
+        expected_value = (self.timestamp, 1)
+        self.assert_single_map_output(line, self.expected_key, expected_value)
 
     def test_good_unenroll_event(self):
-        line = self._create_event_log_line(event_type='edx.course.enrollment.deactivated')
-        event = tuple(self.task.mapper(line))
-        expected = (((self.course_id, self.user_id), (self.timestamp, -1)),)
-        self.assertEquals(event, expected)
+        line = self.create_event_log_line(event_type='edx.course.enrollment.deactivated')
+        expected_value = (self.timestamp, -1)
+        self.assert_single_map_output(line, self.expected_key, expected_value)
 
 
-class CourseEnrollEventReduceTest(unittest.TestCase):
+class CourseEnrollEventReduceTest(unittest.TestCase, ReducerTestMixin):
     """
     Tests to verify that events-per-day-per-user reducer works correctly.
     """
     def setUp(self):
-        self.task = CourseEnrollmentEventsPerDayMixin()
-        self.key = ('course', 'user')
+        super(CourseEnrollEventReduceTest, self).setUp()
 
-    def _get_reducer_output(self, values):
-        """Run reducer with provided values hardcoded key."""
-        return tuple(self.task.reducer(self.key, values))
+        self.task = CourseEnrollmentEventsPerDayMixin()
+        self.reduce_key = ('course', 'user')
 
     def _check_output(self, inputs, expected):
         """Compare generated with expected output."""
         self.assertEquals(self._get_reducer_output(inputs), expected)
-
-    def test_no_events(self):
-        self._check_output([], tuple())
 
     def test_single_enrollment(self):
         inputs = [('2013-01-01T00:00:01', 1), ]
@@ -141,8 +127,7 @@ class CourseEnrollEventReduceTest(unittest.TestCase):
             ('2013-01-01T00:00:03', 1),
             ('2013-01-01T00:00:04', -1),
         ]
-        expected = tuple()
-        self._check_output(inputs, expected)
+        self.assert_no_output(inputs)
 
         # then run with output expected:
         inputs = [
@@ -223,6 +208,7 @@ class CourseEnrollEventReduceTest(unittest.TestCase):
         )
         self._check_output(inputs, expected)
 
+#TODO: this class
 
 class CourseEnrollChangesReduceTest(unittest.TestCase):
     """

--- a/edx/analytics/tasks/tests/test_course_enroll.py
+++ b/edx/analytics/tasks/tests/test_course_enroll.py
@@ -106,8 +106,14 @@ class CourseEnrollEventReduceTest(unittest.TestCase, ReducerTestMixin):
         self.reduce_key = ('course', 'user')
 
     def _check_output(self, inputs, expected):
-        """Compare generated with expected output."""
-        self.assertEquals(self._get_reducer_output(inputs), expected)
+        '''
+        for these tests, we want to check that the whole output tuple is equal to the whole expected tuple
+
+        args:
+            inputs is a valid input to the reducer
+            expected is the tuple of expected reducer outputs
+        '''
+        return self._check_output_complete_tuple(inputs, expected)
 
     def test_single_enrollment(self):
         inputs = [('2013-01-01T00:00:01', 1), ]
@@ -147,8 +153,7 @@ class CourseEnrollEventReduceTest(unittest.TestCase, ReducerTestMixin):
             ('2013-01-01T00:00:01', 1),
             ('2013-01-01T00:00:02', -1),
         ]
-        expected = tuple()
-        self._check_output(inputs, expected)
+        self.assert_no_output(inputs)
 
     def test_multiple_enroll_events_on_same_day(self):
         inputs = [
@@ -210,24 +215,35 @@ class CourseEnrollEventReduceTest(unittest.TestCase, ReducerTestMixin):
 
 #TODO: this class
 
-class CourseEnrollChangesReduceTest(unittest.TestCase):
+class CourseEnrollChangesReduceTest(ReducerTestMixin, unittest.TestCase):
     """
     Verify that CourseEnrollmentChangesPerDayMixin.reduce() works correctly.
     """
     def setUp(self):
-        self.task = CourseEnrollmentChangesPerDayMixin()
-        self.key = ('course', '2013-01-01')
+        self.task_class = CourseEnrollmentChangesPerDayMixin
+        super(CourseEnrollChangesReduceTest, self).setUp()
 
-    def _get_reducer_output(self, values):
-        """Run reducer with provided values hardcoded key."""
-        return tuple(self.task.reducer(self.key, values))
+        self.reduce_key = ('course', '2013-01-01')
+
+    def _check_output(self, inputs, expected):
+        '''
+        for these tests, we want to check that the whole output tuple is equal to the whole expected tuple
+
+        args:
+            inputs is a valid input to the reducer
+            expected is the tuple of expected reducer outputs
+        '''
+        return self._check_output_complete_tuple(inputs, expected)
 
     def test_no_user_counts(self):
-        self.assertEquals(self._get_reducer_output([]), ((self.key, 0),))
+        expected = ((self.reduce_key, 0),)
+        self._check_output([], expected)
 
     def test_single_user_count(self):
-        self.assertEquals(self._get_reducer_output([1]), ((self.key, 1),))
+        expected = ((self.reduce_key, 1),)
+        self._check_output([1], expected)
 
     def test_multiple_user_count(self):
         inputs = [1, 1, 1, -1, 1]
-        self.assertEquals(self._get_reducer_output(inputs), ((self.key, 3),))
+        expected = ((self.reduce_key, 3),)
+        self._check_output(inputs, expected)

--- a/edx/analytics/tasks/tests/test_enrollment_validation.py
+++ b/edx/analytics/tasks/tests/test_enrollment_validation.py
@@ -193,15 +193,15 @@ class BaseCourseEnrollmentValidationTaskReducerTest(unittest.TestCase, ReducerTe
         }
         return (timestamp, VALIDATED, mode or self.mode, validation_info)
 
-    def _get_reducer_output(self, values):
-        """Run reducer with provided values hardcoded key."""
-        return tuple(self.task.reducer(self.reduce_key, values))
+    def _check_output(self, inputs, expected):
+        """Compare generated with expected output, checking the whole tuple and including keys in the expected (in case the reduce_key changes
+            midway through
 
-    def check_output(self, inputs, expected):
-        """Compare generated with expected output."""
-        expected_with_key = tuple([(key, self.reduce_key + value) for key, value in expected])
-        self.assertEquals(self._get_reducer_output(inputs), expected_with_key)
-
+        args:
+            inputs is a valid input to the subclass's reducer
+            expected is an iterable of (key, value) pairs corresponding to expected output
+        """
+        self._check_output_tuple_with_key(inputs, expected)
 
 class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTaskReducerTest):
     """
@@ -224,7 +224,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-04-01T00:00:01.123456', ACTIVATED, "honor", "start => validate(active)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_missing_enroll_unenroll(self):
         inputs = [
@@ -240,7 +240,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-04-01T00:00:01.123457', DEACTIVATED, "honor", "start => validate(inactive)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_single_enrollment(self):
         inputs = [
@@ -261,7 +261,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-04-01T00:00:01.123456', ACTIVATED, "honor", "start => deactivate",
               '2013-04-01T00:00:01.123456', '2013-05-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_single_unenrollment_without_ms(self):
         inputs = [
@@ -274,7 +274,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-04-01T00:00:01', ACTIVATED, "honor", "start => deactivate",
               '2013-04-01T00:00:01', '2013-05-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_single_unvalidated_unenrollment(self):
         inputs = [
@@ -286,7 +286,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-05-01T00:00:01.123455', ACTIVATED, "honor", "start => deactivate",
               None, '2013-05-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_rollover_unvalidated_unenrollment(self):
         inputs = [
@@ -298,7 +298,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-05-01T00:00:00.999999', ACTIVATED, "honor", "start => deactivate",
               None, '2013-05-01T00:00:01.000000')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_unvalidated_unenrollment_without_ms(self):
         inputs = [
@@ -310,7 +310,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-05-01T00:00:00.999999', ACTIVATED, "honor", "start => deactivate",
               None, '2013-05-01T00:00:01')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_single_enroll_unenroll(self):
         inputs = [
@@ -370,7 +370,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-04-01T00:00:01.123456', ACTIVATED, "honor", "start => validate(active)",
               '2013-04-01T00:00:01.123456', '2013-07-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_enroll_unenroll_with_validations(self):
         inputs = [
@@ -395,7 +395,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-08-01T00:00:01.123457', ACTIVATED, "honor", "validate(inactive) => validate(active)",
               '2013-08-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_missing_deactivate_between_validation(self):
         inputs = [
@@ -409,7 +409,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-08-01T00:00:01.123457', DEACTIVATED, "honor", "validate(active) => validate(inactive)",
               '2013-08-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_missing_deactivate_from_validation(self):
         inputs = [
@@ -423,7 +423,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-08-01T00:00:01.123457', DEACTIVATED, "honor", "validate(active) => activate",
               '2013-08-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_missing_deactivate_from_activation(self):
         inputs = [
@@ -436,7 +436,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-04-01T00:00:01.123457', DEACTIVATED, "honor", "activate => validate(inactive)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_rollover_deactivate_from_activation(self):
         inputs = [
@@ -449,7 +449,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-04-01T00:00:02.000000', DEACTIVATED, "honor", "activate => validate(inactive)",
               '2013-04-01T00:00:01.999999', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_missing_activate_from_deactivation(self):
         inputs = [
@@ -463,7 +463,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-08-01T00:00:01.123457', ACTIVATED, "honor", "deactivate => validate(active)",
               '2013-08-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_missing_activate_between_deactivation(self):
         inputs = [
@@ -477,7 +477,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-08-01T00:00:01.123457', ACTIVATED, "honor", "deactivate => deactivate",
               '2013-08-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_missing_deactivate_between_activation(self):
         inputs = [
@@ -490,7 +490,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-01-01T00:00:01.123457', DEACTIVATED, "honor", "activate => activate",
               '2013-01-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_missing_activate_from_validation(self):
         inputs = [
@@ -505,7 +505,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-09-01T00:00:01.123457', ACTIVATED, "honor", "validate(inactive) => deactivate",
               '2013-09-01T00:00:01.123456', '2013-10-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_mode_change_via_activate(self):
         inputs = [
@@ -528,7 +528,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
               "activate => validate(active) (honor=>verified)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_missing_initial_mode_change(self):
         inputs = [
@@ -567,7 +567,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
               "mode_change => validate(active) (verified=>audited)",
               '2013-05-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_activate_with_only_mode_change(self):
         inputs = [
@@ -605,7 +605,7 @@ class CourseEnrollmentValidationTaskEventReducerTest(BaseCourseEnrollmentValidat
                  '2013-09-01T00:00:01.123456'
              )), )
 
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
 class EarliestTimestampTaskReducerTest(BaseCourseEnrollmentValidationTaskReducerTest):
     """
@@ -628,7 +628,7 @@ class EarliestTimestampTaskReducerTest(BaseCourseEnrollmentValidationTaskReducer
              ('2013-04-01T00:00:01.123456', ACTIVATED, "honor", "start => validate(active)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_missing_early_single_enrollment(self):
         inputs = [
@@ -640,7 +640,7 @@ class EarliestTimestampTaskReducerTest(BaseCourseEnrollmentValidationTaskReducer
              ('2013-01-01T11:00:00.000000', ACTIVATED, "honor", "start => validate(active)",
               '2012-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
 
 class ExpectedValidationTaskReducerTest(BaseCourseEnrollmentValidationTaskReducerTest):
@@ -664,7 +664,7 @@ class ExpectedValidationTaskReducerTest(BaseCourseEnrollmentValidationTaskReduce
              ('2013-04-01T00:00:01.123457', DEACTIVATED, "honor", "activate => missing",
               '2013-04-01T00:00:01.123456', '2014-10-01T11:00:00.000000')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_missing_validation_from_deactivation(self):
         inputs = [
@@ -676,7 +676,7 @@ class ExpectedValidationTaskReducerTest(BaseCourseEnrollmentValidationTaskReduce
              ('2013-09-01T00:00:01.123457', DEACTIVATED, "honor", "deactivate => missing",
               '2013-09-01T00:00:01.123456', '2014-10-01T11:00:00.000000')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
 
 class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskReducerTest):
@@ -700,7 +700,7 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
              ('2013-04-01T00:00:01.123456', ACTIVATED, "honor", "start => validate(active)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_missing_early_single_enrollment(self):
         inputs = [
@@ -708,7 +708,7 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
             # missing activation (4/1/12)
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self._check_output(inputs, tuple())
 
     def test_single_deactivation(self):
         inputs = [
@@ -716,7 +716,7 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
             # missing activation
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self._check_output(inputs, tuple())
 
     def test_missing_deactivate_from_activation(self):
         inputs = [
@@ -729,7 +729,7 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
              ('2013-04-01T00:00:01.123457', DEACTIVATED, "honor", "activate => validate(inactive)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_missing_activate_from_validation(self):
         inputs = [
@@ -742,7 +742,7 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
              ('2013-04-01T00:00:01.123456', ACTIVATED, "honor", "start => deactivate",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_missing_early_activate_from_validation(self):
         inputs = [
@@ -766,7 +766,7 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
              ('2013-09-01T00:00:01.123457', ACTIVATED, "honor", "validate(inactive) => deactivate",
               '2013-09-01T00:00:01.123456', '2013-10-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
     def test_unenroll_during_dump(self):
         inputs = [
@@ -778,7 +778,7 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
              ('2013-04-01T00:00:01.123456', ACTIVATED, "honor", "start => validate(active)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:00.123455')),
         )
-        self.check_output(inputs, expected)
+        self._check_output(inputs, expected)
 
 
 class ExcludeNonstateChangesTaskReducerTest(BaseCourseEnrollmentValidationTaskReducerTest):

--- a/edx/analytics/tasks/tests/test_enrollments.py
+++ b/edx/analytics/tasks/tests/test_enrollments.py
@@ -115,8 +115,14 @@ class CourseEnrollmentTaskReducerTest(unittest.TestCase, ReducerTestMixin):
         self.reduce_key = (self.course_id, self.user_id)
 
     def _check_output(self, inputs, expected):
-        """Compare generated with expected output."""
-        self.assertEquals(self._get_reducer_output(inputs), expected)
+        '''
+        for these tests, we want to check that the whole output tuple is equal to the whole expected tuple
+
+        args:
+            inputs is a valid input to the reducer
+            expected is the tuple of expected reducer outputs
+        '''
+        return self._check_output_complete_tuple(inputs, expected)
 
     def test_no_events(self):
         self.assert_no_output([])

--- a/edx/analytics/tasks/tests/test_enrollments.py
+++ b/edx/analytics/tasks/tests/test_enrollments.py
@@ -11,34 +11,24 @@ from edx.analytics.tasks.enrollments import (
     MODE_CHANGED
 )
 from edx.analytics.tasks.tests import unittest
+from edx.analytics.tasks.tests.map_reduce_mixins import MapperTestMixin, ReducerTestMixin
 from edx.analytics.tasks.tests.opaque_key_mixins import InitializeOpaqueKeysMixin, InitializeLegacyKeysMixin
 
 
-class CourseEnrollmentTaskMapTest(InitializeOpaqueKeysMixin, unittest.TestCase):
+class CourseEnrollmentTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMixin, unittest.TestCase):
     """
     Tests to verify that event log parsing by mapper works correctly.
     """
     def setUp(self):
-        self.initialize_ids()
+        super(CourseEnrollmentTaskMapTest, self).setUp()
 
-        fake_param = luigi.DateIntervalParameter()
-        self.task = CourseEnrollmentTask(
-            interval=fake_param.parse('2013-12-17'),
-            output_root='/fake/output'
-        )
-        self.task.init_local()
+        self.initialize_ids()
 
         self.user_id = 21
         self.timestamp = "2013-12-17T15:38:32.805444"
 
-    def _create_event_log_line(self, **kwargs):
-        """Create an event log with test values, as a JSON string."""
-        return json.dumps(self._create_event_dict(**kwargs))
-
-    def _create_event_dict(self, **kwargs):
-        """Create an event log with test values, as a dict."""
-        # Define default values for event log entry.
-        event_dict = {
+        self.event_templates = {
+            'enrollment_event' : {
             "username": "test_user",
             "host": "test_host",
             "event_source": "server",
@@ -54,89 +44,82 @@ class CourseEnrollmentTaskMapTest(InitializeOpaqueKeysMixin, unittest.TestCase):
                 "course_id": self.course_id,
                 "user_id": self.user_id,
                 "mode": "honor",
-            },
-            "agent": "blah, blah, blah",
-            "page": None
-        }
-        event_dict.update(**kwargs)
-        return event_dict
 
-    def assert_no_output_for(self, line):
-        """Assert that an input line generates no output."""
-        self.assertEquals(tuple(self.task.mapper(line)), tuple())
+        }
+        }
+        }
+        self.default_event_template = 'enrollment_event'
+
+        self.expected_key = (self.course_id, self.user_id)
 
     def test_non_enrollment_event(self):
         line = 'this is garbage'
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_unparseable_enrollment_event(self):
         line = 'this is garbage but contains edx.course.enrollment'
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_missing_event_type(self):
         event_dict = self._create_event_dict()
         event_dict['old_event_type'] = event_dict['event_type']
         del event_dict['event_type']
         line = json.dumps(event_dict)
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_nonenroll_event_type(self):
-        line = self._create_event_log_line(event_type='edx.course.enrollment.unknown')
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(event_type='edx.course.enrollment.unknown')
+        self.assert_no_map_output_for(line)
 
     def test_bad_datetime(self):
-        line = self._create_event_log_line(time='this is a bogus time')
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(time='this is a bogus time')
+        self.assert_no_map_output_for(line)
 
     def test_bad_event_data(self):
-        line = self._create_event_log_line(event=["not an event"])
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(event=["not an event"])
+        self.assert_no_map_output_for(line)
 
     def test_illegal_course_id(self):
-        line = self._create_event_log_line(event={"course_id": ";;;;bad/id/val", "user_id": self.user_id})
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(event={"course_id": ";;;;bad/id/val", "user_id": self.user_id})
+        self.assert_no_map_output_for(line)
 
     def test_missing_user_id(self):
-        line = self._create_event_log_line(event={"course_id": self.course_id})
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(event={"course_id": self.course_id})
+        self.assert_no_map_output_for(line)
 
     def test_good_enroll_event(self):
-        line = self._create_event_log_line()
-        event = tuple(self.task.mapper(line))
-        expected = (((self.course_id, self.user_id), (self.timestamp, ACTIVATED, 'honor')),)
-        self.assertEquals(event, expected)
+        line = self.create_event_log_line()
+        expected_value = (self.timestamp, ACTIVATED, 'honor')
+        self.assert_single_map_output(line, self.expected_key, expected_value)
 
     def test_good_unenroll_event(self):
-        line = self._create_event_log_line(event_type=DEACTIVATED)
-        event = tuple(self.task.mapper(line))
-        expected = (((self.course_id, self.user_id), (self.timestamp, DEACTIVATED, 'honor')),)
-        self.assertEquals(event, expected)
+        line = self.create_event_log_line(event_type=DEACTIVATED)
+        expected_value = (self.timestamp, DEACTIVATED, 'honor')
+        self.assert_single_map_output(line, self.expected_key, expected_value)
 
 
 class CourseEnrollmentTaskMapTest(InitializeLegacyKeysMixin, unittest.TestCase):
     pass
 
 
-class CourseEnrollmentTaskReducerTest(unittest.TestCase):
+class CourseEnrollmentTaskReducerTest(unittest.TestCase, ReducerTestMixin):
     """
     Tests to verify that events-per-day-per-user reducer works correctly.
     """
     def setUp(self):
+        super(CourseEnrollmentTaskReducerTest, self).setUp()
+
         self.create_task()
         self.user_id = 0
         self.course_id = 'foo/bar/baz'
-        self.key = (self.course_id, self.user_id)
-
-    def _get_reducer_output(self, values):
-        """Run reducer with provided values hardcoded key."""
-        return tuple(self.task.reducer(self.key, values))
+        self.reduce_key = (self.course_id, self.user_id)
 
     def _check_output(self, inputs, expected):
         """Compare generated with expected output."""
         self.assertEquals(self._get_reducer_output(inputs), expected)
 
     def test_no_events(self):
-        self._check_output([], tuple())
+        self.assert_no_output([])
 
     def test_single_enrollment(self):
         inputs = [('2013-01-01T00:00:01', ACTIVATED, 'honor'), ]

--- a/edx/analytics/tasks/tests/test_location_per_course.py
+++ b/edx/analytics/tasks/tests/test_location_per_course.py
@@ -72,8 +72,14 @@ class LastCountryOfUserReducerTestCase(ReducerTestMixin, unittest.TestCase):
         self.reduce_key = self.username
 
     def _check_output(self, inputs, expected):
-        """Compare generated with expected output."""
-        self.assertEquals(self._get_reducer_output(inputs), expected)
+        '''
+        for these tests, we want to check that the whole output tuple is equal to the whole expected tuple
+
+        args:
+            inputs is a valid input to the reducer
+            expected is the tuple of expected reducer outputs
+        '''
+        return self._check_output_complete_tuple(inputs, expected)
 
     def test_no_ip(self):
         self.assert_no_output([])

--- a/edx/analytics/tasks/tests/test_location_per_course.py
+++ b/edx/analytics/tasks/tests/test_location_per_course.py
@@ -3,6 +3,7 @@ Tests for geolocation-per-course tasks.
 """
 import json
 import textwrap
+from edx.analytics.tasks.tests.map_reduce_mixins import ReducerTestMixin
 
 from mock import Mock, patch
 
@@ -21,78 +22,61 @@ class LastCountryOfUserMapperTestCase(BaseUserLocationEventTestCase):
     """Tests of LastCountryOfUser.mapper()"""
 
     def setUp(self):
-        self.task = LastCountryOfUser(
-            mapreduce_engine='local',
-            user_country_output='test://output/',
-            interval=Year.parse('2013'),
-        )
-        self.task.init_local()
-
-    def assert_no_output_for(self, line):
-        """Assert that an input line generates no output."""
-        self.assertEquals(tuple(self.task.mapper(line)), tuple())
+        self.task_class = LastCountryOfUser
+        super(LastCountryOfUserMapperTestCase, self).setUp()
 
     def test_non_enrollment_event(self):
         line = 'this is garbage'
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_bad_datetime(self):
         line = self._create_event_log_line(time='this is a bogus time')
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_after_end_date(self):
         line = self._create_event_log_line(time="2015-12-17T15:38:32.805444")
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_missing_username(self):
         event_dict = self._create_event_dict()
         del event_dict['username']
         line = json.dumps(event_dict)
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_missing_ip_address(self):
         event_dict = self._create_event_dict()
         del event_dict['ip']
         line = json.dumps(event_dict)
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_good_event(self):
         line = self._create_event_log_line()
-        event = tuple(self.task.mapper(line))
-        expected = ((self.username, (self.timestamp, self.ip_address)),)
-        self.assertEquals(event, expected)
+        self.assert_single_map_output(line, self.username, (self.timestamp, self.ip_address))
 
     def test_username_with_newline(self):
         line = self._create_event_log_line(username="baduser\n")
-        event = tuple(self.task.mapper(line))
-        expected = (("baduser", (self.timestamp, self.ip_address)),)
-        self.assertEquals(event, expected)
+        self.assert_single_map_output(line, "baduser", (self.timestamp, self.ip_address))
 
 
-class LastCountryOfUserReducerTestCase(unittest.TestCase):
+class LastCountryOfUserReducerTestCase(ReducerTestMixin, unittest.TestCase):
     """Tests of LastCountryOfUser.reducer()"""
 
     def setUp(self):
+        self.task_class = LastCountryOfUser
+        super(LastCountryOfUserReducerTestCase, self).setUp()
+
         self.username = "test_user"
         self.timestamp = "2013-12-17T15:38:32.805444"
         self.earlier_timestamp = "2013-12-15T15:38:32.805444"
-        self.task = LastCountryOfUser(
-            mapreduce_engine='local',
-            user_country_output='test://output/',
-            interval=Year.parse('2014'),
-        )
         self.task.geoip = FakeGeoLocation()
-
-    def _get_reducer_output(self, values):
-        """Run reducer with provided values hardcoded key."""
-        return tuple(self.task.reducer(self.username, values))
+        self.reduce_key = self.username
 
     def _check_output(self, inputs, expected):
         """Compare generated with expected output."""
         self.assertEquals(self._get_reducer_output(inputs), expected)
 
     def test_no_ip(self):
-        self._check_output([], tuple())
+        self.assert_no_output([])
 
     def test_single_ip(self):
         inputs = [(self.timestamp, FakeGeoLocation.ip_address_1)]
@@ -151,11 +135,20 @@ class LastCountryOfUserReducerTestCase(unittest.TestCase):
         expected = (((FakeGeoLocation.country_name_1, UNKNOWN_CODE), self.username),)
         self._check_output(inputs, expected)
 
-    def test_unicode_username(self):
-        self.username = 'I\xd4\x89\xef\xbd\x94\xc3\xa9\xef\xbd\x92\xd0\xbb\xc3\xa3\xef\xbd\x94\xc3\xac\xc3\xb2\xef\xbd\x8e\xc3\xa5\xc9\xad\xc3\xaf\xc8\xa5\xef\xbd\x81\xef\xbd\x94\xc3\xad\xdf\x80\xef\xbd\x8e'.decode('utf8')
+    def test_other_username(self):
+        self.username = 'other_user'
+        self.reduce_key = self.username
         inputs = [(self.timestamp, FakeGeoLocation.ip_address_1)]
         expected = (((FakeGeoLocation.country_name_1, FakeGeoLocation.country_code_1), self.username.encode('utf8')),)
         self._check_output(inputs, expected)
+
+    def test_unicode_username(self):
+        self.username = 'I\xd4\x89\xef\xbd\x94\xc3\xa9\xef\xbd\x92\xd0\xbb\xc3\xa3\xef\xbd\x94\xc3\xac\xc3\xb2\xef\xbd\x8e\xc3\xa5\xc9\xad\xc3\xaf\xc8\xa5\xef\xbd\x81\xef\xbd\x94\xc3\xad\xdf\x80\xef\xbd\x8e'.decode('utf8')
+        self.reduce_key = self.username
+        inputs = [(self.timestamp, FakeGeoLocation.ip_address_1)]
+        expected = (((FakeGeoLocation.country_name_1, FakeGeoLocation.country_code_1), self.username.encode('utf8')),)
+        self._check_output(inputs, expected)
+
 
 
 class ImportLastCountryOfUserToHiveTestCase(unittest.TestCase):

--- a/edx/analytics/tasks/tests/test_overall_events.py
+++ b/edx/analytics/tasks/tests/test_overall_events.py
@@ -19,12 +19,6 @@ class TotalEventsTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMixin, unittes
         self.task_class = TotalEventsDailyTask
         super(TotalEventsTaskMapTest, self).setUp()
 
-        # fake_param = luigi.DateIntervalParameter()
-        # self.task = TotalEventsDailyTask(
-        #      interval=fake_param.parse('2014-12-05'),
-        #      output_root='/fake/output'
-        # )
-
         self.initialize_ids()
         self.task.init_local()
 
@@ -122,17 +116,17 @@ class TotalEventsTaskReducerTest(ReducerTestMixin, unittest.TestCase):
         self.task_class = TotalEventsDailyTask
         super(TotalEventsTaskReducerTest, self).setUp()
 
-        # self.interval = '2013-12-17'
-        # fake_param = luigi.DateIntervalParameter()
-        # self.task = TotalEventsDailyTask(
-        #     interval=fake_param.parse(self.interval),
-        #     output_root="/fake/output"
-        # )
         self.reduce_key = '2013-12-17T00:00:01'
 
     def _check_output(self, inputs, expected):
-        """Compare generated with expected output."""
-        self.assertEquals(tuple(self._get_reducer_output(inputs)), expected)
+        '''
+        for these tests, we want to check that the whole output tuple is equal to the whole expected tuple
+
+        args:
+            inputs is a valid input to the reducer
+            expected is the tuple of expected reducer outputs
+        '''
+        return self._check_output_complete_tuple(inputs, expected)
 
     def test_one_event_count(self):
         inputs = [1, ]

--- a/edx/analytics/tasks/tests/test_student_engagement.py
+++ b/edx/analytics/tasks/tests/test_student_engagement.py
@@ -257,6 +257,17 @@ class StudentEngagementTaskReducerTest(ReducerTestMixin, unittest.TestCase):
 
         self.reduce_key = (self.DATE, self.COURSE_ID, self.USERNAME)
 
+    def _check_output(self, inputs, column_values):
+        '''
+        For these tests, we only want to test outputs by key, as there is a large dictionary of outputs for any given reducer input
+
+        args:
+            inputs is a valid input to the reducer
+            column_values is a list of dictionaries, where the (key, value) pairs in the dictionary correspond to (column_num, expected_value)
+                pairs in the expected reducer output
+        '''
+        self._check_output_by_key(inputs, column_values)
+
     def test_any_activity(self):
         inputs = [
             ('', '/foo', '{}', self.DATE)

--- a/edx/analytics/tasks/tests/test_user_activity.py
+++ b/edx/analytics/tasks/tests/test_user_activity.py
@@ -4,6 +4,7 @@ Tests for tasks that collect enrollment events.
 """
 import datetime
 import json
+from edx.analytics.tasks.tests.map_reduce_mixins import ReducerTestMixin, MapperTestMixin
 
 from luigi import date_interval
 
@@ -21,35 +22,25 @@ from edx.analytics.tasks.tests import unittest
 from edx.analytics.tasks.tests.opaque_key_mixins import InitializeOpaqueKeysMixin, InitializeLegacyKeysMixin
 
 
-class UserActivityTaskMapTest(InitializeOpaqueKeysMixin, unittest.TestCase):
+class UserActivityTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMixin, unittest.TestCase):
     """
     Tests to verify that event log parsing by mapper works correctly.
     """
     def setUp(self):
+        self.task_class = UserActivityTask
+        self.interval = '2013-12-01-2013-12-31'
+        super(UserActivityTaskMapTest, self).setUp()
+
         self.initialize_ids()
-        self.interval_string = '2013-12-01-2013-12-31'
-        self.task = UserActivityTask(
-            interval=date_interval.Custom.parse(self.interval_string),
-            output_root='/tmp/foo'
-        )
-        # We're not really using Luigi properly here to create
-        # the task, so set up manually.
-        self.task.init_local()
 
         self.username = "test_user"
         self.timestamp = "2013-12-17T15:38:32.805444"
         self.expected_date_string = '2013-12-17'
         self.event_type = "edx.dummy.event"
 
-    def _create_event_log_line(self, **kwargs):
-        """Create an event log with test values, as a JSON string."""
-        return json.dumps(self._create_event_dict(**kwargs))
-
-    def _create_event_dict(self, **kwargs):
-        """Create an event log with test values, as a dict."""
-        # Define default values for event log entry.
-        event_dict = {
-            "username": self.username,
+        self.event_templates = {
+            'user_activity' : {
+                            "username": self.username,
             "host": "test_host",
             "event_source": "server",
             "event_type": self.event_type,
@@ -63,78 +54,74 @@ class UserActivityTaskMapTest(InitializeOpaqueKeysMixin, unittest.TestCase):
             "event": {},
             "agent": "blah, blah, blah",
             "page": None
+            }
         }
-        event_dict.update(**kwargs)
-        return event_dict
-
-    def assert_no_output_for(self, line):
-        """Assert that an input line generates no output."""
-        self.assertEquals(tuple(self.task.mapper(line)), tuple())
+        self.default_event_template = 'user_activity'
 
     def test_unparseable_event(self):
         line = 'this is garbage'
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_bad_datetime(self):
-        line = self._create_event_log_line(time='this is a bogus time')
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(time='this is a bogus time')
+        self.assert_no_map_output_for(line)
 
     def test_datetime_out_of_range(self):
-        line = self._create_event_log_line(time='2014-05-04T01:23:45')
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(time='2014-05-04T01:23:45')
+        self.assert_no_map_output_for(line)
 
     def test_missing_context(self):
-        event_dict = self._create_event_dict()
+        event_dict = self.create_event_dict()
         del event_dict['context']
         line = json.dumps(event_dict)
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_missing_course_id(self):
-        line = self._create_event_log_line(context={})
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(context={})
+        self.assert_no_map_output_for(line)
 
     def test_illegal_course_id(self):
-        line = self._create_event_log_line(context={"course_id": ";;;;bad/id/val"})
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(context={"course_id": ";;;;bad/id/val"})
+        self.assert_no_map_output_for(line)
 
     def test_empty_username(self):
-        line = self._create_event_log_line(username='')
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(username='')
+        self.assert_no_map_output_for(line)
 
     def test_whitespace_username(self):
-        line = self._create_event_log_line(username='   ')
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(username='   ')
+        self.assert_no_map_output_for(line)
 
     def test_good_dummy_event(self):
-        line = self._create_event_log_line()
+        line = self.create_event_log_line()
         event = tuple(self.task.mapper(line))
         expected = (((self.course_id, self.username, self.expected_date_string, ACTIVE_LABEL), 1),)
         self.assertEquals(event, expected)
 
     def test_play_video_event(self):
-        line = self._create_event_log_line(event_source='browser', event_type='play_video')
+        line = self.create_event_log_line(event_source='browser', event_type='play_video')
         event = tuple(self.task.mapper(line))
         expected = (((self.course_id, self.username, self.expected_date_string, ACTIVE_LABEL), 1),
                     ((self.course_id, self.username, self.expected_date_string, PLAY_VIDEO_LABEL), 1))
         self.assertEquals(event, expected)
 
     def test_problem_event(self):
-        line = self._create_event_log_line(event_source='server', event_type='problem_check')
+        line = self.create_event_log_line(event_source='server', event_type='problem_check')
         event = tuple(self.task.mapper(line))
         expected = (((self.course_id, self.username, self.expected_date_string, ACTIVE_LABEL), 1),
                     ((self.course_id, self.username, self.expected_date_string, PROBLEM_LABEL), 1))
         self.assertEquals(event, expected)
 
     def test_post_forum_event(self):
-        line = self._create_event_log_line(event_source='server', event_type='blah/blah/threads/create')
+        line = self.create_event_log_line(event_source='server', event_type='blah/blah/threads/create')
         event = tuple(self.task.mapper(line))
         expected = (((self.course_id, self.username, self.expected_date_string, ACTIVE_LABEL), 1),
                     ((self.course_id, self.username, self.expected_date_string, POST_FORUM_LABEL), 1))
         self.assertEquals(event, expected)
 
     def test_exclusion_of_events_by_source(self):
-        line = self._create_event_log_line(event_source='task')
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(event_source='task')
+        self.assert_no_map_output_for(line)
 
     def test_exclusion_of_events_by_type(self):
         excluded_event_types = [
@@ -147,16 +134,16 @@ class UserActivityTaskMapTest(InitializeOpaqueKeysMixin, unittest.TestCase):
             'edx.course.enrollment.reverify.reviewed',
         ]
         for event_type in excluded_event_types:
-            line = self._create_event_log_line(event_source='server', event_type=event_type)
-            self.assert_no_output_for(line)
+            line = self.create_event_log_line(event_source='server', event_type=event_type)
+            self.assert_no_map_output_for(line)
 
     def test_multiple(self):
         lines = [
-            self._create_event_log_line(event_source='browser', event_type='play_video'),
-            self._create_event_log_line(event_source='mobile', event_type='play_video'),
-            self._create_event_log_line(
+            self.create_event_log_line(event_source='browser', event_type='play_video'),
+            self.create_event_log_line(event_source='mobile', event_type='play_video'),
+            self.create_event_log_line(
                 time="2013-12-24T00:00:00.000000", event_source='server', event_type='problem_check'),
-            self._create_event_log_line(time="2013-12-16T04:00:00.000000")
+            self.create_event_log_line(time="2013-12-16T04:00:00.000000")
         ]
         outputs = []
         for line in lines:
@@ -172,6 +159,9 @@ class UserActivityTaskMapTest(InitializeOpaqueKeysMixin, unittest.TestCase):
             ((self.course_id, self.username, '2013-12-24', PROBLEM_LABEL), 1),
             ((self.course_id, self.username, '2013-12-16', ACTIVE_LABEL), 1),
         )
+        print lines
+        print self.interval
+        print outputs
         self.assertItemsEqual(outputs, expected)
 
 
@@ -180,42 +170,44 @@ class UserActivityTaskMapLegacyTest(InitializeLegacyKeysMixin, UserActivityTaskM
     pass
 
 
-class UserActivityPerIntervalReduceTest(InitializeOpaqueKeysMixin, unittest.TestCase):
+class UserActivityPerIntervalReduceTest(InitializeOpaqueKeysMixin, ReducerTestMixin, unittest.TestCase):
     """
     Tests to verify that UserActivityPerIntervalTask reducer works correctly.
     """
     def setUp(self):
+        self.task_class = UserActivityTask
+        self.interval = '2013-12-01-2013-12-31'
+        super(UserActivityPerIntervalReduceTest, self).setUp()
+
         self.initialize_ids()
         self.username = 'test_user'
-        self.interval_string = '2013-12-01-2013-12-31'
-        self.task = UserActivityTask(
-            interval=date_interval.Custom.parse(self.interval_string),
-            output_root='/tmp/foo'
-        )
-        self.key = (self.course_id, self.username, '2013-12-04')
 
-    def _get_reducer_output(self, key, values):
-        """Run reducer with provided values hardcoded key."""
-        return tuple(self.task.reducer(key, values))
+        # self.task = UserActivityTask(
+        #     interval=date_interval.Custom.parse(self.interval_string),
+        #     output_root='/tmp/foo'
+        # )
+        self.reduce_key = (self.course_id, self.username, '2013-12-04')
 
-    def _check_output(self, key, values, expected):
+
+    def _check_output(self, values, expected):
         """Compare generated with expected output."""
-        self.assertEquals(self._get_reducer_output(key, values), expected)
+        self.assertEquals(self._get_reducer_output(values), expected)
 
     def test_no_events(self):
-        self._check_output(tuple(), [], tuple())
+        self.reduce_key = ()
+        self.assert_no_output([])
 
     def test_single_event(self):
-        key = (self.course_id, self.username, '2013-12-01', ACTIVE_LABEL)
+        self.reduce_key = (self.course_id, self.username, '2013-12-01', ACTIVE_LABEL)
         values = [1]
         expected = (((self.course_id, self.username, '2013-12-01', ACTIVE_LABEL), 1),)
-        self._check_output(key, values, expected)
+        self._check_output(values, expected)
 
     def test_multiple(self):
-        key = (self.course_id, self.username, '2013-12-01', ACTIVE_LABEL)
+        self.reduce_key = (self.course_id, self.username, '2013-12-01', ACTIVE_LABEL)
         values = [1, 2, 1]
         expected = (((self.course_id, self.username, '2013-12-01', ACTIVE_LABEL), 4),)
-        self._check_output(key, values, expected)
+        self._check_output(values, expected)
 
 
 class CourseActivityWeeklyTaskTest(InitializeOpaqueKeysMixin, unittest.TestCase):

--- a/edx/analytics/tasks/tests/test_user_activity.py
+++ b/edx/analytics/tasks/tests/test_user_activity.py
@@ -182,16 +182,17 @@ class UserActivityPerIntervalReduceTest(InitializeOpaqueKeysMixin, ReducerTestMi
         self.initialize_ids()
         self.username = 'test_user'
 
-        # self.task = UserActivityTask(
-        #     interval=date_interval.Custom.parse(self.interval_string),
-        #     output_root='/tmp/foo'
-        # )
         self.reduce_key = (self.course_id, self.username, '2013-12-04')
 
+    def _check_output(self, inputs, expected):
+        '''
+        for these tests, we want to check that the whole output tuple is equal to the whole expected tuple
 
-    def _check_output(self, values, expected):
-        """Compare generated with expected output."""
-        self.assertEquals(self._get_reducer_output(values), expected)
+        args:
+            inputs is a valid input to the reducer
+            expected is the tuple of expected reducer outputs
+        '''
+        return self._check_output_complete_tuple(inputs, expected)
 
     def test_no_events(self):
         self.reduce_key = ()

--- a/edx/analytics/tasks/tests/test_user_location.py
+++ b/edx/analytics/tasks/tests/test_user_location.py
@@ -13,6 +13,7 @@ from mock import Mock, MagicMock, patch
 import luigi.worker
 
 from edx.analytics.tasks.tests import unittest
+from edx.analytics.tasks.tests.map_reduce_mixins import MapperTestMixin, ReducerTestMixin
 from edx.analytics.tasks.user_location import LastCountryForEachUser
 from edx.analytics.tasks.user_location import UsersPerCountry
 from edx.analytics.tasks.user_location import UsersPerCountryReport
@@ -48,12 +49,15 @@ class FakeGeoLocation(object):
         return country_code_map.get(ip_address)
 
 
-class BaseUserLocationEventTestCase(unittest.TestCase):
+class BaseUserLocationEventTestCase(MapperTestMixin, unittest.TestCase):
     """Provides create-event functionality for testing user location tasks."""
 
     username = 'test_user'
     timestamp = "2013-12-17T15:38:32.805444"
     ip_address = FakeGeoLocation.ip_address_1
+
+    def setUp(self):
+        super(BaseUserLocationEventTestCase, self).setUp()
 
     def _create_event_log_line(self, **kwargs):
         """Create an event log with test values, as a JSON string."""
@@ -75,83 +79,64 @@ class LastCountryForEachUserMapperTestCase(BaseUserLocationEventTestCase):
     """Tests of LastCountryForEachUser.mapper()"""
 
     def setUp(self):
-        self.task = LastCountryForEachUser(
-            mapreduce_engine='local',
-            name='test',
-            src=['test://input/'],
-            dest='test://output/',
-            end_date=datetime.datetime.strptime('2014-04-01', '%Y-%m-%d').date(),
-            geolocation_data='test://data/data.file',
-        )
+        self.task_class = LastCountryForEachUser
 
-    def assert_no_output_for(self, line):
-        """Assert that an input line generates no output."""
-        self.assertEquals(tuple(self.task.mapper(line)), tuple())
+        super(LastCountryForEachUserMapperTestCase, self).setUp()
 
     def test_non_enrollment_event(self):
         line = 'this is garbage'
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_bad_datetime(self):
         line = self._create_event_log_line(time='this is a bogus time')
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_after_end_date(self):
         line = self._create_event_log_line(time="2015-12-17T15:38:32.805444")
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_missing_username(self):
         event_dict = self._create_event_dict()
         del event_dict['username']
         line = json.dumps(event_dict)
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_missing_ip_address(self):
         event_dict = self._create_event_dict()
         del event_dict['ip']
         line = json.dumps(event_dict)
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_good_event(self):
         line = self._create_event_log_line()
-        event = tuple(self.task.mapper(line))
-        expected = ((self.username, (self.timestamp, self.ip_address)),)
-        self.assertEquals(event, expected)
+        self.assert_single_map_output(line, self.username, (self.timestamp, self.ip_address))
 
     def test_username_with_newline(self):
         line = self._create_event_log_line(username="baduser\n")
-        event = tuple(self.task.mapper(line))
-        expected = (("baduser", (self.timestamp, self.ip_address)),)
-        self.assertEquals(event, expected)
+        self.assert_single_map_output(line, "baduser", (self.timestamp, self.ip_address))
 
 
-class LastCountryForEachUserReducerTestCase(unittest.TestCase):
+class LastCountryForEachUserReducerTestCase(ReducerTestMixin, unittest.TestCase):
     """Tests of LastCountryForEachUser.reducer()"""
 
     def setUp(self):
+        self.task_class = LastCountryForEachUser
+        super(LastCountryForEachUserReducerTestCase, self).setUp()
+
+        print self.task
+
         self.username = "test_user"
         self.timestamp = "2013-12-17T15:38:32.805444"
         self.earlier_timestamp = "2013-12-15T15:38:32.805444"
-        self.task = LastCountryForEachUser(
-            mapreduce_engine='local',
-            name='test',
-            src=['test://input/'],
-            dest='test://output/',
-            end_date=datetime.datetime.strptime('2014-04-01', '%Y-%m-%d').date(),
-            geolocation_data='test://data/data.file',
-        )
         self.task.geoip = FakeGeoLocation()
-
-    def _get_reducer_output(self, values):
-        """Run reducer with provided values hardcoded key."""
-        return tuple(self.task.reducer(self.username, values))
+        self.reduce_key = self.username
 
     def _check_output(self, inputs, expected):
         """Compare generated with expected output."""
         self.assertEquals(self._get_reducer_output(inputs), expected)
 
     def test_no_ip(self):
-        self._check_output([], tuple())
+        self.assert_no_output([])
 
     def test_single_ip(self):
         inputs = [(self.timestamp, FakeGeoLocation.ip_address_1)]
@@ -210,7 +195,8 @@ class LastCountryForEachUserReducerTestCase(unittest.TestCase):
         expected = (((FakeGeoLocation.country_name_1, UNKNOWN_CODE), self.username),)
         self._check_output(inputs, expected)
 
-
+#TODO: this looks incomplete, but if it were complete I should refactor it
+#into a mapper test and a reducer test
 class UsersPerCountryTestCase(unittest.TestCase):
     """Tests of UsersPerCountry."""
 

--- a/edx/analytics/tasks/tests/test_user_location.py
+++ b/edx/analytics/tasks/tests/test_user_location.py
@@ -132,8 +132,14 @@ class LastCountryForEachUserReducerTestCase(ReducerTestMixin, unittest.TestCase)
         self.reduce_key = self.username
 
     def _check_output(self, inputs, expected):
-        """Compare generated with expected output."""
-        self.assertEquals(self._get_reducer_output(inputs), expected)
+        '''
+        for these tests, we want to check that the whole output tuple is equal to the whole expected tuple
+
+        args:
+            inputs is a valid input to the reducer
+            expected is the tuple of expected reducer outputs
+        '''
+        return self._check_output_complete_tuple(inputs, expected)
 
     def test_no_ip(self):
         self.assert_no_output([])

--- a/edx/analytics/tasks/tests/test_video.py
+++ b/edx/analytics/tasks/tests/test_video.py
@@ -399,6 +399,17 @@ class UserVideoViewingTaskReducerTest(ReducerTestMixin, unittest.TestCase):
         self.mock_urllib = patcher.start()
         self.addCleanup(patcher.stop)
 
+    def _check_output(self, inputs, column_values):
+        '''
+        For these tests, we only want to test outputs by key, as there is a large dictionary of outputs for any given reducer input
+
+        args:
+            inputs is a valid input to the reducer
+            column_values is a list of dictionaries, where the (key, value) pairs in the dictionary correspond to (column_num, expected_value)
+                pairs in the expected reducer output
+        '''
+        self._check_output_by_key(inputs, column_values)
+
     def test_simple_viewing(self):
         inputs = [
             ('2013-12-17T00:00:00.00000Z', 'play_video', 0, None, 'html5'),
@@ -761,6 +772,18 @@ class VideoUsageTaskReducerTest(ReducerTestMixin, unittest.TestCase):
     def setUp(self):
         super(VideoUsageTaskReducerTest, self).setUp()
         self.reduce_key = (self.COURSE_ID, self.VIDEO_MODULE_ID)
+
+    def _check_output(self, inputs, column_values):
+        '''
+        For these tests, we only want to test outputs by key, as there is a large dictionary of outputs for any given reducer input
+
+        args:
+            inputs is a valid input to the reducer
+            column_values is a list of dictionaries, where the (key, value) pairs in the dictionary correspond to (column_num, expected_value)
+                pairs in the expected reducer output
+        '''
+        self._check_output_by_key(inputs, column_values)
+
 
     def test_single_viewing(self):
         inputs = [


### PR DESCRIPTION
Generalized the mixins in tasks/tests/map_reduce_mixins.py, which initially had only refactored video and student engagement tasks, to cover almost all other tasks (i.e. all but those tested in test_enrollment_validation.py or test_answer_dist.py, which have more complicated event dictionary formats).  

Equipped the mapper and reducer test mixins with additional methods to check outputs depending on the  needs of particular subclasses, and in those subclasses defined the _check_output methods in terms of the general ones given in the mixins (except in test_answer_dist.py, which had a fairly specialized _check_output method).

Modified the individual test cases to be subclasses of the mixins and use mixin methods rather than repeating the same code (e.g. the code for checking that no mapper output is produced or the code for getting reducer output).

Refactors were aimed at

1) reducing the presence of copy-pasted methods and blocks of code to allow for increased readiness for change

2) providing a clearer, more task-agnostic set of mixins for future test development.  In particular, the mixins had setUp and reducer output check methods specific to the student_engagement and video tests, which failed to generalize nicely to the majority of our other test classes (which, for example, had to specify parameters other than interval and output_root in their init methods).  

@jab5569 @brianhw @mulby 
