### PR TITLE
Filter out null course_id from ed_services report.

### DIFF
--- a/edx/analytics/tasks/reports/financial_report/ed_services_financial_report.py
+++ b/edx/analytics/tasks/reports/financial_report/ed_services_financial_report.py
@@ -88,7 +88,10 @@ class BuildEdServicesReportTask(DatabaseImportMixin, MapReduceJobTaskMixin, Hive
                 FROM (
                     SELECT
                         order_course_id AS course_id
-                    FROM reconciled_order_transactions
+                    FROM
+                        reconciled_order_transactions
+                    WHERE
+                        order_course_id is not NULL
                     UNION ALL
                     SELECT
                         course_id


### PR DESCRIPTION
@mulby @jab5569  Small change, but it removes the all-null row.
