### PR TITLE
Revert "Properly escape the names of Hive columns"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,4 +7,3 @@ Jason Bau <jbau@stanford.edu>
 Justin Helbert <jhelbert@edx.org>
 Will Daly <will@edx.org>
 Dylan Rhodes <dylanr@stanford.edu>
-Braden MacDonald <braden@opencraft.com>

--- a/edx/analytics/tasks/database_imports.py
+++ b/edx/analytics/tasks/database_imports.py
@@ -89,7 +89,7 @@ class ImportIntoHiveTableTask(OverwriteOutputMixin, HiveQueryTask):
         query = query_format.format(
             database_name=hive_database_name(),
             table_name=self.table_name,
-            col_spec=','.join(['`{}` {}'.format(*c) for c in self.columns]),
+            col_spec=','.join([' '.join(c) for c in self.columns]),
             location=self.table_location,
             table_format=self.table_format,
             partition_date=self.partition_date,

--- a/edx/analytics/tasks/enrollments.py
+++ b/edx/analytics/tasks/enrollments.py
@@ -349,7 +349,7 @@ class EnrollmentByGenderTask(EnrollmentTask):
     def query(self):
         return """
             SELECT
-                ce.`date`,
+                ce.date,
                 ce.course_id,
                 IF(p.gender != '', p.gender, NULL),
                 SUM(ce.at_end),
@@ -357,7 +357,7 @@ class EnrollmentByGenderTask(EnrollmentTask):
             FROM course_enrollment ce
             LEFT OUTER JOIN auth_userprofile p ON p.user_id = ce.user_id
             GROUP BY
-                ce.`date`,
+                ce.date,
                 ce.course_id,
                 IF(p.gender != '', p.gender, NULL)
         """
@@ -384,7 +384,7 @@ class EnrollmentByBirthYearTask(EnrollmentTask):
     def query(self):
         return """
             SELECT
-                ce.`date`,
+                ce.date,
                 ce.course_id,
                 p.year_of_birth,
                 SUM(ce.at_end),
@@ -392,7 +392,7 @@ class EnrollmentByBirthYearTask(EnrollmentTask):
             FROM course_enrollment ce
             LEFT OUTER JOIN auth_userprofile p ON p.user_id = ce.user_id
             GROUP BY
-                ce.`date`,
+                ce.date,
                 ce.course_id,
                 p.year_of_birth
         """
@@ -419,7 +419,7 @@ class EnrollmentByEducationLevelTask(EnrollmentTask):
     def query(self):
         return """
             SELECT
-                ce.`date`,
+                ce.date,
                 ce.course_id,
                 CASE p.level_of_education
                     WHEN 'el'    THEN 'primary'
@@ -440,7 +440,7 @@ class EnrollmentByEducationLevelTask(EnrollmentTask):
             FROM course_enrollment ce
             LEFT OUTER JOIN auth_userprofile p ON p.user_id = ce.user_id
             GROUP BY
-                ce.`date`,
+                ce.date,
                 ce.course_id,
                 CASE p.level_of_education
                     WHEN 'el'    THEN 'primary'
@@ -480,14 +480,14 @@ class EnrollmentByModeTask(EnrollmentTask):
     def query(self):
         return """
             SELECT
-                ce.`date`,
+                ce.date,
                 ce.course_id,
                 ce.mode,
                 SUM(ce.at_end),
                 COUNT(ce.user_id)
             FROM course_enrollment ce
             GROUP BY
-                ce.`date`,
+                ce.date,
                 ce.course_id,
                 ce.mode
         """
@@ -515,13 +515,13 @@ class EnrollmentDailyTask(EnrollmentTask):
         return """
             SELECT
                 ce.course_id,
-                ce.`date`,
+                ce.date,
                 SUM(ce.at_end),
                 COUNT(ce.user_id)
             FROM course_enrollment ce
             GROUP BY
                 ce.course_id,
-                ce.`date`
+                ce.date
         """
 
     @property

--- a/edx/analytics/tasks/location_per_course.py
+++ b/edx/analytics/tasks/location_per_course.py
@@ -200,7 +200,7 @@ class QueryLastCountryPerCourseTask(
             USE {database_name};
             DROP TABLE IF EXISTS {table_name};
             CREATE EXTERNAL TABLE {table_name} (
-                `date` STRING,
+                date STRING,
                 course_id STRING,
                 country_code STRING,
                 count INT,

--- a/edx/analytics/tasks/student_engagement.py
+++ b/edx/analytics/tasks/student_engagement.py
@@ -293,26 +293,26 @@ class JoinedStudentEngagementTableTask(StudentEngagementTableDownstreamMixin, Hi
         # Join with calendar data only if calculating weekly engagement.
         calendar_join = ""
         if self.interval_type == "daily":
-            date_where = "ce.`date` >= '{start}' AND ce.`date` < '{end}'".format(
+            date_where = "ce.date >= '{start}' AND ce.date < '{end}'".format(
                 start=self.interval.date_a.isoformat(),  # pylint: disable=no-member
                 end=self.interval.date_b.isoformat()  # pylint: disable=no-member
             )
         elif self.interval_type == "weekly":
             last_complete_date = self.interval.date_b - datetime.timedelta(days=1)  # pylint: disable=no-member
             iso_weekday = last_complete_date.isoweekday()
-            calendar_join = "INNER JOIN calendar cal ON (ce.`date` = cal.date) "
-            date_where = "ce.`date` >= '{start}' AND ce.`date` < '{end}' AND cal.iso_weekday = {iso_weekday}".format(
+            calendar_join = "INNER JOIN calendar cal ON (ce.date = cal.date) "
+            date_where = "ce.date >= '{start}' AND ce.date < '{end}' AND cal.iso_weekday = {iso_weekday}".format(
                 start=self.interval.date_a.isoformat(),  # pylint: disable=no-member
                 end=self.interval.date_b.isoformat(),  # pylint: disable=no-member
                 iso_weekday=iso_weekday,
             )
         elif self.interval_type == "all":
             last_complete_date = self.interval.date_b - datetime.timedelta(days=1)  # pylint: disable=no-member
-            date_where = "ce.`date` = '{last_complete_date}'".format(last_complete_date=last_complete_date.isoformat())
+            date_where = "ce.date = '{last_complete_date}'".format(last_complete_date=last_complete_date.isoformat())
 
         return """
         SELECT
-            ce.`date`,
+            ce.date,
             ce.course_id,
             au.username,
             au.email,
@@ -332,7 +332,7 @@ class JoinedStudentEngagementTableTask(StudentEngagementTableDownstreamMixin, Hi
         INNER JOIN auth_user au
             ON (ce.user_id = au.id)
         LEFT OUTER JOIN student_engagement_raw_{interval_type} ser
-            ON (au.username = ser.username AND ce.`date` = ser.end_date and ce.course_id = ser.course_id)
+            ON (au.username = ser.username AND ce.date = ser.end_date and ce.course_id = ser.course_id)
         LEFT OUTER JOIN (
             SELECT
                 cugu.user_id,

--- a/edx/analytics/tasks/tests/test_database_imports.py
+++ b/edx/analytics/tasks/tests/test_database_imports.py
@@ -30,7 +30,7 @@ class ImportStudentCourseEnrollmentTestCase(unittest.TestCase):
             USE default;
             DROP TABLE IF EXISTS student_courseenrollment;
             CREATE EXTERNAL TABLE student_courseenrollment (
-                `id` INT,`user_id` INT,`course_id` STRING,`created` TIMESTAMP,`is_active` BOOLEAN,`mode` STRING
+                id INT,user_id INT,course_id STRING,created TIMESTAMP,is_active BOOLEAN,mode STRING
             )
             PARTITIONED BY (dt STRING)
 

--- a/edx/analytics/tasks/tests/test_location_per_course.py
+++ b/edx/analytics/tasks/tests/test_location_per_course.py
@@ -165,7 +165,7 @@ class ImportLastCountryOfUserToHiveTestCase(unittest.TestCase):
             USE default;
             DROP TABLE IF EXISTS last_country_of_user;
             CREATE EXTERNAL TABLE last_country_of_user (
-                `country_name` STRING,`country_code` STRING,`username` STRING
+                country_name STRING,country_code STRING,username STRING
             )
             PARTITIONED BY (dt STRING)
             ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t'
@@ -218,7 +218,7 @@ class QueryLastCountryPerCourseTaskTestCase(unittest.TestCase):
             USE default;
             DROP TABLE IF EXISTS course_enrollment_location_current;
             CREATE EXTERNAL TABLE course_enrollment_location_current (
-                `date` STRING,
+                date STRING,
                 course_id STRING,
                 country_code STRING,
                 count INT,

--- a/edx/analytics/tasks/user_activity.py
+++ b/edx/analytics/tasks/user_activity.py
@@ -256,8 +256,8 @@ class CourseActivityWeeklyTask(CourseActivityTask):
                 act.category as label,
                 COUNT(DISTINCT username) as count
             FROM user_activity_daily act
-            JOIN calendar cal ON act.`date` = cal.`date`
-            WHERE "{interval_start}" <= cal.`date` AND cal.`date` < "{interval_end}"
+            JOIN calendar cal ON act.date = cal.date
+            WHERE "{interval_start}" <= cal.date AND cal.date < "{interval_end}"
             GROUP BY
                 act.course_id,
                 cal.iso_week_start,
@@ -294,15 +294,15 @@ class CourseActivityDailyTask(CourseActivityTask):
     def activity_query(self):
         return """
             SELECT
-                act.`date`,
+                act.date,
                 act.course_id as course_id,
                 act.category as label,
                 COUNT(DISTINCT username) as count
             FROM user_activity_daily act
-            WHERE "{interval_start}" <= act.`date` AND act.`date` < "{interval_end}"
+            WHERE "{interval_start}" <= act.date AND act.date < "{interval_end}"
             GROUP BY
                 act.course_id,
-                act.`date`,
+                act.date,
                 act.category;
         """
 
@@ -375,8 +375,8 @@ class CourseActivityMonthlyTask(CourseActivityTask):
                 act.category as label,
                 COUNT(DISTINCT username) as count
             FROM user_activity_daily act
-            JOIN calendar cal ON act.`date` = cal.`date`
-            WHERE "{interval_start}" <= cal.`date` AND cal.`date` < "{interval_end}"
+            JOIN calendar cal ON act.date = cal.date
+            WHERE "{interval_start}" <= cal.date AND cal.date < "{interval_end}"
             GROUP BY
                 act.course_id,
                 cal.year,

--- a/edx/analytics/tasks/util/hive.py
+++ b/edx/analytics/tasks/util/hive.py
@@ -57,7 +57,7 @@ class HiveTableTask(WarehouseMixin, OverwriteOutputMixin, HiveQueryTask):
             CREATE EXTERNAL TABLE {table} (
                 {col_spec}
             )
-            PARTITIONED BY (`{partition.key}` STRING)
+            PARTITIONED BY ({partition.key} STRING)
             {table_format}
             LOCATION '{location}';
             ALTER TABLE {table} ADD PARTITION ({partition.query_spec});
@@ -66,7 +66,7 @@ class HiveTableTask(WarehouseMixin, OverwriteOutputMixin, HiveQueryTask):
         query = query_format.format(
             database_name=hive_database_name(),
             table=self.table,
-            col_spec=','.join(['`{}` {}'.format(col_name, col_type) for col_name, col_type in self.columns]),
+            col_spec=','.join([' '.join(c) for c in self.columns]),
             location=self.table_location,
             table_format=self.table_format,
             partition=self.partition,
@@ -153,7 +153,7 @@ class HivePartition(object):
     @property
     def query_spec(self):
         """This format is used when a partition needs to be referred to in a query"""
-        return "`{key}`='{value}'".format(
+        return "{key}='{value}'".format(
             key=self.key,
             value=self.value,
         )

--- a/edx/analytics/tasks/util/tests/test_hive.py
+++ b/edx/analytics/tasks/util/tests/test_hive.py
@@ -16,7 +16,7 @@ class HivePartitionTest(unittest.TestCase):
         self.assertEquals(self.partition.as_dict(), {'dt': '2014-01-01'})
 
     def test_query_spec(self):
-        self.assertEquals(self.partition.query_spec, "`dt`='2014-01-01'")
+        self.assertEquals(self.partition.query_spec, "dt='2014-01-01'")
 
     def test_path_spec(self):
         self.assertEquals(self.partition.path_spec, "dt=2014-01-01")


### PR DESCRIPTION
Reverts edx/edx-analytics-pipeline#127

Not sure why it looks like acceptance tests were passing, but they aren't, reverting for now.
