### PR TITLE
User Profiles Table in Analytics MySQL DB

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Jason Bau <jbau@stanford.edu>
 Justin Helbert <jhelbert@edx.org>
 Will Daly <will@edx.org>
 Dylan Rhodes <dylanr@stanford.edu>
+Braden MacDonald <braden@opencraft.com>

--- a/edx/analytics/tasks/database_imports.py
+++ b/edx/analytics/tasks/database_imports.py
@@ -261,6 +261,7 @@ class ImportAuthUserProfileTask(ImportMysqlToHiveTableTask):
     def columns(self):
         return [
             ('user_id', 'INT'),
+            ('name', 'STRING'),
             ('gender', 'STRING'),
             ('year_of_birth', 'INT'),
             ('level_of_education', 'STRING'),

--- a/edx/analytics/tasks/tests/acceptance/fixtures/input/load_auth_user_and_profiles.sql
+++ b/edx/analytics/tasks/tests/acceptance/fixtures/input/load_auth_user_and_profiles.sql
@@ -1,0 +1,65 @@
+DROP TABLE IF EXISTS `auth_user`;
+
+CREATE TABLE `auth_user` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `username` varchar(30) NOT NULL,
+  `first_name` varchar(30) NOT NULL,
+  `last_name` varchar(30) NOT NULL,
+  `email` varchar(75) NOT NULL,
+  `password` varchar(128) NOT NULL,
+  `is_staff` tinyint(1) NOT NULL,
+  `is_active` tinyint(1) NOT NULL,
+  `is_superuser` tinyint(1) NOT NULL,
+  `last_login` datetime NOT NULL,
+  `date_joined` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `username` (`username`),
+  UNIQUE KEY `email` (`email`)
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8;
+
+INSERT INTO `auth_user` VALUES
+    (1,'jane','','','jane@example.com','no_password',0,1,0,'2014-01-18 00:00:00','2014-01-15 00:00:00'),
+    (2,'alex','','','alex@example.com','no_password',0,1,0,'2014-02-18 00:00:00','2014-02-15 00:00:00'),
+    (3,'cary','','','cary@example.com','no_password',0,1,0,'2014-03-18 00:00:00','2014-03-15 00:00:00'),
+    (4,'erin','','','erin@example.com','no_password',1,1,0,'2014-04-18 00:00:00','2014-04-15 00:00:00'),
+    (5,'lane','','','lane@example.com','no_password',0,1,0,'2014-05-18 00:00:00','2014-05-15 00:00:00');
+
+DROP TABLE IF EXISTS `auth_userprofile`;
+
+CREATE TABLE `auth_userprofile` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `language` varchar(255) NOT NULL,
+  `location` varchar(255) NOT NULL,
+  `meta` longtext NOT NULL,
+  `courseware` varchar(255) NOT NULL,
+  `gender` varchar(6),
+  `mailing_address` longtext,
+  `year_of_birth` int(11),
+  `level_of_education` varchar(6),
+  `goals` longtext,
+  `allow_certificate` tinyint(1) NOT NULL,
+  `country` varchar(2),
+  `city` longtext,
+  `bio` varchar(3000),
+  `profile_image_uploaded_at` datetime,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `user_id` (`user_id`),
+  KEY `auth_userprofile_52094d6e` (`name`),
+  KEY `auth_userprofile_8a7ac9ab` (`language`),
+  KEY `auth_userprofile_b54954de` (`location`),
+  KEY `auth_userprofile_fca3d292` (`gender`),
+  KEY `auth_userprofile_d85587` (`year_of_birth`),
+  KEY `auth_userprofile_551e365c` (`level_of_education`),
+  CONSTRAINT `user_id_refs_id_628b4c11` FOREIGN KEY (`user_id`) REFERENCES `auth_user` (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8;
+
+INSERT INTO `auth_userprofile`
+  (`user_id`, `name`, `gender`, `year_of_birth`, `level_of_education`, `language`, `location`, `meta`, `courseware`, `allow_certificate`)
+VALUES
+  (1, 'Jane Doe', 'f', 1980, 'b', '', '', '', 'course.xml', 1),
+  (2, 'Alex Doe', '',  1990, '',  '', '', '', 'course.xml', 1),
+  (3, 'Cary Doe', 'm', 1985, 'hs','', '', '', 'course.xml', 1),
+  (4, 'Erin Doe', 'f', 1995, '',  '', '', '', 'course.xml', 1),
+  (5, 'Lane Doe', 'm', NULL, 'm', '', '', '', 'course.xml', 1);

--- a/edx/analytics/tasks/tests/acceptance/services/db.py
+++ b/edx/analytics/tasks/tests/acceptance/services/db.py
@@ -46,11 +46,8 @@ class DatabaseService(object):
         """
         with self.cursor(explicit_db=True) as cur:
             with open(file_path, 'r') as sql_file:
-                for line in sql_file:
-                    if line.startswith('--') or len(line.strip()) == 0:
-                        continue
-
-                    cur.execute(line)
+                for _ignored in cur.execute(sql_file.read(), multi=True):
+                    pass
 
     def connect(self, explicit_db=True):
         """

--- a/edx/analytics/tasks/tests/acceptance/test_enrollments.py
+++ b/edx/analytics/tasks/tests/acceptance/test_enrollments.py
@@ -33,6 +33,7 @@ class EnrollmentAcceptanceTest(AcceptanceTestCase):
         self.validate_birth_year()
         self.validate_education_level()
         self.validate_mode()
+        self.validate_snapshot()
 
     def validate_gender(self):
         """Ensure the gender breakdown is correct."""
@@ -121,6 +122,25 @@ class EnrollmentAcceptanceTest(AcceptanceTestCase):
             (datetime.date(2014, 8, 5), 'edX/Open_DemoX/edx_demo_course', None, 1, 1),
             (datetime.date(2014, 8, 5), 'edX/Open_DemoX/edx_demo_course', 'associates', 0, 1),
             (datetime.date(2014, 8, 5), 'edX/Open_DemoX/edx_demo_course', 'bachelors', 0, 2),
+        ]
+        self.assertItemsEqual(expected, results)
+
+    def validate_snapshot(self):
+        """Ensure the snapshot is correct."""
+        with self.export_db.cursor() as cursor:
+            cursor.execute(
+                'SELECT course_id, user_id FROM course_enrollment_snapshot'
+                ' ORDER BY course_id, user_id ASC'
+            )
+            results = cursor.fetchall()
+
+        expected = [
+            ('edX/Open_DemoX/edx_demo_course', 1),
+            ('edX/Open_DemoX/edx_demo_course', 2),
+            ('edX/Open_DemoX/edx_demo_course', 3),
+            ('edX/Open_DemoX/edx_demo_course', 4),
+            ('course-v1:edX+Open_DemoX+edx_demo_course2', 1),
+            ('course-v1:edX+Open_DemoX+edx_demo_course2', 2),
         ]
         self.assertItemsEqual(expected, results)
 

--- a/edx/analytics/tasks/tests/acceptance/test_user_profiles.py
+++ b/edx/analytics/tasks/tests/acceptance/test_user_profiles.py
@@ -1,0 +1,38 @@
+"""Test the task that saves user profiles to MySQL"""
+
+from datetime import datetime
+
+from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase
+
+
+class UserProfilesAcceptanceTest(AcceptanceTestCase):
+    """Test the task that saves user profiles to MySQL"""
+
+    def test_user_activity(self):
+        self.maxDiff = None
+        self.execute_sql_fixture_file('load_auth_user_and_profiles.sql')
+ 
+        self.task.launch([
+            'InsertToMysqlUserProfilesTask',
+            '--credentials', self.export_db.credentials_file_url,
+        ])
+
+        with self.export_db.cursor() as cursor:
+            cursor.execute(
+                'SELECT '
+                    'id, username, last_login, date_joined, is_staff, email, '
+                    'name, gender, year_of_birth, level_of_education '
+                'FROM user_profile ORDER BY id'
+            )
+            results = cursor.fetchall()
+
+        # pylint: disable=line-too-long
+        self.assertItemsEqual([
+            row for row in results
+        ], [
+            (1, 'jane', datetime(2014, 1, 18, 0, 0), datetime(2014, 1, 15, 0, 0), 0, 'jane@example.com', 'Jane Doe', 'f', 1980, 'b'),
+            (2, 'alex', datetime(2014, 2, 18, 0, 0), datetime(2014, 2, 15, 0, 0), 0, 'alex@example.com', 'Alex Doe', None, 1990, None),
+            (3, 'cary', datetime(2014, 3, 18, 0, 0), datetime(2014, 3, 15, 0, 0), 0, 'cary@example.com', 'Cary Doe', 'm', 1985, 'hs'),
+            (4, 'erin', datetime(2014, 4, 18, 0, 0), datetime(2014, 4, 15, 0, 0), 1, 'erin@example.com', 'Erin Doe', 'f', 1995, None),
+            (5, 'lane', datetime(2014, 5, 18, 0, 0), datetime(2014, 5, 15, 0, 0), 0, 'lane@example.com', 'Lane Doe', 'm', None, 'm'),
+        ])

--- a/edx/analytics/tasks/user_profiles.py
+++ b/edx/analytics/tasks/user_profiles.py
@@ -1,0 +1,85 @@
+"""
+Store the basic demographic information about each user into the Analytics MySQL DB.
+"""
+import datetime
+import luigi
+from edx.analytics.tasks.database_imports import ImportAuthUserTask, ImportAuthUserProfileTask
+from edx.analytics.tasks.util.hive import HivePartition, HiveQueryToMysqlTask
+
+
+class InsertToMysqlUserProfilesTask(HiveQueryToMysqlTask):
+    """
+    Select from the 'auth_user' and 'auth_userprofile' tables we already have in Hive and save
+    them to MySQL.
+    """
+    auto_primary_key = None
+    import_date = luigi.DateParameter(default=None)
+    hive_overwrite = True
+
+    def __init__(self, *args, **kwargs):
+        super(InsertToMysqlUserProfilesTask, self).__init__(*args, **kwargs)
+
+        if not self.import_date:
+            self.import_date = datetime.datetime.utcnow().date()
+
+
+    @property
+    def table(self):
+        return "user_profile"
+
+    @property
+    def query(self):
+        return """
+            SELECT
+                au.id,
+                au.username,
+                au.last_login,
+                au.date_joined,
+                au.is_staff,
+                au.email,
+                p.name,
+                IF(p.gender != '', p.gender, NULL),
+                p.year_of_birth,
+                IF(p.level_of_education != '', p.level_of_education, NULL)
+            FROM auth_user au
+            LEFT OUTER JOIN auth_userprofile p ON au.id = p.user_id
+            WHERE au.is_active
+        """
+
+    @property
+    def columns(self):
+        return [
+            ('id', 'INT PRIMARY KEY NOT NULL'),
+            ('username', 'VARCHAR(30) NOT NULL'),
+            ('last_login', 'DATETIME'),
+            ('date_joined', 'DATETIME NOT NULL'),
+            ('is_staff', 'TINYINT(1) NOT NULL'),
+            ('email', 'VARCHAR(75) NOT NULL'),
+            ('name', 'VARCHAR(255)'),
+            ('gender', 'VARCHAR(6)'),
+            ('year_of_birth', 'INT'),
+            ('level_of_education', 'VARCHAR(6)'),
+        ]
+
+    @property
+    def required_table_tasks(self):
+        kwargs_for_db_import = {
+            'overwrite': False,
+            'import_date': self.import_date,
+            # Are other parameters needed?
+        }
+        yield (
+            ImportAuthUserTask(**kwargs_for_db_import),
+            ImportAuthUserProfileTask(**kwargs_for_db_import)
+        )
+
+    @property
+    def indexes(self):
+        return [
+            ('id', ),
+            ('username', ),
+        ]
+
+    @property
+    def partition(self):
+        return HivePartition('dt', self.import_date)

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ edx.analytics.tasks =
     export-student-module = edx.analytics.tasks.database_exports:StudentModulePerCourseAfterImportWorkflow
     last-country = edx.analytics.tasks.user_location:LastCountryForEachUser
     export-events = edx.analytics.tasks.event_exports:EventExportTask
+    user-profiles = edx.analytics.tasks.user_profiles:InsertToMysqlUserProfilesTask
     user-activity = edx.analytics.tasks.user_activity:CourseActivityWeeklyTask
     insert-into-table = edx.analytics.tasks.mysql_load:MysqlInsertTask
     database-import = edx.analytics.tasks.database_imports:ImportAllDatabaseTablesTask


### PR DESCRIPTION
In order to support user-specific reports in the Insights dashboard, this PR takes the first step by making user data available within the MySQL DB.

Two [related](https://github.com/edx/edx-analytics-data-api/pull/80) [PRs](https://github.com/edx/edx-analytics-data-api-client/pull/21) update the data API to allow analytics software to access the data, and [a final PR for the Dashboard](https://github.com/edx/edx-analytics-dashboard/pull/338) displays it to the user.

**Changes**:
- Add user's "name" to the existing task that imports data from the LMS `auth_userprofile` table to Hive.
- Adds two new pipeline tasks:
  - `InsertToMysqlUserProfilesTask` which creates the new `user_profile` table in the analytics MySQL DB. This new table contains basic user information (ID, name, email, username, gender, age, education level, login date) extracted and joined from the existing `auth_user` and `auth_userprofile` Hive tables.
  - `EnrollmentSnapshotTask` which creates/updates a new MySQL table (`course_enrollment_snapshot`) to contain the most current enrollment information available.

These changes together allow us to create new Data API methods that can (a) get the profiles of all known users or (b) get the profiles of all users in a specific course.

**Partner Information**: Third-party open edX instance, not an edX partner.

**Test Instructions - OpenCraft devstack**:
One way to test is with the analytics devstack:
1. Setup an [analytics devstack](https://github.com/open-craft/edx-analytics-devstack). 
2. Modify your local LMS devstack to work with the new analytics devstack (See analytics devstack README).
3. Login to the analytics devstack as the `analytics` user.
4. Run the command:
   `
   launch-task InsertToMysqlUserProfilesTask --local-scheduler
   `
5. Wait for it to complete. To check if it worked, run `mysql -u root analytics --execute="SELECT * FROM user_profile;"`. You should get a result set showing all the users on your LMS devstack.

**Test Instructions - Combined devstack**:
Another way is the nascent combined devstack:
1. Setup a [combined devstack](https://gist.github.com/bradenmacdonald/8b3b9736bf2b5ec44bc0)
2. Clear out any existing pipeline repo: `vagrant ssh` then `sudo rm -r /var/lib/analytics-tasks/devstack/repo` (This is necessary since the ansible scripts won't force the use of a different upstream repo during the next step)
3. On your host, in the edx-analytics-pipeline folder (with the venv loaded), run these commands:
   
   ```
   export WHEEL_URL=http://edx-wheelhouse.s3-website-us-east-1.amazonaws.com/Ubuntu/precise
   remote-task --vagrant-path ../ --remote-name devstack --override-config ${PWD}/config/devstack.cfg --wheel-url $WHEEL_URL --repo https://github.com/open-craft/edx-analytics-pipeline.git --branch user-table-mysql --wait InsertToMysqlUserProfilesTask --local-scheduler
   ```
4. Wait for it to complete, then inside the devstack, run `mysql -u root reports --execute="SELECT * FROM user_profile;"` You should get a result set showing all the users on your LMS devstack.
5. Now, try the other new task, `EnrollmentSnapshotTask`, with this command:
   
   ```
   remote-task --vagrant-path ../ --remote-name devstack --override-config ${PWD}/config/devstack.cfg --wheel-url $WHEEL_URL --repo https://github.com/open-craft/edx-analytics-pipeline.git --branch user-table-mysql --wait ImportEnrollmentsIntoMysql --local-scheduler --interval-end $(date -v+1d +%Y-%m-%d) --n-reduce-tasks 1
   ```
   
   (If the `date` subcommand isn't working, try `date +%Y-%m-%d -d "tomorrow"` instead)
6. Then, to check that it worked, run `mysql -u root reports --execute="SELECT * FROM course_enrollment_snapshot;"` as any user within the devstack.

**Author Notes/questions**
- Does it make sense for this data to be imported this way and stored in the analytics MySQL DB?
- Is it necessary to add a migration or something to account for a new column being added to the auth_userprofile Hive table?
- How do I write tests for this?
