### PR TITLE
Jamesrowan/unit tests refactor

### DIFF
--- a/edx/analytics/tasks/answer_dist.py
+++ b/edx/analytics/tasks/answer_dist.py
@@ -230,6 +230,12 @@ class ProblemCheckEventMixin(object):
 
         return False
 
+    def init_local(self):
+        """
+        Empty local initialization method to make this mixin of the same form as other reducer-containing tasks.
+        """
+        return
+
 
 class AnswerDistributionPerCourseMixin(object):
     """Calculates answer distribution on a problem in a course, given per-user answers by date."""

--- a/edx/analytics/tasks/course_enroll.py
+++ b/edx/analytics/tasks/course_enroll.py
@@ -123,6 +123,13 @@ class CourseEnrollmentEventsPerDayMixin(object):
 
             prev_date = this_date
 
+    def init_local(self):
+        """
+        Empty local initialization method to make this mixin of the same form as other reducer-containing tasks.
+        """
+        return
+
+
 
 class CourseEnrollmentChangesPerDayMixin(object):
     """Calculates daily changes in enrollment, given per-user net changes by date."""
@@ -161,6 +168,12 @@ class CourseEnrollmentChangesPerDayMixin(object):
         log.debug("Found key in second reducer: %s", key)
         count = sum(int(v) for v in values)
         yield key, count
+
+    def init_local(self):
+        """
+        Empty local initialization method to make this mixin of the same form as other reducer-containing tasks.
+        """
+        return
 
 
 class BaseCourseEnrollmentTaskDownstreamMixin(OverwriteOutputMixin, MapReduceJobTaskMixin):

--- a/edx/analytics/tasks/tests/map_reduce_mixins.py
+++ b/edx/analytics/tasks/tests/map_reduce_mixins.py
@@ -1,8 +1,8 @@
 """Utility mixins that simplify tests for map reduce jobs."""
 import json
+import datetime
 
 import luigi
-
 
 class MapperTestMixin(object):
     """
@@ -14,22 +14,44 @@ class MapperTestMixin(object):
     DEFAULT_USER_ID = 10
     DEFAULT_TIMESTAMP = "2013-12-17T15:38:32.805444"
     DEFAULT_DATE = "2013-12-17"
+    # This dictionary stores the default values for arguments to various task constructors; if not told otherwise,
+    # the task constructor will pull needed values from this dictionary.
+    DEFAULT_ARGS = {
+        'interval': DEFAULT_DATE,
+        'output_root': '/fake/output',
+        'end_date': datetime.datetime.strptime('2014-04-01', '%Y-%m-%d').date(),
+        'geolocation_data': 'test://data/data.file',
+        'mapreduce_engine': 'local',
+        'user_country_output': 'test://output/',
+        'name': 'test',
+        'src': ['test://input/'],
+        'dest': 'test://output/'
+    }
 
     task_class = None
 
     def setUp(self):
         self.event_templates = {}
         self.default_event_template = ''
-        self.create_task()
+        if hasattr(self, 'interval') and self.interval is not None:
+            self.create_task(interval=self.interval)
+        else:
+            self.create_task()
 
-    def create_task(self, interval=None):
+    def create_task(self, **kwargs):
         """Allow arguments to be passed to the task constructor."""
-        if not interval:
-            interval = self.DEFAULT_DATE
-        self.task = self.task_class(
-            interval=luigi.DateIntervalParameter().parse(interval),
-            output_root='/fake/output',
-        )
+
+        new_kwargs = {}
+        for attr in self.DEFAULT_ARGS:
+            if not hasattr(self.task_class, attr):
+                continue
+            value = kwargs.get(attr, self.DEFAULT_ARGS.get(attr))
+            if attr == 'interval':
+                new_kwargs[attr] = luigi.DateIntervalParameter().parse(value)
+            else:
+                new_kwargs[attr] = value
+
+        self.task = self.task_class(**new_kwargs)  # pylint: disable=not-callable
         self.task.init_local()
 
     def create_event_log_line(self, **kwargs):
@@ -54,6 +76,33 @@ class MapperTestMixin(object):
         self.assertEquals(expected_key, actual_key)
         self.assertEquals(expected_value, actual_value)
 
+    def assert_single_map_output_load_jsons(self, line, expected_key, expected_value):
+        """
+        Checks if two tuples are equal, but loading jsons and comparing dictionaries rather than comparing JSON strings
+        directly to avoid potential ordering issues.
+
+        args:
+            line is a tuple, possibly including json strings.
+            expected_key is the expected key of the result of the mapping.
+            expected_value is a tuple, possibly including dictionaries to be compared with the json strings in values.
+        """
+        mapper_output = tuple(self.task.mapper(line))
+        self.assertEquals(len(mapper_output), 1)
+        row = mapper_output[0]
+        self.assertEquals(len(row), 2)
+        actual_key, actual_value = row
+        self.assertEquals(actual_key, expected_key)
+
+        read_list = []
+        expected_list = list(expected_value)
+        for element in actual_value:
+            # Load the json if we can, otherwise, just put in the element.
+            try:
+                read_list.append(json.loads(element))
+            except ValueError:
+                read_list.append(element)
+        self.assertEquals(read_list, expected_list)
+
     def assert_no_map_output_for(self, line):
         """Assert that an input line generates no output."""
         self.assertEquals(
@@ -72,15 +121,37 @@ class ReducerTestMixin(object):
     DATE = '2013-12-17'
     COURSE_ID = 'foo/bar/baz'
     USERNAME = 'test_user'
+    # This dictionary stores the default values for arguments to various task constructors; if not told otherwise,
+    # the task constructor will pull needed values from this dictionary.
+    DEFAULT_ARGS = {
+        'interval': DATE,
+        'output_root': '/fake/output',
+        'end_date': datetime.datetime.strptime('2014-04-01', '%Y-%m-%d').date(),
+        'geolocation_data': 'test://data/data.file',
+        'mapreduce_engine': 'local',
+        'user_country_output': 'test://output/',
+        'name': 'test',
+        'src': ['test://input/'],
+        'dest': 'test://output/'
+    }
 
     reduce_key = tuple()
     task_class = None
 
     def setUp(self):
-        self.task = self.task_class(
-            interval=luigi.DateIntervalParameter().parse(self.DATE),
-            output_root='/fake/output',
-        )
+
+        new_kwargs = {}
+        for attr in self.DEFAULT_ARGS:
+            if not hasattr(self.task_class, attr):
+                continue
+            value = getattr(self, attr, self.DEFAULT_ARGS.get(attr))
+            if attr == 'interval':
+                new_kwargs[attr] = luigi.DateIntervalParameter().parse(value)
+            else:
+                new_kwargs[attr] = value
+
+        self.task = self.task_class(**new_kwargs)  # pylint: disable=not-callable
+
         self.task.init_local()
         self.reduce_key = tuple()
 
@@ -90,11 +161,27 @@ class ReducerTestMixin(object):
         self.assertEquals(len(output), 0)
 
     def _get_reducer_output(self, inputs):
-        """Run the reducer and return the output"""
+        """Runs the reducer and return the output."""
         return tuple(self.task.reducer(self.reduce_key, inputs))
 
-    def _check_output(self, inputs, column_values):
-        """Compare generated with expected output."""
+    def _check_output_complete_tuple(self, inputs, expected):
+        """Compare generated with expected output, comparing the entire tuples.
+
+        args:
+            inputs is a valid input to the subclass's reducer.
+            expected is a tuple containing the expected output of the reducer.
+        """
+        self.assertEquals(self._get_reducer_output(inputs), expected)
+
+    def _check_output_by_key(self, inputs, column_values):
+        """
+        Compare generated with expected output, but only checking specified columns
+
+        args:
+            inputs is a valid input to the subclass's reducer.
+            column_values is a list of dictionaries, where the (key, value) pairs in the dictionary correspond to (column_num, expected_value)
+                pairs in the expected reducer output.
+        """
         output = self._get_reducer_output(inputs)
         if not isinstance(column_values, list):
             column_values = [column_values]
@@ -102,3 +189,15 @@ class ReducerTestMixin(object):
         for output_tuple, expected_columns in zip(output, column_values):
             for column_num, expected_value in expected_columns.iteritems():
                 self.assertEquals(output_tuple[column_num], expected_value)
+
+    def _check_output_tuple_with_key(self, inputs, expected):
+        """
+        Compare generated with expected output, checking the whole tuple and including keys in the expected
+        (in case the reduce_key changes midway through).
+
+        args:
+            inputs is a valid input to the subclass's reducer.
+            expected is an iterable of (key, value) pairs corresponding to expected output.
+        """
+        expected_with_key = tuple([(key, self.reduce_key + value) for key, value in expected])
+        self.assertEquals(self._get_reducer_output(inputs), expected_with_key)

--- a/edx/analytics/tasks/tests/test_answer_dist.py
+++ b/edx/analytics/tasks/tests/test_answer_dist.py
@@ -21,10 +21,11 @@ from edx.analytics.tasks.answer_dist import (
 )
 from edx.analytics.tasks.tests import unittest
 from edx.analytics.tasks.tests.config import with_luigi_config, OPTION_REMOVED
+from edx.analytics.tasks.tests.map_reduce_mixins import MapperTestMixin, ReducerTestMixin
 from edx.analytics.tasks.tests.opaque_key_mixins import InitializeOpaqueKeysMixin, InitializeLegacyKeysMixin
 
 
-class ProblemCheckEventBaseTest(unittest.TestCase):
+class ProblemCheckEventBaseTest(MapperTestMixin, ReducerTestMixin, unittest.TestCase):
     """Base test class for testing ProblemCheckEventMixin."""
 
     def initialize_ids(self):
@@ -32,17 +33,15 @@ class ProblemCheckEventBaseTest(unittest.TestCase):
         raise NotImplementedError
 
     def setUp(self):
+        self.task_class = ProblemCheckEventMixin
+        super(ProblemCheckEventBaseTest, self).setUp()
+
         self.initialize_ids()
-        self.task = ProblemCheckEventMixin()
         self.username = 'test_user'
         self.user_id = 24
         self.timestamp = "2013-12-17T15:38:32.805444"
         self.earlier_timestamp = "2013-12-15T15:38:32.805444"
-        self.key = (self.course_id, self.problem_id, self.username)
-
-    def _create_event_log_line(self, **kwargs):
-        """Create an event log with test values, as a JSON string."""
-        return json.dumps(self._create_event_dict(**kwargs))
+        self.reduce_key = (self.course_id, self.problem_id, self.username)  # pylint: disable=no-member
 
     def _create_event_data_dict(self, **kwargs):
         """Returns event data dict with test values."""
@@ -72,7 +71,6 @@ class ProblemCheckEventBaseTest(unittest.TestCase):
             "success": "incorrect",
         }
         self._update_with_kwargs(event_data, **kwargs)
-
         return event_data
 
     @staticmethod
@@ -102,7 +100,7 @@ class ProblemCheckEventBaseTest(unittest.TestCase):
         self._update_with_kwargs(problem_data, **kwargs)
         return problem_data
 
-    def _create_event_dict(self, **kwargs):
+    def create_event_dict(self, **kwargs):
         """Create an event log with test values, as a dict."""
         # Define default values for event log entry.
         event_dict = {
@@ -117,6 +115,7 @@ class ProblemCheckEventBaseTest(unittest.TestCase):
             "agent": "blah, blah, blah",
             "page": None
         }
+
         self._update_with_kwargs(event_dict, **kwargs)
         return event_dict
 
@@ -124,82 +123,71 @@ class ProblemCheckEventBaseTest(unittest.TestCase):
 class ProblemCheckEventMapTest(InitializeOpaqueKeysMixin, ProblemCheckEventBaseTest):
     """Tests to verify that event log parsing by mapper works correctly."""
 
-    def assert_no_output_for(self, line):
-        """Assert that an input line generates no output."""
-        self.assertEquals(tuple(self.task.mapper(line)), tuple())
-
     def test_non_problem_check_event(self):
         line = 'this is garbage'
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_unparseable_problem_check_event(self):
         line = 'this is garbage but contains problem_check'
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_browser_event_source(self):
-        line = self._create_event_log_line(event_source='browser')
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(event_source='browser')
+        self.assert_no_map_output_for(line)
 
     def test_missing_event_source(self):
-        line = self._create_event_log_line(event_source=None)
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(event_source=None)
+        self.assert_no_map_output_for(line)
 
     def test_missing_username(self):
-        line = self._create_event_log_line(username=None)
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(username=None)
+        self.assert_no_map_output_for(line)
 
     def test_missing_event_type(self):
-        event_dict = self._create_event_dict()
+        # Here, we make the event as a dictionary so we can edit individual attributes of the event.
+        event_dict = self.create_event_dict()
         event_dict['old_event_type'] = event_dict['event_type']
         del event_dict['event_type']
         line = json.dumps(event_dict)
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_implicit_problem_check_event_type(self):
-        line = self._create_event_log_line(event_type='implicit/event/ending/with/problem_check')
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(event_type='implicit/event/ending/with/problem_check')
+        self.assert_no_map_output_for(line)
 
     def test_bad_datetime(self):
-        line = self._create_event_log_line(time='this is a bogus time')
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(time='this is a bogus time')
+        self.assert_no_map_output_for(line)
 
     def test_bad_event_data(self):
-        line = self._create_event_log_line(event=["not an event"])
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(event=["not an event"])
+        self.assert_no_map_output_for(line)
 
     def test_missing_course_id(self):
-        line = self._create_event_log_line(context={})
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(context={})
+        self.assert_no_map_output_for(line)
 
     def test_illegal_course_id(self):
-        line = self._create_event_log_line(course_id=";;;;bad/id/val")
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(course_id=";;;;bad/id/val")
+        self.assert_no_map_output_for(line)
 
     def test_missing_problem_id(self):
-        line = self._create_event_log_line(problem_id=None)
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(problem_id=None)
+        self.assert_no_map_output_for(line)
 
     def test_missing_context(self):
-        line = self._create_event_log_line(context=None)
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(context=None)
+        self.assert_no_map_output_for(line)
 
     def test_good_problem_check_event(self):
-        event = self._create_event_dict()
+        # Here, we make the event as a dictionary since we're comparing based on dictionaries anyway.
+        event = self.create_event_dict()
         line = json.dumps(event)
-        mapper_output = tuple(self.task.mapper(line))
         expected_data = self._create_problem_data_dict()
-        expected_key = self.key
-        self.assertEquals(len(mapper_output), 1)
-        self.assertEquals(len(mapper_output[0]), 2)
-        self.assertEquals(mapper_output[0][0], expected_key)
-        self.assertEquals(len(mapper_output[0][1]), 2)
-        self.assertEquals(mapper_output[0][1][0], self.timestamp)
-        # apparently the output of json.dumps() is not consistent enough
+        # Apparently the output of json.dumps() is not consistent enough
         # to compare, due to ordering issues.  So compare the dicts
         # rather than the JSON strings.
-        actual_info = mapper_output[0][1][1]
-        actual_data = json.loads(actual_info)
-        self.assertEquals(actual_data, expected_data)
+        self.assert_single_map_output_load_jsons(line, self.reduce_key, (self.timestamp, expected_data))
 
 
 class ProblemCheckEventLegacyMapTest(InitializeLegacyKeysMixin, ProblemCheckEventMapTest):
@@ -212,13 +200,11 @@ class ProblemCheckEventReduceTest(InitializeOpaqueKeysMixin, ProblemCheckEventBa
     Verify that ProblemCheckEventMixin.reduce() works correctly.
     """
 
-    def _get_reducer_output(self, values):
-        """Run reducer with provided values hardcoded key."""
-        return tuple(self.task.reducer(self.key, values))
-
     def _check_output(self, inputs, expected):
         """
-        Compare generated with expected output.
+        Compare generated with expected output; we define an explicit check_output to meet the needs of answer
+        distribution checking.
+
         Args:
             inputs: array of values to pass to reducer
                 for hard-coded key.
@@ -332,7 +318,7 @@ class ProblemCheckEventReduceTest(InitializeOpaqueKeysMixin, ProblemCheckEventBa
         return "{id}_{category}".format(id=answer_id, category=attempt_category)
 
     def test_no_events(self):
-        self._check_output([], tuple())
+        self.assert_no_output([])
 
     def test_one_answer_event(self):
         problem_data = self._create_problem_data_dict()
@@ -475,26 +461,23 @@ class ProblemCheckEventReduceTest(InitializeOpaqueKeysMixin, ProblemCheckEventBa
         )
 
 
-class ProblemCheckEventLegacyReduceTest(InitializeLegacyKeysMixin, ProblemCheckEventReduceTest):
+class ProblemCheckEventLegacyReduceTest(ProblemCheckEventReduceTest, InitializeLegacyKeysMixin):
     """Run same reducer() tests, but using legacy values for keys."""
     pass
 
 
-class AnswerDistributionPerCourseReduceTest(InitializeOpaqueKeysMixin, unittest.TestCase):
+class AnswerDistributionPerCourseReduceTest(InitializeOpaqueKeysMixin, unittest.TestCase, ReducerTestMixin):
     """
     Verify that AnswerDistributionPerCourseMixin.reduce() works correctly.
     """
     def setUp(self):
+        super(AnswerDistributionPerCourseReduceTest, self).setUp()
         self.initialize_ids()
         self.task = AnswerDistributionPerCourseMixin()
         self.timestamp = "2013-12-17T15:38:32.805444"
         self.earlier_timestamp = "2013-12-15T15:38:32.805444"
-        self.key = (self.course_id, self.answer_id)
+        self.reduce_key = (self.course_id, self.answer_id)
         self.problem_display_name = "This is the Problem for You!"
-
-    def _get_reducer_output(self, values):
-        """Run reducer with provided values hardcoded key."""
-        return tuple(self.task.reducer(self.key, values))
 
     def _check_output(self, inputs, expected):
         """Compare generated with expected output."""
@@ -555,7 +538,7 @@ class AnswerDistributionPerCourseReduceTest(InitializeOpaqueKeysMixin, unittest.
         return expected_output
 
     def test_no_user_counts(self):
-        self.assertEquals(self._get_reducer_output([]), tuple())
+        self.assert_no_output([])
 
     def test_one_answer_event(self):
         answer_data = self._get_answer_data()
@@ -657,7 +640,7 @@ class AnswerDistributionPerCourseReduceTest(InitializeOpaqueKeysMixin, unittest.
             response_type="nonsenseresponse",
         )
         input_data = (self.timestamp, json.dumps(answer_data))
-        self.assertEquals(self._get_reducer_output([input_data]), tuple())
+        self.assert_no_output([input_data])
 
     @with_luigi_config('answer-distribution', 'valid_response_types', OPTION_REMOVED)
     def test_filtered_response_type_default(self):
@@ -665,7 +648,7 @@ class AnswerDistributionPerCourseReduceTest(InitializeOpaqueKeysMixin, unittest.
             response_type="nonsenseresponse",
         )
         input_data = (self.timestamp, json.dumps(answer_data))
-        self.assertEquals(self._get_reducer_output([input_data]), tuple())
+        self.assert_no_output([input_data])
 
     @with_luigi_config('answer-distribution', 'valid_response_types', OPTION_REMOVED)
     def test_valid_response_type_default(self):
@@ -696,7 +679,7 @@ class AnswerDistributionPerCourseReduceTest(InitializeOpaqueKeysMixin, unittest.
     def test_filtered_non_submission_answer(self):
         answer_data = self._get_non_submission_answer_data()
         input_data = (self.timestamp, json.dumps(answer_data))
-        self.assertEquals(self._get_reducer_output([input_data]), tuple())
+        self.assert_no_output([input_data])
 
     def test_two_answer_event_same(self):
         answer_data = self._get_answer_data()
@@ -896,10 +879,13 @@ class AnswerDistributionPerCourseLegacyReduceTest(InitializeLegacyKeysMixin, Ans
     pass
 
 
-class AnswerDistributionOneFilePerCourseTaskTest(unittest.TestCase):
+class AnswerDistributionOneFilePerCourseTaskTest(MapperTestMixin, ReducerTestMixin, unittest.TestCase):
     """Tests for AnswerDistributionOneFilePerCourseTask class."""
 
     def setUp(self):
+        self.task_class = AnswerDistributionOneFilePerCourseTask
+        super(AnswerDistributionOneFilePerCourseTaskTest, self).setUp()
+
         self.task = AnswerDistributionOneFilePerCourseTask(
             mapreduce_engine='local',
             src=None,
@@ -910,9 +896,7 @@ class AnswerDistributionOneFilePerCourseTaskTest(unittest.TestCase):
         )
 
     def test_map_single_value(self):
-        key, value = next(self.task.mapper('foo\tbar'))
-        self.assertEquals(key, 'foo')
-        self.assertEquals(value, 'bar')
+        self.assert_single_map_output('foo\tbar', 'foo', 'bar')
 
     def test_reduce_multiple_values(self):
         field_names = AnswerDistributionPerCourseMixin.get_column_order()

--- a/edx/analytics/tasks/tests/test_course_enroll.py
+++ b/edx/analytics/tasks/tests/test_course_enroll.py
@@ -9,129 +9,112 @@ from edx.analytics.tasks.course_enroll import (
     CourseEnrollmentChangesPerDayMixin,
 )
 from edx.analytics.tasks.tests import unittest
+from edx.analytics.tasks.tests.map_reduce_mixins import MapperTestMixin, ReducerTestMixin
 from edx.analytics.tasks.tests.opaque_key_mixins import InitializeOpaqueKeysMixin
 
 
-class CourseEnrollEventMapTest(InitializeOpaqueKeysMixin, unittest.TestCase):
+class CourseEnrollEventMapTest(InitializeOpaqueKeysMixin, MapperTestMixin, unittest.TestCase):
     """
     Tests to verify that event log parsing by mapper works correctly.
     """
     def setUp(self):
+        self.task_class = CourseEnrollmentEventsPerDayMixin
+
+        super(CourseEnrollEventMapTest, self).setUp()
+
         self.initialize_ids()
-        self.task = CourseEnrollmentEventsPerDayMixin()
         self.user_id = 21
         self.timestamp = "2013-12-17T15:38:32.805444"
-
-    def _create_event_log_line(self, **kwargs):
-        """Create an event log with test values, as a JSON string."""
-        return json.dumps(self._create_event_dict(**kwargs))
-
-    def _create_event_dict(self, **kwargs):
-        """Create an event log with test values, as a dict."""
-        # Define default values for event log entry.
-        event_dict = {
-            "username": "test_user",
-            "host": "test_host",
-            "event_source": "server",
-            "event_type": "edx.course.enrollment.activated",
-            "context": {
-                "course_id": self.course_id,
-                "org_id": self.org_id,
-                "user_id": self.user_id,
-            },
-            "time": "{0}+00:00".format(self.timestamp),
-            "ip": "127.0.0.1",
-            "event": {
-                "course_id": self.course_id,
-                "user_id": self.user_id,
-                "mode": "honor",
-            },
-            "agent": "blah, blah, blah",
-            "page": None
+        self.event_templates = {
+            'course_enroll': {
+                "username": "test_user",
+                "host": "test_host",
+                "event_source": "server",
+                "event_type": "edx.course.enrollment.activated",
+                "context": {
+                    "course_id": self.course_id,
+                    "org_id": self.org_id,
+                    "user_id": self.user_id,
+                },
+                "time": "{0}+00:00".format(self.timestamp),
+                "ip": "127.0.0.1",
+                "event": {
+                    "course_id": self.course_id,
+                    "user_id": self.user_id,
+                    "mode": "honor",
+                },
+                "agent": "blah, blah, blah",
+                "page": None
+            }
         }
-        event_dict.update(**kwargs)
-        return event_dict
-
-    def assert_no_output_for(self, line):
-        """Assert that an input line generates no output."""
-        self.assertEquals(tuple(self.task.mapper(line)), tuple())
+        self.default_event_template = 'course_enroll'
+        self.expected_key = (self.course_id, self.user_id)
 
     def test_non_enrollment_event(self):
         line = 'this is garbage'
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_unparseable_enrollment_event(self):
         line = 'this is garbage but contains edx.course.enrollment'
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_missing_event_type(self):
-        event_dict = self._create_event_dict()
+        event_dict = self.create_event_dict()
         event_dict['old_event_type'] = event_dict['event_type']
         del event_dict['event_type']
         line = json.dumps(event_dict)
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_nonenroll_event_type(self):
-        line = self._create_event_log_line(event_type='edx.course.enrollment.unknown')
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(event_type='edx.course.enrollment.unknown')
+        self.assert_no_map_output_for(line)
 
     def test_bad_datetime(self):
-        line = self._create_event_log_line(time='this is a bogus time')
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(time='this is a bogus time')
+        self.assert_no_map_output_for(line)
 
     def test_bad_event_data(self):
-        line = self._create_event_log_line(event=["not an event"])
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(event=["not an event"])
+        self.assert_no_map_output_for(line)
 
     def test_illegal_course_id(self):
-        line = self._create_event_log_line(event={"course_id": ";;;;bad/id/val", "user_id": self.user_id})
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(event={"course_id": ";;;;bad/id/val", "user_id": self.user_id})
+        self.assert_no_map_output_for(line)
 
     def test_missing_user_id(self):
-        line = self._create_event_log_line(event={"course_id": self.course_id})
-        self.assert_no_output_for(line)
+        line = self.create_event_log_line(event={"course_id": self.course_id})
+        self.assert_no_map_output_for(line)
 
     def test_good_enroll_event(self):
-        line = self._create_event_log_line()
-        event = tuple(self.task.mapper(line))
-        expected = (((self.course_id, self.user_id), (self.timestamp, 1)),)
-        self.assertEquals(event, expected)
+        line = self.create_event_log_line()
+        expected_value = (self.timestamp, 1)
+        self.assert_single_map_output(line, self.expected_key, expected_value)
 
     def test_good_unenroll_event(self):
-        line = self._create_event_log_line(event_type='edx.course.enrollment.deactivated')
-        event = tuple(self.task.mapper(line))
-        expected = (((self.course_id, self.user_id), (self.timestamp, -1)),)
-        self.assertEquals(event, expected)
+        line = self.create_event_log_line(event_type='edx.course.enrollment.deactivated')
+        expected_value = (self.timestamp, -1)
+        self.assert_single_map_output(line, self.expected_key, expected_value)
 
 
-class CourseEnrollEventReduceTest(unittest.TestCase):
+class CourseEnrollEventReduceTest(unittest.TestCase, ReducerTestMixin):
     """
     Tests to verify that events-per-day-per-user reducer works correctly.
     """
     def setUp(self):
+        super(CourseEnrollEventReduceTest, self).setUp()
+
         self.task = CourseEnrollmentEventsPerDayMixin()
-        self.key = ('course', 'user')
-
-    def _get_reducer_output(self, values):
-        """Run reducer with provided values hardcoded key."""
-        return tuple(self.task.reducer(self.key, values))
-
-    def _check_output(self, inputs, expected):
-        """Compare generated with expected output."""
-        self.assertEquals(self._get_reducer_output(inputs), expected)
-
-    def test_no_events(self):
-        self._check_output([], tuple())
+        self.reduce_key = ('course', 'user')
 
     def test_single_enrollment(self):
         inputs = [('2013-01-01T00:00:01', 1), ]
         expected = ((('course', '2013-01-01'), 1),)
-        self._check_output(inputs, expected)
+        self._check_output_complete_tuple(inputs, expected)
 
     def test_single_unenrollment(self):
         inputs = [('2013-01-01T00:00:01', -1), ]
         expected = ((('course', '2013-01-01'), -1),)
-        self._check_output(inputs, expected)
+        self._check_output_complete_tuple(inputs, expected)
 
     def test_multiple_events_on_same_day(self):
         # run first with no output expected:
@@ -141,8 +124,7 @@ class CourseEnrollEventReduceTest(unittest.TestCase):
             ('2013-01-01T00:00:03', 1),
             ('2013-01-01T00:00:04', -1),
         ]
-        expected = tuple()
-        self._check_output(inputs, expected)
+        self.assert_no_output(inputs)
 
         # then run with output expected:
         inputs = [
@@ -152,7 +134,7 @@ class CourseEnrollEventReduceTest(unittest.TestCase):
             ('2013-01-01T00:00:04', 1),
         ]
         expected = ((('course', '2013-01-01'), 1),)
-        self._check_output(inputs, expected)
+        self._check_output_complete_tuple(inputs, expected)
 
     def test_multiple_events_out_of_order(self):
         # Make sure that events are sorted by the reducer.
@@ -162,8 +144,7 @@ class CourseEnrollEventReduceTest(unittest.TestCase):
             ('2013-01-01T00:00:01', 1),
             ('2013-01-01T00:00:02', -1),
         ]
-        expected = tuple()
-        self._check_output(inputs, expected)
+        self.assert_no_output(inputs)
 
     def test_multiple_enroll_events_on_same_day(self):
         inputs = [
@@ -173,7 +154,7 @@ class CourseEnrollEventReduceTest(unittest.TestCase):
             ('2013-01-01T00:00:04', 1),
         ]
         expected = ((('course', '2013-01-01'), 1),)
-        self._check_output(inputs, expected)
+        self._check_output_complete_tuple(inputs, expected)
 
     def test_multiple_unenroll_events_on_same_day(self):
         inputs = [
@@ -183,7 +164,7 @@ class CourseEnrollEventReduceTest(unittest.TestCase):
             ('2013-01-01T00:00:04', -1),
         ]
         expected = ((('course', '2013-01-01'), -1),)
-        self._check_output(inputs, expected)
+        self._check_output_complete_tuple(inputs, expected)
 
     def test_multiple_enroll_events_on_many_days(self):
         inputs = [
@@ -194,7 +175,7 @@ class CourseEnrollEventReduceTest(unittest.TestCase):
             ('2013-01-04T00:00:05', 1),
         ]
         expected = ((('course', '2013-01-01'), 1),)
-        self._check_output(inputs, expected)
+        self._check_output_complete_tuple(inputs, expected)
 
     def test_multiple_events_on_many_days(self):
         # Run with an arbitrary list of events.
@@ -221,27 +202,28 @@ class CourseEnrollEventReduceTest(unittest.TestCase):
             (('course', '2013-01-07'), 1),
             (('course', '2013-01-09'), -1),
         )
-        self._check_output(inputs, expected)
+        self._check_output_complete_tuple(inputs, expected)
 
 
-class CourseEnrollChangesReduceTest(unittest.TestCase):
+class CourseEnrollChangesReduceTest(ReducerTestMixin, unittest.TestCase):
     """
     Verify that CourseEnrollmentChangesPerDayMixin.reduce() works correctly.
     """
     def setUp(self):
-        self.task = CourseEnrollmentChangesPerDayMixin()
-        self.key = ('course', '2013-01-01')
+        self.task_class = CourseEnrollmentChangesPerDayMixin
+        super(CourseEnrollChangesReduceTest, self).setUp()
 
-    def _get_reducer_output(self, values):
-        """Run reducer with provided values hardcoded key."""
-        return tuple(self.task.reducer(self.key, values))
+        self.reduce_key = ('course', '2013-01-01')
 
     def test_no_user_counts(self):
-        self.assertEquals(self._get_reducer_output([]), ((self.key, 0),))
+        expected = ((self.reduce_key, 0),)
+        self._check_output_complete_tuple([], expected)
 
     def test_single_user_count(self):
-        self.assertEquals(self._get_reducer_output([1]), ((self.key, 1),))
+        expected = ((self.reduce_key, 1),)
+        self._check_output_complete_tuple([1], expected)
 
     def test_multiple_user_count(self):
         inputs = [1, 1, 1, -1, 1]
-        self.assertEquals(self._get_reducer_output(inputs), ((self.key, 3),))
+        expected = ((self.reduce_key, 3),)
+        self._check_output_complete_tuple(inputs, expected)

--- a/edx/analytics/tasks/tests/test_enrollment_validation.py
+++ b/edx/analytics/tasks/tests/test_enrollment_validation.py
@@ -18,24 +18,21 @@ from edx.analytics.tasks.enrollment_validation import (
     CreateEnrollmentValidationEventsForTodayTask,
 )
 from edx.analytics.tasks.tests import unittest
+from edx.analytics.tasks.tests.map_reduce_mixins import MapperTestMixin, ReducerTestMixin
 from edx.analytics.tasks.tests.opaque_key_mixins import InitializeOpaqueKeysMixin, InitializeLegacyKeysMixin
 from edx.analytics.tasks.util.datetime_util import add_microseconds
 from edx.analytics.tasks.util.event_factory import SyntheticEventFactory
 
 
-class CourseEnrollmentValidationTaskMapTest(InitializeOpaqueKeysMixin, unittest.TestCase):
+class CourseEnrollmentValidationTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMixin, unittest.TestCase):
     """
     Tests to verify that event log parsing by mapper works correctly.
     """
     def setUp(self):
-        self.initialize_ids()
+        self.task_class = CourseEnrollmentValidationTask
+        super(CourseEnrollmentValidationTaskMapTest, self).setUp()
 
-        fake_param = luigi.DateIntervalParameter()
-        self.task = CourseEnrollmentValidationTask(
-            interval=fake_param.parse('2013-12-17'),
-            output_root='/fake/output'
-        )
-        self.task.init_local()
+        self.initialize_ids()
 
         self.user_id = 21
         self.timestamp = "2013-12-17T15:38:32.805444"
@@ -52,6 +49,8 @@ class CourseEnrollmentValidationTaskMapTest(InitializeOpaqueKeysMixin, unittest.
             org_id=self.org_id,
         )
 
+        self.expected_key = (self.course_id, self.user_id)
+
     def _create_event_log_line(self, **kwargs):
         """Create an event log with test values, as a JSON string."""
         return json.dumps(self._create_event_dict(**kwargs))
@@ -66,62 +65,55 @@ class CourseEnrollmentValidationTaskMapTest(InitializeOpaqueKeysMixin, unittest.
         event = self.factory.create_event_dict(event_data, **kwargs)
         return event
 
-    def assert_no_output_for(self, line):
-        """Assert that an input line generates no output."""
-        self.assertEquals(tuple(self.task.mapper(line)), tuple())
-
     def test_non_enrollment_event(self):
         line = 'this is garbage'
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_unparseable_enrollment_event(self):
         line = 'this is garbage but contains edx.course.enrollment'
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_missing_event_type(self):
         event_dict = self._create_event_dict()
         event_dict['old_event_type'] = event_dict['event_type']
         del event_dict['event_type']
         line = json.dumps(event_dict)
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_nonenroll_event_type(self):
         line = self._create_event_log_line(event_type='edx.course.enrollment.unknown')
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_bad_datetime(self):
         line = self._create_event_log_line(time='this is a bogus time')
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_bad_event_data(self):
         line = self._create_event_log_line(event=["not an event"])
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_illegal_course_id(self):
         line = self._create_event_log_line(event={"course_id": ";;;;bad/id/val", "user_id": self.user_id})
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_missing_user_id(self):
         line = self._create_event_log_line(event={"course_id": self.course_id})
-        self.assert_no_output_for(line)
+        self.assert_no_map_output_for(line)
 
     def test_good_enroll_event(self):
         line = self._create_event_log_line()
-        event = tuple(self.task.mapper(line))
-        expected = (((self.course_id, self.user_id), (self.timestamp, ACTIVATED, self.mode, None)),)
-        self.assertEquals(event, expected)
+        expected_value = (self.timestamp, ACTIVATED, self.mode, None)
+        self.assert_single_map_output(line, self.expected_key, expected_value)
 
     def test_good_unenroll_event(self):
         line = self._create_event_log_line(event_type=DEACTIVATED)
-        event = tuple(self.task.mapper(line))
-        expected = (((self.course_id, self.user_id), (self.timestamp, DEACTIVATED, self.mode, None)),)
-        self.assertEquals(event, expected)
+        expected_value = (self.timestamp, DEACTIVATED, self.mode, None)
+        self.assert_single_map_output(line, self.expected_key, expected_value)
 
     def test_good_mode_change_event(self):
         line = self._create_event_log_line(event_type=MODE_CHANGED)
-        event = tuple(self.task.mapper(line))
-        expected = (((self.course_id, self.user_id), (self.timestamp, MODE_CHANGED, self.mode, None)),)
-        self.assertEquals(event, expected)
+        expected_value = (self.timestamp, MODE_CHANGED, self.mode, None)
+        self.assert_single_map_output(line, self.expected_key, expected_value)
 
     def test_good_validation_event(self):
         validation_info = {
@@ -137,9 +129,8 @@ class CourseEnrollmentValidationTaskMapTest(InitializeOpaqueKeysMixin, unittest.
         }
         event_info.update(validation_info)
         line = self._create_event_log_line(event_type=VALIDATED, event=event_info)
-        event = tuple(self.task.mapper(line))
-        expected = (((self.course_id, self.user_id), (self.timestamp, VALIDATED, self.mode, validation_info)),)
-        self.assertEquals(event, expected)
+        expected_value = (self.timestamp, VALIDATED, self.mode, validation_info)
+        self.assert_single_map_output(line, self.expected_key, expected_value)
 
 
 class CourseEnrollmentValidationTaskLegacyMapTest(InitializeLegacyKeysMixin, CourseEnrollmentValidationTaskMapTest):
@@ -147,18 +138,15 @@ class CourseEnrollmentValidationTaskLegacyMapTest(InitializeLegacyKeysMixin, Cou
     pass
 
 
-class BaseCourseEnrollmentValidationTaskReducerTest(unittest.TestCase):
+class BaseCourseEnrollmentValidationTaskReducerTest(ReducerTestMixin, unittest.TestCase):
     """Provide common methods for testing CourseEnrollmentValidationTask reducer."""
 
-    def setUp(self):
-        self.mode = 'honor'
 
-    @property
-    def key(self):
-        """Returns key value to simulate output from mapper to pass to reducer."""
-        user_id = 0
-        course_id = 'foo/bar/baz'
-        return (course_id, user_id)
+    def setUp(self):
+        self.task_class = CourseEnrollmentValidationTask
+        super(BaseCourseEnrollmentValidationTaskReducerTest, self).setUp()
+        self.reduce_key = ('foo/bar/baz', 0)
+        self.mode = 'honor'
 
     def create_task(self, generate_before=True, tuple_output=True, include_nonstate_changes=True,
                     earliest_timestamp=None, expected_validation=None):
@@ -206,15 +194,6 @@ class BaseCourseEnrollmentValidationTaskReducerTest(unittest.TestCase):
         }
         return (timestamp, VALIDATED, mode or self.mode, validation_info)
 
-    def _get_reducer_output(self, values):
-        """Run reducer with provided values hardcoded key."""
-        return tuple(self.task.reducer(self.key, values))
-
-    def check_output(self, inputs, expected):
-        """Compare generated with expected output."""
-        expected_with_key = tuple([(key, self.key + value) for key, value in expected])
-        self.assertEquals(self._get_reducer_output(inputs), expected_with_key)
-
 
 class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTaskReducerTest):
     """
@@ -225,7 +204,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
         self.create_task(generate_before=True)
 
     def test_no_events(self):
-        self.check_output([], tuple())
+        self.assert_no_output([])
 
     def test_missing_single_enrollment(self):
         inputs = [
@@ -237,7 +216,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-04-01T00:00:01.123456', ACTIVATED, "honor", "start => validate(active)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_missing_enroll_unenroll(self):
         inputs = [
@@ -253,7 +232,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-04-01T00:00:01.123457', DEACTIVATED, "honor", "start => validate(inactive)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_single_enrollment(self):
         inputs = [
@@ -261,7 +240,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
             self._activated('2013-04-01T00:00:01.123456'),
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self.assert_no_output(inputs)
 
     def test_single_unenrollment(self):
         inputs = [
@@ -274,7 +253,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-04-01T00:00:01.123456', ACTIVATED, "honor", "start => deactivate",
               '2013-04-01T00:00:01.123456', '2013-05-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_single_unenrollment_without_ms(self):
         inputs = [
@@ -287,7 +266,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-04-01T00:00:01', ACTIVATED, "honor", "start => deactivate",
               '2013-04-01T00:00:01', '2013-05-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_single_unvalidated_unenrollment(self):
         inputs = [
@@ -299,7 +278,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-05-01T00:00:01.123455', ACTIVATED, "honor", "start => deactivate",
               None, '2013-05-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_rollover_unvalidated_unenrollment(self):
         inputs = [
@@ -311,7 +290,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-05-01T00:00:00.999999', ACTIVATED, "honor", "start => deactivate",
               None, '2013-05-01T00:00:01.000000')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_unvalidated_unenrollment_without_ms(self):
         inputs = [
@@ -323,7 +302,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-05-01T00:00:00.999999', ACTIVATED, "honor", "start => deactivate",
               None, '2013-05-01T00:00:01')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_single_enroll_unenroll(self):
         inputs = [
@@ -332,7 +311,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
             self._activated('2013-04-01T00:00:01.123456'),
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self.assert_no_output(inputs)
 
     def test_unenroll_during_dump(self):
         inputs = [
@@ -341,7 +320,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
             self._activated('2013-04-01T00:00:01.123456'),
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self.assert_no_output(inputs)
 
     def test_unenroll_during_dump_reverse(self):
         inputs = [
@@ -350,7 +329,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
             self._validated('2013-09-01T00:00:01.123456', True, '2013-04-01T00:00:01.123456'),
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self.assert_no_output(inputs)
 
     def test_single_unenroll_enroll(self):
         inputs = [
@@ -359,7 +338,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
             self._activated('2013-04-01T00:00:01.123456'),
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self.assert_no_output(inputs)
 
     def test_multiple_validation(self):
         inputs = [
@@ -369,7 +348,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
             self._activated('2013-01-01T00:00:01.123456'),
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self.assert_no_output(inputs)
 
     def test_multiple_validation_without_enroll(self):
         inputs = [
@@ -383,7 +362,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-04-01T00:00:01.123456', ACTIVATED, "honor", "start => validate(active)",
               '2013-04-01T00:00:01.123456', '2013-07-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_enroll_unenroll_with_validations(self):
         inputs = [
@@ -393,7 +372,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
             self._activated('2013-04-01T00:00:01.123456'),
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self.assert_no_output(inputs)
 
     def test_missing_activate_between_validation(self):
         inputs = [
@@ -408,7 +387,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-08-01T00:00:01.123457', ACTIVATED, "honor", "validate(inactive) => validate(active)",
               '2013-08-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_missing_deactivate_between_validation(self):
         inputs = [
@@ -422,7 +401,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-08-01T00:00:01.123457', DEACTIVATED, "honor", "validate(active) => validate(inactive)",
               '2013-08-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_missing_deactivate_from_validation(self):
         inputs = [
@@ -436,7 +415,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-08-01T00:00:01.123457', DEACTIVATED, "honor", "validate(active) => activate",
               '2013-08-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_missing_deactivate_from_activation(self):
         inputs = [
@@ -449,7 +428,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-04-01T00:00:01.123457', DEACTIVATED, "honor", "activate => validate(inactive)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_rollover_deactivate_from_activation(self):
         inputs = [
@@ -462,7 +441,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-04-01T00:00:02.000000', DEACTIVATED, "honor", "activate => validate(inactive)",
               '2013-04-01T00:00:01.999999', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_missing_activate_from_deactivation(self):
         inputs = [
@@ -476,7 +455,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-08-01T00:00:01.123457', ACTIVATED, "honor", "deactivate => validate(active)",
               '2013-08-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_missing_activate_between_deactivation(self):
         inputs = [
@@ -490,7 +469,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-08-01T00:00:01.123457', ACTIVATED, "honor", "deactivate => deactivate",
               '2013-08-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_missing_deactivate_between_activation(self):
         inputs = [
@@ -503,7 +482,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-01-01T00:00:01.123457', DEACTIVATED, "honor", "activate => activate",
               '2013-01-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_missing_activate_from_validation(self):
         inputs = [
@@ -518,7 +497,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
              ('2013-09-01T00:00:01.123457', ACTIVATED, "honor", "validate(inactive) => deactivate",
               '2013-09-01T00:00:01.123456', '2013-10-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_mode_change_via_activate(self):
         inputs = [
@@ -527,7 +506,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
             self._activated('2013-04-01T00:00:01.123456'),
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self.assert_no_output(inputs)
 
     def test_activate_missing_mode_change(self):
         inputs = [
@@ -541,14 +520,14 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
               "activate => validate(active) (honor=>verified)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_missing_initial_mode_change(self):
         inputs = [
             self._activated('2013-04-01T00:00:01.123456', mode='verified'),
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self.assert_no_output(inputs)
 
     def test_activate_duplicate_mode_change(self):
         inputs = [
@@ -556,7 +535,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
             self._activated('2013-04-01T00:00:01.123456', mode='honor'),
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self.assert_no_output(inputs)
 
     def test_activate_with_mode_change(self):
         inputs = [
@@ -565,7 +544,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
             self._activated('2013-04-01T00:00:01.123456', mode='honor'),
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self.assert_no_output(inputs)
 
     def test_validate_with_missing_mode_change(self):
         inputs = [
@@ -580,7 +559,7 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
               "mode_change => validate(active) (verified=>audited)",
               '2013-05-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_activate_with_only_mode_change(self):
         inputs = [
@@ -588,15 +567,14 @@ class CourseEnrollmentValidationTaskReducerTest(BaseCourseEnrollmentValidationTa
             self._activated('2013-04-01T00:00:01.123456', mode='honor'),
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self.assert_no_output(inputs)
 
     def test_only_mode_change(self):
         inputs = [
             self._mode_changed('2013-05-01T00:00:01.123456', mode='verified'),
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
-
+        self.assert_no_output(inputs)
 
 class CourseEnrollmentValidationTaskEventReducerTest(BaseCourseEnrollmentValidationTaskReducerTest):
     """
@@ -607,6 +585,9 @@ class CourseEnrollmentValidationTaskEventReducerTest(BaseCourseEnrollmentValidat
         self.create_task(tuple_output=False)
 
     def test_missing_single_enrollment(self):
+        """
+        Tests the event formatting, so the assertions are done bit-by-bit rather than with the tuple check of output.
+        """
         inputs = [
             self._validated('2013-09-01T00:00:01.123456', True, '2013-04-01T00:00:01.123456'),
             # missing activation (4/1)
@@ -635,7 +616,7 @@ class EarliestTimestampTaskReducerTest(BaseCourseEnrollmentValidationTaskReducer
         self.create_task(earliest_timestamp="2013-01-01T11")
 
     def test_no_events(self):
-        self.check_output([], tuple())
+        self.assert_no_output([])
 
     def test_missing_single_enrollment(self):
         inputs = [
@@ -647,7 +628,7 @@ class EarliestTimestampTaskReducerTest(BaseCourseEnrollmentValidationTaskReducer
              ('2013-04-01T00:00:01.123456', ACTIVATED, "honor", "start => validate(active)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_missing_early_single_enrollment(self):
         inputs = [
@@ -659,7 +640,7 @@ class EarliestTimestampTaskReducerTest(BaseCourseEnrollmentValidationTaskReducer
              ('2013-01-01T11:00:00.000000', ACTIVATED, "honor", "start => validate(active)",
               '2012-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
 
 class ExpectedValidationTaskReducerTest(BaseCourseEnrollmentValidationTaskReducerTest):
@@ -671,7 +652,7 @@ class ExpectedValidationTaskReducerTest(BaseCourseEnrollmentValidationTaskReduce
         self.create_task(expected_validation="2014-10-01T11")
 
     def test_no_events(self):
-        self.check_output([], tuple())
+        self.assert_no_output([])
 
     def test_missing_validation_from_activation(self):
         inputs = [
@@ -683,7 +664,7 @@ class ExpectedValidationTaskReducerTest(BaseCourseEnrollmentValidationTaskReduce
              ('2013-04-01T00:00:01.123457', DEACTIVATED, "honor", "activate => missing",
               '2013-04-01T00:00:01.123456', '2014-10-01T11:00:00.000000')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_missing_validation_from_deactivation(self):
         inputs = [
@@ -695,7 +676,7 @@ class ExpectedValidationTaskReducerTest(BaseCourseEnrollmentValidationTaskReduce
              ('2013-09-01T00:00:01.123457', DEACTIVATED, "honor", "deactivate => missing",
               '2013-09-01T00:00:01.123456', '2014-10-01T11:00:00.000000')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
 
 class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskReducerTest):
@@ -707,7 +688,7 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
         self.create_task(generate_before=False)
 
     def test_no_events(self):
-        self.check_output([], tuple())
+        self.assert_no_output([])
 
     def test_missing_single_enrollment(self):
         inputs = [
@@ -719,7 +700,7 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
              ('2013-04-01T00:00:01.123456', ACTIVATED, "honor", "start => validate(active)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_missing_early_single_enrollment(self):
         inputs = [
@@ -727,7 +708,7 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
             # missing activation (4/1/12)
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self._check_output_tuple_with_key(inputs, tuple())
 
     def test_single_deactivation(self):
         inputs = [
@@ -735,7 +716,7 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
             # missing activation
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self._check_output_tuple_with_key(inputs, tuple())
 
     def test_missing_deactivate_from_activation(self):
         inputs = [
@@ -748,7 +729,7 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
              ('2013-04-01T00:00:01.123457', DEACTIVATED, "honor", "activate => validate(inactive)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_missing_activate_from_validation(self):
         inputs = [
@@ -761,7 +742,7 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
              ('2013-04-01T00:00:01.123456', ACTIVATED, "honor", "start => deactivate",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_missing_early_activate_from_validation(self):
         inputs = [
@@ -770,7 +751,7 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
             # missing activation (4/1/12)
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self.assert_no_output(inputs)
 
     def test_missing_activate_after_validation(self):
         inputs = [
@@ -785,7 +766,7 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
              ('2013-09-01T00:00:01.123457', ACTIVATED, "honor", "validate(inactive) => deactivate",
               '2013-09-01T00:00:01.123456', '2013-10-01T00:00:01.123456')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
     def test_unenroll_during_dump(self):
         inputs = [
@@ -797,7 +778,7 @@ class GenerateBeforeDisabledTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
              ('2013-04-01T00:00:01.123456', ACTIVATED, "honor", "start => validate(active)",
               '2013-04-01T00:00:01.123456', '2013-09-01T00:00:00.123455')),
         )
-        self.check_output(inputs, expected)
+        self._check_output_tuple_with_key(inputs, expected)
 
 
 class ExcludeNonstateChangesTaskReducerTest(BaseCourseEnrollmentValidationTaskReducerTest):
@@ -818,7 +799,7 @@ class ExcludeNonstateChangesTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
         self.create_task(generate_before=False, include_nonstate_changes=False)
 
     def test_no_events(self):
-        self.check_output([], tuple())
+        self.assert_no_output([])
 
     def test_missing_deactivate_between_activation(self):
         inputs = [
@@ -827,7 +808,7 @@ class ExcludeNonstateChangesTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
             self._activated('2013-01-01T00:00:01.123456'),
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self.assert_no_output(inputs)
 
     def test_missing_deactivate_before_activation(self):
         inputs = [
@@ -837,7 +818,7 @@ class ExcludeNonstateChangesTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
             self._activated('2013-04-01T00:00:01.123456'),
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self.assert_no_output(inputs)
 
     def test_missing_activate_between_deactivation(self):
         inputs = [
@@ -847,7 +828,7 @@ class ExcludeNonstateChangesTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
             self._activated('2013-01-01T00:00:01.123456'),
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self.assert_no_output(inputs)
 
     def test_missing_activate_before_deactivation(self):
         inputs = [
@@ -858,7 +839,7 @@ class ExcludeNonstateChangesTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
             self._activated('2013-04-01T00:00:01.123456'),
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self.assert_no_output(inputs)
 
     def test_single_deactivation_validation(self):
         inputs = [
@@ -866,7 +847,7 @@ class ExcludeNonstateChangesTaskReducerTest(BaseCourseEnrollmentValidationTaskRe
             # missing activation and deactivation?
         ]
         # expect no event.
-        self.check_output(inputs, tuple())
+        self.assert_no_output(inputs)
 
 
 class CreateAllEnrollmentValidationEventsTest(unittest.TestCase):

--- a/edx/analytics/tasks/tests/test_overall_events.py
+++ b/edx/analytics/tasks/tests/test_overall_events.py
@@ -2,6 +2,7 @@
 
 import sys
 import json
+from edx.analytics.tasks.tests.map_reduce_mixins import MapperTestMixin, ReducerTestMixin
 import luigi
 
 from edx.analytics.tasks.tests import unittest
@@ -11,67 +12,60 @@ from edx.analytics.tasks.tests.opaque_key_mixins import InitializeOpaqueKeysMixi
 from StringIO import StringIO
 
 
-class TotalEventsTaskMapTest(InitializeOpaqueKeysMixin, unittest.TestCase):
+class TotalEventsTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMixin, unittest.TestCase):
     """Ensure events of various flavors are counted"""
 
-    def setUp(self):
+    DATE = '2013-12-17'
 
-        fake_param = luigi.DateIntervalParameter()
-        self.task = TotalEventsDailyTask(
-            interval=fake_param.parse('2014-12-05'),
-            output_root='/fake/output'
-        )
+    def setUp(self):
+        self.task_class = TotalEventsDailyTask
+        super(TotalEventsTaskMapTest, self).setUp()
 
         self.initialize_ids()
         self.task.init_local()
 
         self.event_type = "edx.course.enrollment.activated"
-        self.timestamp = "2014-12-05T22:13:09.691008+00:00"
-        self.user_id = 5
+        self.timestamp = "{}T15:38:32.805444".format(self.DATE)
+        self.user_id = 10
 
-    def _create_event_log_line(self, **kwargs):
-        """Create an event log with test values, as a JSON string."""
-        return json.dumps(self._create_event_dict(**kwargs))
+        self.event_templates = {
+            'event': {
+                "username": "test_user",
+                "host": "test_host",
+                "session": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "event_source": "server",
+                "name": self.event_type,
+                "event_type": self.event_type,
+                "context": {
+                    "course_id": self.course_id,
+                    "org_id": self.org_id,
+                    "user_id": self.user_id,
+                },
+                "time": "{0}+00:00".format(self.timestamp),
+                "ip": "127.0.0.1",
+                "event": {
+                    "course_id": self.course_id,
+                    "user_id": self.user_id,
+                    "mode": "honor",
+                },
+                "agent": "blah, blah, blah",
+                "page": None
+            }
 
-    def _create_event_dict(self, **kwargs):
-        """Create an event log with test values, as a dict."""
-        # Define default values for event log entry.
-        event_dict = {
-            "username": "test_user",
-            "host": "test_host",
-            "session": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-            "event_source": "server",
-            "name": self.event_type,
-            "event_type": self.event_type,
-            "context": {
-                "course_id": self.course_id,
-                "org_id": self.org_id,
-                "user_id": self.user_id,
-            },
-            "time": "{0}+00:00".format(self.timestamp),
-            "ip": "127.0.0.1",
-            "event": {
-                "course_id": self.course_id,
-                "user_id": self.user_id,
-                "mode": "honor",
-            },
-            "agent": "blah, blah, blah",
-            "page": None
         }
-        event_dict.update(**kwargs)
-        return event_dict
+        self.default_event_template = 'event'
 
     def test_explicit_event(self):
-        line = self._create_event_log_line(user_id="")
-        self.assertEquals(tuple(self.task.mapper(line)), (('2014-12-05', 1), ))
+        line = self.create_event_log_line(user_id="")
+        self.assert_single_map_output(line, self.DATE, 1)
 
     def test_no_timestamp(self):
-        line = self._create_event_log_line(timestamp="")
-        self.assertEquals(tuple(self.task.mapper(line)), (('2014-12-05', 1), ))
+        line = self.create_event_log_line(timestamp="")
+        self.assert_single_map_output(line, self.DATE, 1)
 
     def test_bad_event(self):
         line = "bad event"
-        self.assertEquals(tuple(self.task.mapper(line)), tuple())
+        self.assert_no_map_output_for(line)
 
     def test_event_no_ids(self):
         """
@@ -79,8 +73,8 @@ class TotalEventsTaskMapTest(InitializeOpaqueKeysMixin, unittest.TestCase):
         because of their contexts. This test ensures these events are still counted.
         """
         self.empty_ids()
-        line = self._create_event_log_line()
-        self.assertEquals(tuple(self.task.mapper(line)), (('2014-12-05', 1), ))
+        line = self.create_event_log_line()
+        self.assert_single_map_output(line, self.DATE, 1)
 
     def test_implicit_event(self):
         event = {
@@ -94,7 +88,7 @@ class TotalEventsTaskMapTest(InitializeOpaqueKeysMixin, unittest.TestCase):
                 "course_id": "",
                 "path": "/jsi18n/"
             },
-            "time": "2014-12-05T22:11:29.689805+00:00",
+            "time": "{}T22:11:29.689805+00:00".format(self.DATE),
             "ip": "10.0.2.2",
             "event": "{\"POST\": {}, \"GET\": {}}",
             "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) "
@@ -102,10 +96,10 @@ class TotalEventsTaskMapTest(InitializeOpaqueKeysMixin, unittest.TestCase):
             "page": "null"
         }
         line = json.dumps(event)
-        self.assertEquals(tuple(self.task.mapper(line)), (('2014-12-05', 1), ))
+        self.assert_single_map_output(line, self.DATE, 1)
 
     def test_no_time_element(self):
-        event_line = self._create_event_dict()
+        event_line = self.create_event_dict()
         del event_line["time"]
         line = json.dumps(event_line)
         # When the time element is missing, luigi will print an error to stderr.
@@ -113,35 +107,26 @@ class TotalEventsTaskMapTest(InitializeOpaqueKeysMixin, unittest.TestCase):
         # count the event.
         test_stderr = StringIO()
         sys.stderr = test_stderr
-        self.assertEquals(tuple(self.task.mapper(line)), tuple())
+        self.assert_no_map_output_for(line)
         test_stderr = test_stderr.getvalue().strip()
         self.assertEquals(test_stderr, 'reporter:counter:Event,Missing Time Field,1')
 
 
-class TotalEventsTaskReducerTest(unittest.TestCase):
+class TotalEventsTaskReducerTest(ReducerTestMixin, unittest.TestCase):
     """Ensure counts are aggregated"""
 
     def setUp(self):
-        self.interval = '2014-12-17'
-        fake_param = luigi.DateIntervalParameter()
-        self.task = TotalEventsDailyTask(
-            interval=fake_param.parse(self.interval),
-            output_root="/fake/output"
-        )
-        self.key = '2014-12-17T00:00:01'
+        self.task_class = TotalEventsDailyTask
+        super(TotalEventsTaskReducerTest, self).setUp()
 
-    def _check_output(self, key, values, expected):
-        """Compare generated with expected output."""
-        self.assertEquals(tuple(self.task.reducer(key, values)), expected)
+        self.reduce_key = '2013-12-17T00:00:01'
 
     def test_one_event_count(self):
-        key = '2014-12-17T00:00:01'
-        values = [1, ]
-        expected = ((key, 1), )
-        self._check_output(key, values, expected)
+        inputs = [1, ]
+        expected = ((self.reduce_key, 1), )
+        self._check_output_complete_tuple(inputs, expected)
 
     def test_multiple_events_same_day(self):
-        key = '2014-12-17T00:00:01'
-        values = [1, 1]
-        expected = ((key, 2), )
-        self._check_output(key, values, expected)
+        inputs = [1, 1]
+        expected = ((self.reduce_key, 2), )
+        self._check_output_complete_tuple(inputs, expected)

--- a/edx/analytics/tasks/tests/test_student_engagement.py
+++ b/edx/analytics/tasks/tests/test_student_engagement.py
@@ -261,7 +261,7 @@ class StudentEngagementTaskReducerTest(ReducerTestMixin, unittest.TestCase):
         inputs = [
             ('', '/foo', '{}', self.DATE)
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             self.WAS_ACTIVE_COLUMN: 1,
             self.PROBLEMS_ATTEMPTED_COLUMN: 0,
             self.PROBLEM_ATTEMPTS_COLUMN: 0,
@@ -278,7 +278,7 @@ class StudentEngagementTaskReducerTest(ReducerTestMixin, unittest.TestCase):
         inputs = [
             ('i4x://foo/bar/baz', 'problem_check', json.dumps({'correct': True}), self.DATE)
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             self.WAS_ACTIVE_COLUMN: 1,
             self.PROBLEMS_ATTEMPTED_COLUMN: 1,
             self.PROBLEM_ATTEMPTS_COLUMN: 1,
@@ -289,7 +289,7 @@ class StudentEngagementTaskReducerTest(ReducerTestMixin, unittest.TestCase):
         inputs = [
             ('i4x://foo/bar/baz', 'problem_check', '{}', self.DATE)
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             self.WAS_ACTIVE_COLUMN: 1,
             self.PROBLEMS_ATTEMPTED_COLUMN: 1,
             self.PROBLEM_ATTEMPTS_COLUMN: 1,
@@ -302,7 +302,7 @@ class StudentEngagementTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('i4x://foo/bar/baz', 'problem_check', json.dumps({'correct': True}), self.DATE),
             ('i4x://foo/bar/baz', 'problem_check', '{}', self.DATE)
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             self.WAS_ACTIVE_COLUMN: 1,
             self.PROBLEMS_ATTEMPTED_COLUMN: 1,
             self.PROBLEM_ATTEMPTS_COLUMN: 3,
@@ -315,7 +315,7 @@ class StudentEngagementTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('i4x://foo/bar/baz2', 'problem_check', json.dumps({'correct': True}), self.DATE),
             ('i4x://foo/bar/baz', 'problem_check', '{}', self.DATE)
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             self.WAS_ACTIVE_COLUMN: 1,
             self.PROBLEMS_ATTEMPTED_COLUMN: 2,
             self.PROBLEM_ATTEMPTS_COLUMN: 3,
@@ -326,7 +326,7 @@ class StudentEngagementTaskReducerTest(ReducerTestMixin, unittest.TestCase):
         inputs = [
             ('foobarbaz', 'play_video', '{}', self.DATE),
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             self.WAS_ACTIVE_COLUMN: 1,
             self.VIDEOS_PLAYED_COLUMN: 1,
         })
@@ -337,7 +337,7 @@ class StudentEngagementTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('foobarbaz', 'play_video', '{}', self.DATE),
             ('foobarbaz', 'play_video', '{}', self.DATE),
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             self.WAS_ACTIVE_COLUMN: 1,
             self.VIDEOS_PLAYED_COLUMN: 1,
         })
@@ -347,7 +347,7 @@ class StudentEngagementTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('foobarbaz', 'pause_video', '{}', self.DATE),
             ('foobarbaz2', 'seek_video', '{}', self.DATE),
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             self.WAS_ACTIVE_COLUMN: 1,
             self.VIDEOS_PLAYED_COLUMN: 0,
         })
@@ -363,7 +363,7 @@ class StudentEngagementTaskReducerTest(ReducerTestMixin, unittest.TestCase):
         inputs = [
             ('', event_type, '{}', self.DATE),
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             self.WAS_ACTIVE_COLUMN: 1,
             column_num: 1,
         })
@@ -380,7 +380,7 @@ class StudentEngagementTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('', event_type, '{}', self.DATE),
             ('', event_type, '{}', self.DATE),
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             column_num: 2,
         })
 
@@ -391,7 +391,7 @@ class StudentEngagementTaskReducerTest(ReducerTestMixin, unittest.TestCase):
                 'timestamp': '2014-12-01T00:00:00.000000',
             }), self.DATE),
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             self.LAST_SUBSECTION_COLUMN: 'foobar',
         })
 
@@ -410,6 +410,6 @@ class StudentEngagementTaskReducerTest(ReducerTestMixin, unittest.TestCase):
                 'timestamp': '2014-12-01T00:00:03.000000',
             }), self.DATE),
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             self.LAST_SUBSECTION_COLUMN: 'finalpath',
         })

--- a/edx/analytics/tasks/tests/test_video.py
+++ b/edx/analytics/tasks/tests/test_video.py
@@ -404,7 +404,7 @@ class UserVideoViewingTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('2013-12-17T00:00:00.00000Z', 'play_video', 0, None, 'html5'),
             ('2013-12-17T00:00:03.00000Z', 'pause_video', 3, None, None),
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             ViewingColumns.USERNAME: self.USERNAME,
             ViewingColumns.COURSE_ID: self.COURSE_ID,
             ViewingColumns.VIDEO_MODULE_ID: self.VIDEO_MODULE_ID,
@@ -420,7 +420,7 @@ class UserVideoViewingTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('2013-12-17T00:00:03.00000Z', 'pause_video', 3, None, None),
             ('2013-12-17T00:00:00.00000Z', 'play_video', 0, None, 'html5'),
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             ViewingColumns.START_TIMESTAMP: '2013-12-17T00:00:00+00:00',
             ViewingColumns.START_OFFSET: 0,
             ViewingColumns.END_OFFSET: 3,
@@ -432,7 +432,7 @@ class UserVideoViewingTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('2013-12-17T00:00:00.00000Z', 'play_video', 0, None, 'html5'),
             ('2013-12-17T00:00:03.00000Z', 'pause_video', eval('1.2e+2'), None, None),
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             ViewingColumns.END_OFFSET: 120
         })
 
@@ -443,7 +443,7 @@ class UserVideoViewingTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('2013-12-17T00:00:07.00000Z', 'play_video', 0, None, 'html5'),
             ('2013-12-17T00:00:12.00000Z', 'stop_video', 5, None, None),
         ]
-        self._check_output(inputs, [
+        self._check_output_by_key(inputs, [
             {
                 ViewingColumns.START_TIMESTAMP: '2013-12-17T00:00:00+00:00',
                 ViewingColumns.START_OFFSET: 0,
@@ -465,7 +465,7 @@ class UserVideoViewingTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('2013-12-17T00:00:03.10000Z', 'play_video', 2, None, 'html5'),
             ('2013-12-17T00:00:06.00000Z', 'pause_video', 5, None, None),
         ]
-        self._check_output(inputs, [
+        self._check_output_by_key(inputs, [
             {
                 ViewingColumns.START_TIMESTAMP: '2013-12-17T00:00:00+00:00',
                 ViewingColumns.START_OFFSET: 0,
@@ -493,7 +493,7 @@ class UserVideoViewingTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('2013-12-17T00:00:03.10000Z', 'play_video', 3, None, 'html5'),
             ('2013-12-17T00:00:06.00000Z', 'pause_video', 11, None, None),
         ]
-        self._check_output(inputs, [
+        self._check_output_by_key(inputs, [
             {
                 ViewingColumns.START_TIMESTAMP: '2013-12-17T00:00:00+00:00',
                 ViewingColumns.START_OFFSET: 0,
@@ -520,7 +520,7 @@ class UserVideoViewingTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('2013-12-17T00:00:00.60000Z', 'play_video', 6, None, 'html5'),
             ('2013-12-17T00:00:03.00000Z', 'pause_video', 9, None, None),
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             ViewingColumns.START_TIMESTAMP: '2013-12-17T00:00:00.600000+00:00',
             ViewingColumns.START_OFFSET: 6,
             ViewingColumns.END_OFFSET: 9,
@@ -534,7 +534,7 @@ class UserVideoViewingTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('2013-12-17T00:00:06.00000Z', 'pause_video', 3, None, None),
             ('2013-12-17T00:00:07.00000Z', 'pause_video', 1, None, None),
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             ViewingColumns.START_TIMESTAMP: '2013-12-17T00:00:03+00:00',
             ViewingColumns.START_OFFSET: 0,
             ViewingColumns.END_OFFSET: 3,
@@ -547,7 +547,7 @@ class UserVideoViewingTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('2013-12-17T00:00:06.00000Z', 'pause_video', 3, None, None),
             ('2013-12-17T00:00:07.00000Z', 'pause_video', 1, None, None),
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             ViewingColumns.START_TIMESTAMP: '2013-12-17T00:00:03+00:00',
             ViewingColumns.START_OFFSET: 0,
             ViewingColumns.END_OFFSET: 3,
@@ -565,7 +565,7 @@ class UserVideoViewingTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('2013-12-17T00:00:05.00000Z', '/foobar', None, None, None),
             ('2013-12-17T00:00:06.00000Z', 'pause_video', 3, None, None),
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             ViewingColumns.START_TIMESTAMP: '2013-12-17T00:00:03+00:00',
             ViewingColumns.START_OFFSET: 0,
             ViewingColumns.END_OFFSET: 3,
@@ -591,7 +591,7 @@ class UserVideoViewingTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('2013-12-17T00:00:00.00000Z', 'play_video', 0, None, '9bZkp7q19f0'),
             ('2013-12-17T00:00:03.00000Z', 'pause_video', 3, None, None),
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             ViewingColumns.START_TIMESTAMP: '2013-12-17T00:00:00+00:00',
             ViewingColumns.START_OFFSET: 0,
             ViewingColumns.END_OFFSET: 3,
@@ -649,7 +649,7 @@ class UserVideoViewingTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('2013-12-17T00:00:00.00000Z', 'play_video', 0, None, '9bZkp7q19f0'),
             ('2013-12-17T00:00:03.00000Z', 'pause_video', 62.9, None, None),
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             ViewingColumns.START_TIMESTAMP: '2013-12-17T00:00:00+00:00',
             ViewingColumns.START_OFFSET: 0,
             ViewingColumns.END_OFFSET: 62.9,
@@ -668,7 +668,7 @@ class UserVideoViewingTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('2013-12-17T00:00:00.00000Z', 'play_video', 0, None, '9bZkp7q19f0'),
             ('2013-12-17T00:00:03.00000Z', 'pause_video', 3, None, None),
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             ViewingColumns.START_TIMESTAMP: '2013-12-17T00:00:00+00:00',
             ViewingColumns.START_OFFSET: 0,
             ViewingColumns.END_OFFSET: 3,
@@ -682,7 +682,7 @@ class UserVideoViewingTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('2013-12-17T00:00:00.00000Z', 'play_video', 0, None, '9bZkp7q19f0'),
             ('2013-12-17T00:00:03.00000Z', 'pause_video', 3, None, None),
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             ViewingColumns.START_TIMESTAMP: '2013-12-17T00:00:00+00:00',
             ViewingColumns.START_OFFSET: 0,
             ViewingColumns.END_OFFSET: 3,
@@ -703,7 +703,7 @@ class UserVideoViewingTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('2013-12-17T00:00:00.00000Z', 'play_video', 0, None, '9bZkp7q19f0'),
             ('2013-12-17T00:00:03.00000Z', 'pause_video', 3, None, None),
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             ViewingColumns.START_TIMESTAMP: '2013-12-17T00:00:00+00:00',
             ViewingColumns.START_OFFSET: 0,
             ViewingColumns.END_OFFSET: 3,
@@ -766,7 +766,7 @@ class VideoUsageTaskReducerTest(ReducerTestMixin, unittest.TestCase):
         inputs = [
             ('foo', 0, 4.99, VIDEO_UNKNOWN_DURATION),
         ]
-        self._check_output(inputs, {
+        self._check_output_by_key(inputs, {
             UsageColumns.PIPELINE_VIDEO_ID: self.COURSE_ID + '|' + self.VIDEO_MODULE_ID,
             UsageColumns.COURSE_ID: self.COURSE_ID,
             UsageColumns.VIDEO_MODULE_ID: self.VIDEO_MODULE_ID,
@@ -784,7 +784,7 @@ class VideoUsageTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('foo', 0, 4.99, VIDEO_UNKNOWN_DURATION),
             ('foo', 5, 5.2, VIDEO_UNKNOWN_DURATION),
         ]
-        self._check_output(inputs, [
+        self._check_output_by_key(inputs, [
             {
                 UsageColumns.SEGMENT: 0,
                 UsageColumns.USERS_VIEWED: 1,
@@ -806,7 +806,7 @@ class VideoUsageTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('foo', 0, 4.6, VIDEO_UNKNOWN_DURATION),
             ('foo', 4.6, 4.9, VIDEO_UNKNOWN_DURATION),
         ]
-        self._check_output(inputs, [
+        self._check_output_by_key(inputs, [
             {
                 UsageColumns.SEGMENT: 0,
                 UsageColumns.USERS_VIEWED: 1,
@@ -819,7 +819,7 @@ class VideoUsageTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('foo', 0, 4.99, VIDEO_UNKNOWN_DURATION),
             ('foo', 4.8, 5.2, VIDEO_UNKNOWN_DURATION),
         ]
-        self._check_output(inputs, [
+        self._check_output_by_key(inputs, [
             {
                 UsageColumns.SEGMENT: 0,
                 UsageColumns.USERS_VIEWED: 1,
@@ -836,7 +836,7 @@ class VideoUsageTaskReducerTest(ReducerTestMixin, unittest.TestCase):
         inputs = [
             ('foo', 0, 10.2, VIDEO_UNKNOWN_DURATION),
         ]
-        self._check_output(inputs, [
+        self._check_output_by_key(inputs, [
             {
                 UsageColumns.SEGMENT: 0,
                 UsageColumns.USERS_VIEWED: 1,
@@ -860,7 +860,7 @@ class VideoUsageTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('foo2', 4.8, 5.2, VIDEO_UNKNOWN_DURATION),
             ('foo2', 4.2, 10.2, VIDEO_UNKNOWN_DURATION),
         ]
-        self._check_output(inputs, [
+        self._check_output_by_key(inputs, [
             {
                 UsageColumns.SEGMENT: 0,
                 UsageColumns.USERS_VIEWED: 2,
@@ -896,7 +896,7 @@ class VideoUsageTaskReducerTest(ReducerTestMixin, unittest.TestCase):
 
         # Note that the start and end counts are denormalized into all results, so they should have an
         # identical value in every record. Also note that the middle records are ignored here.
-        self._check_output(inputs, [
+        self._check_output_by_key(inputs, [
             {
                 UsageColumns.VIDEO_DURATION: '\\N',
                 UsageColumns.USERS_AT_START: 2,
@@ -939,7 +939,7 @@ class VideoUsageTaskReducerTest(ReducerTestMixin, unittest.TestCase):
 
         # Note that the start and end counts are denormalized into all results, so they should have an
         # identical value in every record.
-        self._check_output(inputs, [
+        self._check_output_by_key(inputs, [
             {
                 UsageColumns.USERS_AT_START: 2,
                 UsageColumns.USERS_AT_END: 3,
@@ -963,7 +963,7 @@ class VideoUsageTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('foo', 16, 19, 40),
         ]
 
-        self._check_output(inputs, [
+        self._check_output_by_key(inputs, [
             # Note that segment 0 is omitted since we didn't see any activity there
             {
                 UsageColumns.SEGMENT: 1,
@@ -984,7 +984,7 @@ class VideoUsageTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('foo', 0, 1, 10),
             ('foo', 0, 1, 50),
         ]
-        self._check_output(inputs, [
+        self._check_output_by_key(inputs, [
             {
                 UsageColumns.VIDEO_DURATION: 50,
                 UsageColumns.USERS_AT_END: 0,
@@ -996,7 +996,7 @@ class VideoUsageTaskReducerTest(ReducerTestMixin, unittest.TestCase):
             ('foo', 0, 1, VIDEO_UNKNOWN_DURATION),
             ('foo', 0, 1, 50),
         ]
-        self._check_output(inputs, [
+        self._check_output_by_key(inputs, [
             {
                 UsageColumns.VIDEO_DURATION: '\\N',
                 UsageColumns.USERS_AT_END: 1,
@@ -1007,7 +1007,7 @@ class VideoUsageTaskReducerTest(ReducerTestMixin, unittest.TestCase):
         inputs = [
             ('foo', 6, 8, 9.2),
         ]
-        self._check_output(inputs, [
+        self._check_output_by_key(inputs, [
             {
                 UsageColumns.VIDEO_DURATION: 9,
                 UsageColumns.USERS_AT_END: 1,


### PR DESCRIPTION
updated -- the old PR was listed as an OSPR

Generalized the mixins in tasks/tests/map_reduce_mixins.py, which initially had only refactored video and student engagement tasks, to cover almost all other tasks (i.e. all but those tested in test_enrollment_validation.py or test_answer_dist.py, which have more complicated event dictionary formats).

Equipped the mapper and reducer test mixins with additional methods to check outputs depending on the needs of particular subclasses, and in those subclasses defined the _check_output methods in terms of the general ones given in the mixins (except in test_answer_dist.py, which had a fairly specialized _check_output method).

Modified the individual test cases to be subclasses of the mixins and use mixin methods rather than repeating the same code (e.g. the code for checking that no mapper output is produced or the code for getting reducer output).

Refactors were aimed at

1) reducing the presence of copy-pasted methods and blocks of code to allow for increased readiness for change

2) providing a clearer, more task-agnostic set of mixins for future test development. In particular, the mixins had setUp and reducer output check methods specific to the student_engagement and video tests, which failed to generalize nicely to the majority of our other test classes (which, for example, had to specify parameters other than interval and output_root in their init methods).

@jab5569 @brianhw @mulby
