### PR TITLE
Vertica Bulkloader Infrastructure Improvements

### DIFF
--- a/edx/analytics/tasks/course_catalog.py
+++ b/edx/analytics/tasks/course_catalog.py
@@ -1,4 +1,4 @@
-"""Collect the course catalog from the course catalog API for processing of course metadata like subjects or types"""
+"""Collect the course catalog from the course catalog API for processing of course metadata like subjects or types."""
 import requests
 import datetime
 
@@ -140,7 +140,7 @@ class DailyLoadSubjectsToVerticaTask(PullCatalogMixin, VerticaCopyTask):
     @property
     def auto_primary_key(self):
         """Overridden since the database schema specifies a different name for the auto incrementing primary key."""
-        return None
+        return ('row_number', 'AUTO_INCREMENT')
 
     @property
     def default_columns(self):
@@ -150,7 +150,6 @@ class DailyLoadSubjectsToVerticaTask(PullCatalogMixin, VerticaCopyTask):
     @property
     def columns(self):
         return [
-            ('row_number', 'AUTO_INCREMENT PRIMARY KEY'),
             ('course_id', 'VARCHAR(200)'),
             ('date', 'DATE'),
             ('subject_uri', 'VARCHAR(200)'),


### PR DESCRIPTION
Update vertica_load.py to be more robust, allowing the copying of streams, the definition of foreign keys, correct handling of auto primary keys, and the ability to just load specified changes, and fixed the course subjects task to be compatible with the new vertica loader.  This PR is to merge in all the uncontroversial, useful infrastructure improvements made on Brian's branch to pull student engagement into the warehouse and my branch to pull event logs into the warehouse, which are both somewhat experimental in nature and unlikely to be merged soon (if ever).

@brianhw @mulby @jab5569 
