### PR TITLE
Fix issues preventing remote-task from running pipeline tasks

### DIFF
--- a/edx/analytics/tasks/launchers/remote.py
+++ b/edx/analytics/tasks/launchers/remote.py
@@ -196,7 +196,7 @@ def parse_vagrant_ssh_config(arguments):
         elif key == "Port":
             port = value
         elif key == "IdentityFile":
-            arguments.private_key = value
+            arguments.private_key = value.strip('"')
 
     arguments.host = hostname + ':' + port
 

--- a/share/task.yml
+++ b/share/task.yml
@@ -15,7 +15,7 @@
   gather_facts: False
 
   vars:
-    - repo: git@github.com:edx/edx-analytics-pipeline.git
+    - repo: https://github.com/edx/edx-analytics-pipeline.git
     - branch: master
     # - root_data_dir: /var/lib/analytics-tasks
     # - root_log_dir: /var/log/analytics-tasks


### PR DESCRIPTION
cf. [OLIVE-5](https://openedx.atlassian.net/browse/OLIVE-5)

Building on https://github.com/edx/configuration/pull/2753, this PR fixes issues related to running pipeline tasks from a locally checked out copy of edx-analytics-pipeline via `remote-task`.

**Test instructions**
- Follow instructions from https://github.com/edx/configuration/pull/2753 to set up a new instance of analyticstack.
- Starting from the `analyticstack` directory, update the version of `edx-analytics-pipeline` that is installed into a virtualenv on your local machine:
  
  ``` sh
  cd ../edx-analytics-pipeline
  source venv/bin/activate
  git remote add fork https://github.com/open-craft/edx-analytics-pipeline.git
  git fetch fork
  git checkout tim/fix-analyticstack
  make bootstrap
  ```
- Set `WHEEL_URL`:
  
  ``` sh
  export WHEEL_URL=https://edx-wheelhouse.s3-website-us-east-1.amazonaws.com/Ubuntu/precise
  ```
- Run enrollment task (make sure to adjust `--vagrant-path` before):
  
  ``` sh
  remote-task --vagrant-path /path/to/analytics/analyticstack --remote-name devstack --override-config ${PWD}/config/devstack.cfg --wheel-url $WHEEL_URL --wait ImportEnrollmentsIntoMysql --local-scheduler --interval-end $(date +%Y-%m-%d -d "tomorrow") --n-reduce-tasks 1
  ```
