### PR TITLE
WIP: Support python UDFs in hive

### DIFF
--- a/edx/analytics/tasks/reports/cybersource.py
+++ b/edx/analytics/tasks/reports/cybersource.py
@@ -10,6 +10,7 @@ from edx.analytics.tasks.url import get_target_from_url
 from edx.analytics.tasks.url import url_path_join
 from edx.analytics.tasks.util.hive import HivePartition, WarehouseMixin
 from edx.analytics.tasks.util.overwrite import OverwriteOutputMixin
+from edx.analytics.tasks.util.id_codec import encode_id
 
 # Tell urllib3 to switch the ssl backend to PyOpenSSL.
 # see https://urllib3.readthedocs.org/en/latest/security.html#pyopenssl
@@ -171,6 +172,8 @@ class DailyProcessFromCybersourceTask(PullFromCybersourceTaskMixin, luigi.Task):
                         row['payment_method'].lower().replace(' ', '_'),
                         # Identifier for the transaction.
                         row['request_id'],
+                        # globally unique transaction ID
+                        encode_id('cybersource', 'transaction_id', row['request_id']),
                     ]
                     output_file.write('\t'.join(result))
                     output_file.write('\n')

--- a/edx/analytics/tasks/reports/paypal.py
+++ b/edx/analytics/tasks/reports/paypal.py
@@ -9,6 +9,7 @@ from luigi.date_interval import DateInterval
 from edx.analytics.tasks.url import get_target_from_url
 from edx.analytics.tasks.url import url_path_join
 from edx.analytics.tasks.util.overwrite import OverwriteOutputMixin
+from edx.analytics.tasks.util.id_codec import encode_id
 
 # Tell urllib3 to switch the ssl backend to PyOpenSSL.
 # see https://urllib3.readthedocs.org/en/latest/security.html#pyopenssl
@@ -174,6 +175,8 @@ class PaypalTransactionsByDayTask(PaypalTaskMixin, luigi.Task):
                                 payment_method_type,
                                 # identifier for the transaction
                                 details['id'],
+                                # globally unique transaction ID
+                                encode_id('paypal', 'transaction_id', details['id']),
                             ]
                             output_file.write('\t'.join(record) + '\n')
 

--- a/edx/analytics/tasks/util/id_codec.py
+++ b/edx/analytics/tasks/util/id_codec.py
@@ -1,0 +1,10 @@
+
+import base64
+
+
+def encode_id(scope, id_type, id_value):
+    return base64.b32encode('|'.join([scope, id_type, id_value]))
+
+def decode_id(encoded_id):
+    scope, id_type, id_value = base64.b32decode(encoded_id).split('|')
+    return scope, id_type, id_value


### PR DESCRIPTION
@brianhw and @jab5569 

Here is a sketch of the type of thing I was thinking for the unique identifiers. It uses a python UDF in Hive to generate the IDs.

Stuff that is suboptimal:
- The "encode_id" function is duplicated in the UDF code and the rest of the pipeline code.
- There is some complexity associated with defining and using python UDFs in Hive.
- I had to pretty much fork the "run" function of the HiveQueryTask in order to inject the UDF setup code when running Hive tasks. This may be a good thing, though, since it could allow us to more elegantly inject other Hive boilerplate to our queries.

Other alternate approaches that we could do:
- Defer creation of these IDs until reconciliation where we are running python code on every row anyway.
- Use a Hive-friendly encoding (one of the SHA hashes for example).
- Add another processing step in after the big Hive query that injects these IDs into the records and stores them in another table.

Let me know if you would prefer any of the other approaches (or if you have another suggestion that I didn't mention above). I'm not attached to this method at all.

That said - I do like the idea of being able to define other simple python UDFs and run them in Hive in the future, but I'm not sure when/if we will need them for other purposes.
