### PR TITLE
Use config_path instead of deprecated default_from_config kwarg

### DIFF
--- a/edx/analytics/tasks/calendar_task.py
+++ b/edx/analytics/tasks/calendar_task.py
@@ -22,7 +22,7 @@ class CalendarDownstreamMixin(OverwriteOutputMixin):
     """The parameters needed to generate a complete calendar."""
 
     interval = luigi.DateIntervalParameter(
-        default_from_config={'section': 'calendar', 'name': 'interval'}
+        config_path={'section': 'calendar', 'name': 'interval'}
     )
 
 

--- a/edx/analytics/tasks/course_catalog.py
+++ b/edx/analytics/tasks/course_catalog.py
@@ -23,7 +23,7 @@ class PullCatalogMixin(OverwriteOutputMixin, WarehouseMixin):
     """Define common parameters for the course catalog API pull and downstream tasks."""
 
     run_date = luigi.DateParameter(default=datetime.datetime.utcnow().date())
-    catalog_path = luigi.Parameter(default_from_config={'section': 'course-catalog', 'name': 'catalog_path'})
+    catalog_path = luigi.Parameter(config_path={'section': 'course-catalog', 'name': 'catalog_path'})
 
 
 class DailyPullCatalogTask(PullCatalogMixin, luigi.Task):

--- a/edx/analytics/tasks/course_enroll.py
+++ b/edx/analytics/tasks/course_enroll.py
@@ -208,7 +208,7 @@ class CourseEnrollmentEventsPerDay(
         MapReduceJobTask):
     """Calculates daily change in enrollment for a user in a course, given raw event log input."""
     # input_format overwrites the default value of none from MapReduceJobTaskMixin
-    input_format = luigi.Parameter(default_from_config={'section': 'manifest', 'name': 'input_format'})
+    input_format = luigi.Parameter(config_path={'section': 'manifest', 'name': 'input_format'})
 
     def requires(self):
         return PathSetTask(self.src, self.include, self.manifest)

--- a/edx/analytics/tasks/database_exports.py
+++ b/edx/analytics/tasks/database_exports.py
@@ -126,7 +126,7 @@ class StudentModulePerCourseAfterImportWorkflow(StudentModulePerCourseTask):
 
     """
     credentials = luigi.Parameter(
-        default_from_config={'section': 'database-import', 'name': 'credentials'}
+        config_path={'section': 'database-import', 'name': 'credentials'}
     )
     num_mappers = luigi.Parameter(default=None, significant=False)  # TODO: move to config
     where = luigi.Parameter(default=None)

--- a/edx/analytics/tasks/database_imports.py
+++ b/edx/analytics/tasks/database_imports.py
@@ -38,10 +38,10 @@ class DatabaseImportMixin(object):
         }
     """
     destination = luigi.Parameter(
-        default_from_config={'section': 'database-import', 'name': 'destination'}
+        config_path={'section': 'database-import', 'name': 'destination'}
     )
     credentials = luigi.Parameter(
-        default_from_config={'section': 'database-import', 'name': 'credentials'}
+        config_path={'section': 'database-import', 'name': 'credentials'}
     )
     import_date = luigi.DateParameter(default=None)
 

--- a/edx/analytics/tasks/enrollment_validation.py
+++ b/edx/analytics/tasks/enrollment_validation.py
@@ -884,10 +884,10 @@ class EnrollmentValidationWorkflow(CourseEnrollmentValidationPerDateTask):
     """
 
     validation_root = luigi.Parameter(
-        default_from_config={'section': 'enrollment-validation', 'name': 'validation_root'}
+        config_path={'section': 'enrollment-validation', 'name': 'validation_root'}
     )
     validation_pattern = luigi.Parameter(
-        default_from_config={'section': 'enrollment-validation', 'name': 'validation_pattern'}
+        config_path={'section': 'enrollment-validation', 'name': 'validation_pattern'}
     )
     credentials = luigi.Parameter(default=None)
 

--- a/edx/analytics/tasks/enrollments.py
+++ b/edx/analytics/tasks/enrollments.py
@@ -266,7 +266,7 @@ class CourseEnrollmentTableDownstreamMixin(WarehouseMixin, EventLogSelectionDown
 
     # Define optional parameters, to be used if 'interval' is not defined.
     interval_start = luigi.DateParameter(
-        default_from_config={'section': 'enrollments', 'name': 'interval_start'},
+        config_path={'section': 'enrollments', 'name': 'interval_start'},
         significant=False,
     )
     interval_end = luigi.DateParameter(default=datetime.datetime.utcnow().date(), significant=False)

--- a/edx/analytics/tasks/event_exports.py
+++ b/edx/analytics/tasks/event_exports.py
@@ -42,25 +42,25 @@ class EventExportTask(EventLogSelectionMixin, MultiOutputMapReduceJobTask):
     """
 
     output_root = luigi.Parameter(
-        default_from_config={'section': 'event-export', 'name': 'output_root'}
+        config_path={'section': 'event-export', 'name': 'output_root'}
     )
     config = luigi.Parameter(
-        default_from_config={'section': 'event-export', 'name': 'config'}
+        config_path={'section': 'event-export', 'name': 'config'}
     )
     org_id = luigi.Parameter(is_list=True, default=[])
 
     gpg_key_dir = luigi.Parameter(
-        default_from_config={'section': 'event-export', 'name': 'gpg_key_dir'}
+        config_path={'section': 'event-export', 'name': 'gpg_key_dir'}
     )
     gpg_master_key = luigi.Parameter(
-        default_from_config={'section': 'event-export', 'name': 'gpg_master_key'}
+        config_path={'section': 'event-export', 'name': 'gpg_master_key'}
     )
     environment = luigi.Parameter(
-        default_from_config={'section': 'event-export', 'name': 'environment'}
+        config_path={'section': 'event-export', 'name': 'environment'}
     )
 
     required_path_text = luigi.Parameter(
-        default_from_config={'section': 'event-export', 'name': 'required_path_text'}
+        config_path={'section': 'event-export', 'name': 'required_path_text'}
     )
 
     def requires_local(self):

--- a/edx/analytics/tasks/location_per_course.py
+++ b/edx/analytics/tasks/location_per_course.py
@@ -37,7 +37,7 @@ class LastCountryOfUserMixin(
 
     """
     user_country_output = luigi.Parameter(
-        default_from_config={'section': 'last-country-of-user', 'name': 'user_country_output'}
+        config_path={'section': 'last-country-of-user', 'name': 'user_country_output'}
     )
 
 
@@ -184,7 +184,7 @@ class QueryLastCountryPerCourseMixin(object):
         course_country_output:  location to write query results.
     """
     course_country_output = luigi.Parameter(
-        default_from_config={'section': 'query-country-per-course', 'name': 'course_country_output'}
+        config_path={'section': 'query-country-per-course', 'name': 'course_country_output'}
     )
 
 

--- a/edx/analytics/tasks/mapreduce.py
+++ b/edx/analytics/tasks/mapreduce.py
@@ -27,7 +27,7 @@ class MapReduceJobTaskMixin(object):
     """Defines arguments used by downstream tasks to pass to upstream MapReduceJobTask."""
 
     mapreduce_engine = luigi.Parameter(
-        default_from_config={'section': 'map-reduce', 'name': 'engine'},
+        config_path={'section': 'map-reduce', 'name': 'engine'},
         significant=False
     )
     # TODO: remove these parameters
@@ -39,7 +39,7 @@ class MapReduceJobTaskMixin(object):
     n_reduce_tasks = luigi.Parameter(default=25, significant=False)
 
     remote_log_level = luigi.Parameter(
-        default_from_config={'section': 'map-reduce', 'name': 'remote_log_level'},
+        config_path={'section': 'map-reduce', 'name': 'remote_log_level'},
         significant=False
     )
 
@@ -244,7 +244,7 @@ class MultiOutputMapReduceJobTask(MapReduceJobTask):
     output_root = luigi.Parameter()
     delete_output_root = luigi.BooleanParameter(default=False, significant=False)
     marker = luigi.Parameter(
-        default_from_config={'section': 'map-reduce', 'name': 'marker'},
+        config_path={'section': 'map-reduce', 'name': 'marker'},
         significant=False
     )
 

--- a/edx/analytics/tasks/mysql_dump.py
+++ b/edx/analytics/tasks/mysql_dump.py
@@ -38,13 +38,13 @@ class MysqlSelectTask(luigi.Task):
     """
 
     credentials = luigi.Parameter(
-        default_from_config={'section': 'database-import', 'name': 'credentials'}
+        config_path={'section': 'database-import', 'name': 'credentials'}
     )
     destination = luigi.Parameter(
-        default_from_config={'section': 'database-import', 'name': 'destination'}
+        config_path={'section': 'database-import', 'name': 'destination'}
     )
     database = luigi.Parameter(
-        default_from_config={'section': 'database-import', 'name': 'database'}
+        config_path={'section': 'database-import', 'name': 'database'}
     )
 
     converters = [

--- a/edx/analytics/tasks/mysql_load.py
+++ b/edx/analytics/tasks/mysql_load.py
@@ -36,10 +36,10 @@ class MysqlInsertTaskMixin(OverwriteOutputMixin):
 
     """
     database = luigi.Parameter(
-        default_from_config={'section': 'database-export', 'name': 'database'}
+        config_path={'section': 'database-export', 'name': 'database'}
     )
     credentials = luigi.Parameter(
-        default_from_config={'section': 'database-export', 'name': 'credentials'}
+        config_path={'section': 'database-export', 'name': 'credentials'}
     )
     insert_chunk_size = luigi.IntParameter(default=100, significant=False)
 

--- a/edx/analytics/tasks/pathutil.py
+++ b/edx/analytics/tasks/pathutil.py
@@ -40,7 +40,7 @@ class PathSetTask(luigi.Task):
     """
     src = luigi.Parameter(
         is_list=True,
-        default_from_config={'section': 'event-logs', 'name': 'source'}
+        config_path={'section': 'event-logs', 'name': 'source'}
     )
     include = luigi.Parameter(is_list=True, default=('*',))
     manifest = luigi.Parameter(default=None)
@@ -104,15 +104,15 @@ class EventLogSelectionDownstreamMixin(object):
 
     source = luigi.Parameter(
         is_list=True,
-        default_from_config={'section': 'event-logs', 'name': 'source'}
+        config_path={'section': 'event-logs', 'name': 'source'}
     )
     interval = luigi.DateIntervalParameter()
     expand_interval = luigi.TimeDeltaParameter(
-        default_from_config={'section': 'event-logs', 'name': 'expand_interval'}
+        config_path={'section': 'event-logs', 'name': 'expand_interval'}
     )
     pattern = luigi.Parameter(
         is_list=True,
-        default_from_config={'section': 'event-logs', 'name': 'pattern'}
+        config_path={'section': 'event-logs', 'name': 'pattern'}
     )
 
 

--- a/edx/analytics/tasks/reports/enrollments.py
+++ b/edx/analytics/tasks/reports/enrollments.py
@@ -24,7 +24,7 @@ class CourseEnrollmentCountMixin(MapReduceJobTaskMixin):
     name = luigi.Parameter()
     src = luigi.Parameter(
         is_list=True,
-        default_from_config={'section': 'enrollment-reports', 'name': 'src'},
+        config_path={'section': 'enrollment-reports', 'name': 'src'},
     )
     include = luigi.Parameter(is_list=True, default=('*',))
     weeks = luigi.IntParameter(default=DEFAULT_NUM_WEEKS)
@@ -36,11 +36,11 @@ class CourseEnrollmentCountMixin(MapReduceJobTaskMixin):
     manifest = luigi.Parameter(default=None)
     manifest_path = luigi.Parameter(default=None)
     destination_directory = luigi.Parameter(default=None)
-    destination = luigi.Parameter(default_from_config={'section': 'enrollment-reports', 'name': 'destination'})
+    destination = luigi.Parameter(config_path={'section': 'enrollment-reports', 'name': 'destination'})
     credentials = luigi.Parameter(
-        default_from_config={'section': 'database-import', 'name': 'credentials'}
+        config_path={'section': 'database-import', 'name': 'credentials'}
     )
-    blacklist = luigi.Parameter(default_from_config={'section': 'enrollment-reports', 'name': 'blacklist'})
+    blacklist = luigi.Parameter(config_path={'section': 'enrollment-reports', 'name': 'blacklist'})
 
     """Provides methods useful for generating reports using course enrollment counts."""
 

--- a/edx/analytics/tasks/sqoop.py
+++ b/edx/analytics/tasks/sqoop.py
@@ -62,13 +62,13 @@ class SqoopImportTask(OverwriteOutputMixin, luigi.hadoop.BaseHadoopJobTask):
         }
     """
     destination = luigi.Parameter(
-        default_from_config={'section': 'database-import', 'name': 'destination'}
+        config_path={'section': 'database-import', 'name': 'destination'}
     )
     credentials = luigi.Parameter(
-        default_from_config={'section': 'database-import', 'name': 'credentials'}
+        config_path={'section': 'database-import', 'name': 'credentials'}
     )
     database = luigi.Parameter(
-        default_from_config={'section': 'database-import', 'name': 'database'}
+        config_path={'section': 'database-import', 'name': 'database'}
     )
     num_mappers = luigi.Parameter(default=None)
     verbose = luigi.BooleanParameter(default=False)

--- a/edx/analytics/tasks/studentmodule_dist.py
+++ b/edx/analytics/tasks/studentmodule_dist.py
@@ -42,7 +42,7 @@ class HistogramTaskFromSqoopParamsMixin(object):
     name = luigi.Parameter()
     dest = luigi.Parameter()
     credentials = luigi.Parameter(
-        default_from_config={'section': 'database-import', 'name': 'credentials'}
+        config_path={'section': 'database-import', 'name': 'credentials'}
     )
     sqoop_overwrite = luigi.BooleanParameter(default=False)  # prefixed with sqoop for disambiguation
     num_mappers = luigi.Parameter(default=None, significant=False)  # TODO: move to config

--- a/edx/analytics/tasks/user_location.py
+++ b/edx/analytics/tasks/user_location.py
@@ -27,7 +27,7 @@ class GeolocationMixin(object):
         geolocation_data: a URL to the location of country-level geolocation data.
     """
     geolocation_data = luigi.Parameter(
-        default_from_config={'section': 'geolocation', 'name': 'geolocation_data'}
+        config_path={'section': 'geolocation', 'name': 'geolocation_data'}
     )
 
 

--- a/edx/analytics/tasks/util/hive.py
+++ b/edx/analytics/tasks/util/hive.py
@@ -25,7 +25,7 @@ class WarehouseMixin(object):
     """Task that is aware of the data warehouse."""
 
     warehouse_path = luigi.Parameter(
-        default_from_config={'section': 'hive', 'name': 'warehouse_path'}
+        config_path={'section': 'hive', 'name': 'warehouse_path'}
     )
 
 

--- a/edx/analytics/tasks/vertica_load.py
+++ b/edx/analytics/tasks/vertica_load.py
@@ -31,10 +31,10 @@ class VerticaCopyTaskMixin(OverwriteOutputMixin):
         schema:  The schema to which to write.
     """
     schema = luigi.Parameter(
-        default_from_config={'section': 'vertica-export', 'name': 'schema'}
+        config_path={'section': 'vertica-export', 'name': 'schema'}
     )
     credentials = luigi.Parameter(
-        default_from_config={'section': 'vertica-export', 'name': 'credentials'}
+        config_path={'section': 'vertica-export', 'name': 'credentials'}
     )
 
 


### PR DESCRIPTION
**Description**: The pipeline code uses `default_from_config` in its luigi parameters all over the place, but that is deprecated. This PR changes the pipeline code to use the new variable name, `config_path`. This should ease upgrading to newer versions of luigi in the future.

**JIRA**: [OSPR-719](https://openedx.atlassian.net/browse/OSPR-719)

**Merge timeline**: Not an edX partner, so best effort.

**Reviewers**: @mtyaka and TBD
