### PR TITLE
Address lock contention problems writing to Vertica

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Jason Bau <jbau@stanford.edu>
 Justin Helbert <jhelbert@edx.org>
 Will Daly <will@edx.org>
 Dylan Rhodes <dylanr@stanford.edu>
+James Rowan <jrowan@mit.edu>


### PR DESCRIPTION
DELETE operations in Vertica acquire exclusive (X) table-level locks.  Since we occasionally will want to use the VerticaCopyTask in an overwriting setting, we need to be able to support deleting rows from the marker table during the execution of that task.  This PR moves the deletion of the marker table rows from before the start of the streaming copy to afterwards, immediately before the insertion of the new row into the marker table.  This avoids the problem of Vertica loading tasks holding exclusive locks on the marker table for too long and causing lock wait timeouts for other Vertica loading tasks trying to concurrently write to the same schema.

@mulby @jab5569 
