### PR TITLE
Fix answer distribution handling of malformed event data

### DIFF
--- a/edx/analytics/tasks/tests/test_answer_dist.py
+++ b/edx/analytics/tasks/tests/test_answer_dist.py
@@ -179,6 +179,16 @@ class ProblemCheckEventMapTest(InitializeOpaqueKeysMixin, ProblemCheckEventBaseT
         line = self.create_event_log_line(context=None)
         self.assert_no_map_output_for(line)
 
+    def test_invalid_answer_id(self):
+        self.answer_id = 'foo\nbar'
+        line = self.create_event_log_line()
+        self.assert_no_map_output_for(line)
+
+    def test_invalid_answer_id_with_tab(self):
+        self.answer_id = 'foo\tbar'
+        line = self.create_event_log_line()
+        self.assert_no_map_output_for(line)
+
     def test_good_problem_check_event(self):
         # Here, we make the event as a dictionary since we're comparing based on dictionaries anyway.
         event = self.create_event_dict()


### PR DESCRIPTION
There is an event in the tracking logs that has a corrupt answer_id that is causing the answer distribution job to fail on the RC branch.

We should prevent malformed events like this from being analyzed.

@brianhw @jab5569 
