### PR TITLE
(WIP) Using GeoIP2 instead of Pygeoip, and add country_for_private_ip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,10 @@ develop: requirements
 	python setup.py develop
 
 system-requirements:
+	sudo add-apt-repository -y ppa:maxmind/ppa
 	sudo apt-get update -q
 	# This is not great, we can't use these libraries on slave nodes using this method.
-	sudo apt-get install -y -q libmysqlclient-dev libatlas3gf-base libpq-dev python-dev libffi-dev libssl-dev libxml2-dev libxslt1-dev
+	sudo apt-get install -y -q libmysqlclient-dev libatlas3gf-base libpq-dev python-dev libffi-dev libssl-dev libxml2-dev libxslt1-dev libmaxminddb-dev
 
 requirements:
 	$(PIP_INSTALL) -U -r requirements/pre.txt

--- a/edx/analytics/tasks/location_per_course.py
+++ b/edx/analytics/tasks/location_per_course.py
@@ -56,6 +56,12 @@ class LastCountryOfUser(LastCountryOfUserMixin, EventLogSelectionMixin, BaseGeol
     def geolocation_data_target(self):
         return self.input_local()
 
+    def default_country_name(self):
+        return self.country_name_for_private_ip
+
+    def default_country_code(self):
+        return self.country_code_for_private_ip
+
     def output(self):
         return get_target_from_url(
             url_path_join(
@@ -144,6 +150,8 @@ class ImportLastCountryOfUserToHiveTask(LastCountryOfUserMixin, ImportIntoHiveTa
             geolocation_data=self.geolocation_data,
             overwrite=self.overwrite,
             user_country_output=self.user_country_output,
+            country_name_for_private_ip=self.country_name_for_private_ip,
+            country_code_for_private_ip=self.country_code_for_private_ip,
         )
 
 
@@ -174,6 +182,8 @@ class InsertToMysqlLastCountryOfUserTask(LastCountryOfUserMixin, MysqlInsertTask
             geolocation_data=self.geolocation_data,
             overwrite=self.overwrite,
             user_country_output=self.user_country_output,
+            country_name_for_private_ip=self.country_name_for_private_ip,
+            country_code_for_private_ip=self.country_code_for_private_ip,
         )
 
 
@@ -344,4 +354,6 @@ class InsertToMysqlCourseEnrollByCountryWorkflow(
             overwrite=self.overwrite,
             user_country_output=self.user_country_output,
             course_country_output=self.course_country_output,
+            country_name_for_private_ip=self.country_name_for_private_ip,
+            country_code_for_private_ip=self.country_code_for_private_ip,
         )

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -19,7 +19,7 @@ psycopg2==2.6.1         # LGPL
 pyOpenSSL==0.15.1       # Apache 2.0
 pyasn1==0.1.7           # BSD
 pycparser==2.13         # BSD
-pygeoip==0.3.1 		# LGPL
+geoip2==2.2.0 		# Apache 2.0
 pymongo==2.7.2		# Apache 2.0
 python-cjson==1.0.5	# LGPL
 python-dateutil==2.2 	# BSD


### PR DESCRIPTION
pygeoip works only on IPv4 or IPv6 with a single database, while in a dual-stack configuration, both IPv4 and IPv6 addresses may occur in the tracking log. In this case, some logs may not be correctly parsed and the location reports will be wrong.

Another issue here is that currently all IP addresses not in the database will be marked as 'UNKNOWN'. However, in some openedx deployments, especially those inside an institute or university, users inside the institute or university may use private adress to access openedx, which will generate a lot of 'UNKNOWN' results with the current code. This PR uses ···country_<name/code>_for_private_ip··· rather than UNKNOWN_COUNTRY for such private addresses.

Tests for these modifications will be provided later...
