### PR TITLE
Change NO_COST orders to no longer check order status.

### DIFF
--- a/edx/analytics/tasks/reports/reconcile.py
+++ b/edx/analytics/tasks/reports/reconcile.py
@@ -228,7 +228,10 @@ class ReconcileOrdersAndTransactionsTask(ReconcileOrdersAndTransactionsDownstrea
             elif orderitem.line_item_unit_price == 0.0:
                 order_audit_code = 'ORDER_BALANCED'
                 orderitem_audit_code = 'NO_COST'
-            orderitem_audit_code = self._check_orderitem_wrongstatus(orderitem, orderitem_audit_code)
+            # Note that we don't call "check_orderitem_wrongstatus" here, as the
+            # existing status is generally sufficient.  In the case of "NO_COST"
+            # honor enrollment orders, they may in fact be refunded when a user unenrolls,
+            # but the refund is zero.
             audit_code = (order_audit_code, orderitem_audit_code, transaction_audit_code)
             yield audit_code, orderitem
 

--- a/edx/analytics/tasks/reports/tests/test_reconcile.py
+++ b/edx/analytics/tasks/reports/tests/test_reconcile.py
@@ -252,7 +252,7 @@ class ReconciliationTaskReducerTest(ReconciliationTaskMixin, ReducerTestMixin, u
         }), ]
         self._check_output(inputs, {
             'order_audit_code': 'ORDER_BALANCED',
-            'orderitem_audit_code': 'ERROR_WRONGSTATUS_NO_COST',
+            'orderitem_audit_code': 'NO_COST',
             'transaction_audit_code': 'NO_TRANSACTION',
             'transaction_id': None,
         })


### PR DESCRIPTION
Such 'honor' enrollment orders may be refunded when a user unenrolls,
and a zero-cost refund just skips creating a transaction.

@mulby
