### PR TITLE
Fix class name of manifest input format

### DIFF
--- a/config/devstack.cfg
+++ b/config/devstack.cfg
@@ -35,7 +35,7 @@ output_root = hdfs://localhost:9000/edx-analytics-pipeline/event-export-by-cours
 
 [manifest]
 threshold = 500
-input_format = org.edx.localhost.input.ManifestTextInputFormat
+input_format = org.edx.hadoop.input.ManifestTextInputFormat
 lib_jar = hdfs://localhost:9000/edx-analytics-pipeline/packages/edx-analytics-hadoop-util.jar
 path = hdfs://localhost:9000/edx-analytics-pipeline/manifest/
 


### PR DESCRIPTION
@brianhw this has been breaking some single-node deploys and devstacks
