### PR TITLE
WIP: cache user information during deidentification

### DIFF
--- a/edx/analytics/tasks/database_imports.py
+++ b/edx/analytics/tasks/database_imports.py
@@ -267,6 +267,7 @@ class ImportAuthUserProfileTask(ImportMysqlToHiveTableTask):
     def columns(self):
         return [
             ('user_id', 'INT'),
+            ('name', 'STRING'),
             ('gender', 'STRING'),
             ('year_of_birth', 'INT'),
             ('level_of_education', 'STRING'),

--- a/edx/analytics/tasks/deidentification.py
+++ b/edx/analytics/tasks/deidentification.py
@@ -10,6 +10,8 @@ import urlparse
 import luigi
 
 from edx.analytics.tasks.encrypt import make_encrypted_file
+from edx.analytics.tasks.mapreduce import MapReduceJobTaskMixin
+from edx.analytics.tasks.util.deid_util import UserInfoDownstreamMixin
 from edx.analytics.tasks.util.file_util import copy_file_to_file
 
 from edx.analytics.tasks.data_deidentification import DeidentifiedCourseDumpTask
@@ -24,7 +26,7 @@ from edx.analytics.tasks.util.tempdir import make_temp_directory
 log = logging.getLogger(__name__)
 
 
-class DeidentifiedCourseTaskMixin(object):
+class DeidentifiedCourseTaskMixin(UserInfoDownstreamMixin, MapReduceJobTaskMixin):
     """Parameters used by DeidentifiedCourseTask."""
 
     deidentified_output_root = luigi.Parameter(
@@ -67,11 +69,16 @@ class DeidentifiedCourseTask(DeidentifiedCourseTaskMixin, luigi.Task):
             dump_root=self.dump_root,
             course=self.course,
             output_root=output_root_with_version,
+            auth_user_path=self.auth_user_path,
+            auth_userprofile_path=self.auth_userprofile_path,
         )
         yield DeidentifyCourseEventsTask(
             dump_root=self.dump_root,
             course=self.course,
             output_root=output_root_with_version,
+            auth_user_path=self.auth_user_path,
+            auth_userprofile_path=self.auth_userprofile_path,
+            n_reduce_tasks=self.n_reduce_tasks,
         )
 
     def run(self):

--- a/edx/analytics/tasks/util/deid_util.py
+++ b/edx/analytics/tasks/util/deid_util.py
@@ -1,3 +1,7 @@
+import luigi
+
+from edx.analytics.tasks.url import ExternalURL
+
 IMPLICIT_EVENT_TYPE_PATTERNS = [
     r"/courses/\(course_id\)/jump_to_id/",
     r"/courses/\(course_id\)/courseware/",
@@ -16,3 +20,67 @@ IMPLICIT_EVENT_TYPE_PATTERNS = [
     r"/courses/\(course_id\)/discussion/forum/[\w\-.]+/(inline|search|threads)$",
     r"/courses/\(course_id\)/discussion/forum/[\w\-.]+/threads/\w+$",
 ]
+
+
+_user_by_id = None
+_user_by_username = None
+
+
+class UserInfoDownstreamMixin(object):
+
+    auth_user_path = luigi.Parameter()
+    auth_userprofile_path = luigi.Parameter()
+
+
+class UserInfoMixin(UserInfoDownstreamMixin):
+
+    def user_info_requirements(self):
+        return {
+            'auth_user': ExternalURL(self.auth_user_path.rstrip('/') + '/'),
+            'auth_userprofile': ExternalURL(self.auth_userprofile_path.rstrip('/') + '/')
+        }
+
+    @property
+    def user_by_id(self):
+        self._intialize_user_info()
+        return _user_by_id
+
+    @property
+    def user_by_username(self):
+        self._intialize_user_info()
+        return _user_by_username
+
+    def _intialize_user_info(self):
+        global _user_by_id
+        global _user_by_username
+
+        if _user_by_id is None:
+            _user_by_id = {}
+            _user_by_username = {}
+
+            input_targets = {k: v.output() for k, v in self.user_info_requirements().items()}
+            with input_targets['auth_user'].open('r') as auth_user_file:
+                for line in auth_user_file:
+                    split_line = line.rstrip('\r\n').split('\x01')
+                    try:
+                        user_id = int(split_line[0])
+                    except ValueError:
+                        continue
+                    username = split_line[1]
+                    _user_by_id[user_id] = {'username': username, 'user_id': user_id}
+                    # Point to the same object so that we can just store two pointers to the data instead of two
+                    # copies of the data
+                    _user_by_username[username] = _user_by_id[user_id]
+
+            with input_targets['auth_userprofile'].open('r') as auth_user_profile_file:
+                for line in auth_user_profile_file:
+                    split_line = line.rstrip('\r\n').split('\x01')
+                    try:
+                        user_id = int(split_line[0])
+                    except ValueError:
+                        continue
+                    name = split_line[1]
+                    try:
+                        _user_by_id[user_id]['name'] = name
+                    except KeyError:
+                        pass

--- a/edx/analytics/tasks/util/file_util.py
+++ b/edx/analytics/tasks/util/file_util.py
@@ -17,13 +17,10 @@ class FileCopyMixin(object):
             """Update hadoop counters as the file is written"""
             self.incr_counter('FileCopyTask', 'Bytes Written to Output', num_bytes)
 
-        if isinstance(self.input(), list):
-            if len(self.input()) == 1:
-                input_target = self.input()[0]
-            else:
-                raise ValueError("Number of input files should be exactly 1")
-        else:
-            input_target = self.input()
+        input_target = self.input()
+
+        if hasattr(self, 'file_input_target'):
+            input_target = self.file_input_target
 
         with self.output().open('w') as output_file:
             with input_target.open('r') as input_file:


### PR DESCRIPTION
@brianhw here is a POC

Stuff that could use work:
- Loading the tables takes so much memory that we cannot run it in the map phase since the large number of map tasks require too many copies of the tables. Doing the join in the reducer allows us to tightly control the number of copies of the tables in memory on a particular node.
- I only wanted to store a single copy of the tables per python process, thus the module scope storage. I also wanted to fail fast if we ever tried to load multiple different copies.
- Passing in the whole path to the tables isn't great... we may want to figure out a better way.
- The way the requirements are handled is not great either.
