### PR TITLE
Change MySQL requirement location

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -9,7 +9,7 @@ html5lib==1.0b3 	# MIT
 idna==2.0               # BSD-like
 isoweek==1.3.0		# BSD
 mechanize==0.2.5	# BSD
-mysql-connector-python==1.2.2  	# GPL v2 with FOSS License Exception
+http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-1.2.2.zip  	# GPL v2 with FOSS License Exception
 ndg-httpsclient==0.4.0  # BSD
 numpy==1.8.0 		# BSD
 pandas==0.13.0 		# BSD


### PR DESCRIPTION
@nedbat - as discussed in hipchat

Context for others:

http://stackoverflow.com/questions/34489271/i-cannot-install-mysql-connector-python-using-pip/34489738
https://bitbucket.org/pypa/pypi/issues/365/many-packages-have-empty-list-of-links
