### PR TITLE
Removed end-of-video segments that show a sharp drop in users

### DIFF
--- a/config/devstack.cfg
+++ b/config/devstack.cfg
@@ -54,3 +54,7 @@ geolocation_data = hdfs://localhost:9000/edx-analytics-pipeline/geo.dat
 
 [calendar]
 interval = 2012-01-01-2020-01-01
+
+[videos]
+dropoff_threshold = 0.05
+

--- a/config/test.cfg
+++ b/config/test.cfg
@@ -100,3 +100,6 @@ interval_start = 2015-09-01
 [payment]
 cybersource_merchant_ids = test
                            empty_test
+
+[videos]
+dropoff_threshold = 0.05

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -32,6 +32,7 @@ tornado==3.1.1 		# Apache 2.0
 urllib3==1.10.4         # MIT
 vertica-python==0.5.1   # MIT
 wsgiref==0.1.2 		# ZPL
+pip==1.5.6
 git+https://github.com/edx/luigi.git@v1.0.17-fork.edx.1#egg=luigi 		# Apache License 2.0
 git+https://github.com/edx/opaque-keys.git@33f2b099e92957046a866a9b6d48a71c484bb475#egg=opaque-keys
 git+https://github.com/edx/pyinstrument.git@a35ff76df4c3d5ff9a2876d859303e33d895e78f#egg=pyinstrument     # BSD


### PR DESCRIPTION
@brianhw  @mulby 
I am not sure if this is the right way to go about it. It basically just looks for a spike in num_users from the end to the start and drops those segments. 
