### PR TITLE
Use standardized parameter name.

### DIFF
--- a/edx/analytics/tasks/event_exports_by_course.py
+++ b/edx/analytics/tasks/event_exports_by_course.py
@@ -24,7 +24,7 @@ class EventExportByCourseTask(EventLogSelectionMixin, MultiOutputMapReduceJobTas
         config_path={'section': 'event-export-course', 'name': 'output_root'}
     )
 
-    course_id = luigi.Parameter(is_list=True, default=[])
+    course = luigi.Parameter(is_list=True, default=[])
 
     def mapper(self, line):
         event, date_string = self.get_event_and_date_string(line) or (None, None)
@@ -36,7 +36,7 @@ class EventExportByCourseTask(EventLogSelectionMixin, MultiOutputMapReduceJobTas
         if course_id is None:
             return
 
-        if self.course_id and course_id not in self.course_id:
+        if self.course and course_id not in self.course:
             return
 
         key = (date_string, course_id)

--- a/edx/analytics/tasks/tests/test_event_export_by_course.py
+++ b/edx/analytics/tasks/tests/test_event_export_by_course.py
@@ -63,7 +63,7 @@ class EventExportByCourseMapTest(EventExportByCourseBaseTest):
         self.assert_no_map_output_for(line)
 
     def test_output_for_unwanted_event(self):
-        self.create_task(course_id=['Foo'])
+        self.create_task(course=['Foo'])
         line = self.create_event_log_line()
         self.assert_no_map_output_for(line)
 


### PR DESCRIPTION
@mulby @brianhw 
