### PR TITLE
Update to vertica-python 0.5.1

### DIFF
--- a/edx/analytics/tasks/tests/test_vertica_load.py
+++ b/edx/analytics/tasks/tests/test_vertica_load.py
@@ -175,9 +175,9 @@ class VerticaCopyTaskTest(unittest.TestCase):
         task = self.create_task(source=self._get_source_string(1))
         cursor = MagicMock()
         task.copy_data_table_from_target(cursor)
-        query = cursor.copy_stream.call_args[0][0]
+        query = cursor.copy.call_args[0][0]
         self.assertEquals(query, self._get_expected_query())
-        file_to_copy = cursor.copy_stream.call_args[0][1]
+        file_to_copy = cursor.copy.call_args[0][1]
         with task.input()['insert_source'].open('r') as expected_data:
             expected_source = expected_data.read()
         sent_source = file_to_copy.read()
@@ -187,9 +187,9 @@ class VerticaCopyTaskTest(unittest.TestCase):
         task = self.create_task(source=self._get_source_string(4))
         cursor = MagicMock()
         task.copy_data_table_from_target(cursor)
-        query = cursor.copy_stream.call_args[0][0]
+        query = cursor.copy.call_args[0][0]
         self.assertEquals(query, self._get_expected_query())
-        file_to_copy = cursor.copy_stream.call_args[0][1]
+        file_to_copy = cursor.copy.call_args[0][1]
         with task.input()['insert_source'].open('r') as expected_data:
             expected_source = expected_data.read()
         sent_source = file_to_copy.read()
@@ -199,9 +199,9 @@ class VerticaCopyTaskTest(unittest.TestCase):
         task = self.create_task(cls=CopyToPredefinedVerticaDummyTable)
         cursor = MagicMock()
         task.copy_data_table_from_target(cursor)
-        query = cursor.copy_stream.call_args[0][0]
+        query = cursor.copy.call_args[0][0]
         self.assertEquals(query, self._get_expected_query())
-        file_to_copy = cursor.copy_stream.call_args[0][1]
+        file_to_copy = cursor.copy.call_args[0][1]
         with task.input()['insert_source'].open('r') as expected_data:
             expected_source = expected_data.read()
         sent_source = file_to_copy.read()

--- a/edx/analytics/tasks/vertica_load.py
+++ b/edx/analytics/tasks/vertica_load.py
@@ -249,8 +249,8 @@ class VerticaCopyTask(VerticaCopyTaskMixin, luigi.Task):
                             % (self.columns[0],))
 
         with self.input()['insert_source'].open('r') as insert_source_file:
-            log.debug("Running copy_stream from source file")
-            cursor.copy_stream(
+            log.debug("Running stream copy from source file")
+            cursor.copy(
                 "COPY {schema}.{table} ({cols}) FROM STDIN DELIMITER AS {delim} NULL AS {null} DIRECT NO COMMIT;".format(
                     schema=self.schema,
                     table=self.table,

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -30,7 +30,7 @@ pycparser==2.13        # BSD
 requests==2.7.0     # Apache 2.0
 urllib3==1.10.4        # MIT
 psycopg2==2.6.1     # LGPL
+vertica-python==0.5.1   # MIT
 git+https://github.com/edx/luigi.git@v1.0.17-fork.edx.1#egg=luigi 		# Apache License 2.0
 git+https://github.com/edx/opaque-keys.git@33f2b099e92957046a866a9b6d48a71c484bb475#egg=opaque-keys
 git+https://github.com/edx/pyinstrument.git@a35ff76df4c3d5ff9a2876d859303e33d895e78f#egg=pyinstrument     # BSD
-git+https://github.com/jrowan/vertica-python#egg=vertica-python     # MIT


### PR DESCRIPTION
Version 0.5.1 added support for streaming copy commands, so we will no longer need to use a fork of the package.  This is a small change which just replaces "copy_stream" with "copy" throughout the code and updates the requirements file.

The acceptance test for the course subjects workflow and the course subjects workflow continue to work as expected, and I've also checked that the Vertica bulkloader still handles unicode in course names/descriptions correctly.

@brianhw @mulby @jab5569 
