### PR TITLE
Add IPv6 address support

### DIFF
--- a/edx/analytics/tasks/tests/test_location_per_course.py
+++ b/edx/analytics/tasks/tests/test_location_per_course.py
@@ -69,10 +69,23 @@ class LastCountryOfUserReducerTestCase(ReducerTestMixin, unittest.TestCase):
         self.timestamp = "2013-12-17T15:38:32.805444"
         self.earlier_timestamp = "2013-12-15T15:38:32.805444"
         self.task.geoip = FakeGeoLocation()
+        self.task.country_name_for_private_ip = "PRIVATE NAME"
+        self.task.country_code_for_private_ip = "PRIVATE CODE"
+        self.task.geodata_ipv6 = True
         self.reduce_key = self.username
 
     def test_no_ip(self):
         self.assert_no_output([])
+
+    def test_private_ip(self):
+        inputs = [(self.timestamp, "192.168.0.1")]
+        expected = ((("PRIVATE NAME", "PRIVATE CODE"), self.username),)
+        self._check_output_complete_tuple(inputs, expected)
+
+    def test_single_ipv6(self):
+        inputs = [(self.timestamp, FakeGeoLocation.ip_address_3)]
+        expected = (((FakeGeoLocation.country_name_3, FakeGeoLocation.country_code_3), self.username),)
+        self._check_output_complete_tuple(inputs, expected)
 
     def test_single_ip(self):
         inputs = [(self.timestamp, FakeGeoLocation.ip_address_1)]

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -7,6 +7,7 @@ enum34==1.0.4           # BSD
 filechunkio==1.5	# MIT
 html5lib==1.0b3 	# MIT
 idna==2.0               # BSD-like
+ipaddress==1.0.15   # Python Software Foundation License v2
 isoweek==1.3.0		# BSD
 mechanize==0.2.5	# BSD
 http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-1.2.2.zip  	# GPL v2 with FOSS License Exception


### PR DESCRIPTION
Currently, we assume that the addresses in tracking log are always IPv4 or IPv6 in pipeline. However, in a dual-stack configuration, both IPv4 and IPv6 addresses may occur in the tracking log.
This PR adds support for both IPv4 and IPv6 address by using the "IPv4-Mapped IPv6 Address" feature. An IPv4 address is always converted into its equivalent IPv6 version, so that we can just use the single IPv6 database for processing.
This PR also adds support for specifying country code & name for private addresses (such as "192.168.0.0/16", "172.16.0.0/12" and "10.0.0.0/8").
