### PR TITLE
Precompute total seconds watched for each video

### DIFF
--- a/edx/analytics/tasks/tests/acceptance/test_video.py
+++ b/edx/analytics/tasks/tests/acceptance/test_video.py
@@ -33,7 +33,7 @@ class VideoAcceptanceTest(AcceptanceTestCase):
         with self.export_db.cursor() as cursor:
             cursor.execute(
                 'SELECT pipeline_video_id, course_id, encoded_module_id, duration, segment_length,'
-                ' users_at_start, users_at_end FROM video'
+                ' users_at_start, users_at_end, total_viewed_seconds FROM video'
                 ' ORDER BY pipeline_video_id ASC'
             )
             results = cursor.fetchall()
@@ -47,6 +47,7 @@ class VideoAcceptanceTest(AcceptanceTestCase):
                 5,
                 1,
                 1,
+                5,
             ),
             (
                 'edX/DemoX/Demo_Course|i4x-edX-DemoX-video-3cb54a11efae4ccc8a0aade24d14b255',
@@ -56,6 +57,7 @@ class VideoAcceptanceTest(AcceptanceTestCase):
                 5,
                 2,
                 2,
+                60,
             ),
             (
                 'edX/DemoX/Demo_Course|i4x-edX-DemoX-video-8c0028eb2a724f48a074bc184cd8635f',
@@ -65,6 +67,7 @@ class VideoAcceptanceTest(AcceptanceTestCase):
                 5,
                 0,
                 1,
+                15,
             ),
         ]
         self.assertItemsEqual(expected, results)

--- a/edx/analytics/tasks/video.py
+++ b/edx/analytics/tasks/video.py
@@ -538,7 +538,17 @@ class InsertToMysqlVideoTask(VideoTableDownstreamMixin, HiveQueryToMysqlTask):
     @property
     def query(self):
         return """
-            SELECT DISTINCT
+            SELECT
+                pipeline_video_id,
+                course_id,
+                encoded_module_id,
+                duration,
+                segment_length,
+                users_at_start,
+                users_at_end,
+                sum(num_views) * segment_length
+            FROM video_usage
+            GROUP BY
                 pipeline_video_id,
                 course_id,
                 encoded_module_id,
@@ -546,7 +556,6 @@ class InsertToMysqlVideoTask(VideoTableDownstreamMixin, HiveQueryToMysqlTask):
                 segment_length,
                 users_at_start,
                 users_at_end
-            FROM video_usage
         """
 
     @property
@@ -559,6 +568,7 @@ class InsertToMysqlVideoTask(VideoTableDownstreamMixin, HiveQueryToMysqlTask):
             ('segment_length', 'INTEGER'),
             ('users_at_start', 'INTEGER'),
             ('users_at_end', 'INTEGER'),
+            ('total_viewed_seconds', 'INTEGER'),
         ]
 
     @property


### PR DESCRIPTION
Added  'total_viewed_seconds' for video table that captures total viewing time in seconds per video across all users. 

@mulby @brianhw @jab5569 
