### PR TITLE
Improve workflow for running acceptance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ test: test-requirements develop test-local
 test-acceptance: test-requirements
 	LUIGI_CONFIG_PATH='config/test.cfg' python -m coverage run --rcfile=./.coveragerc -m nose --nocapture --with-xunit -A acceptance $(ONLY_TESTS)
 
+test-acceptance-local:
+	REMOTE_TASK=$(shell which remote-task) LUIGI_CONFIG_PATH='config/test.cfg' ACCEPTANCE_TEST_CONFIG="/var/tmp/acceptance.json" python -m coverage run --rcfile=./.coveragerc -m nose --nocapture --with-xunit -A acceptance --stop -v $(ONLY_TESTS)
+
 coverage-local: test-local
 	python -m coverage html
 	python -m coverage xml -o coverage.xml
@@ -67,4 +70,3 @@ coverage: test coverage-local
 
 todo:
 	pylint --disable=all --enable=W0511 edx
-

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The Hadoop-based data pipeline.
 Installation instructions
 --------------------
 
-We have some draft docs: 
+We have some draft docs:
 
 * https://openedx.atlassian.net/wiki/display/OpenOPS/edX+Analytics+Installation describes how to install a small scale analytics stack on a single machine. It'll get merged into the next doc below at some point. Help welcome!
 * http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/latest/analytics/install_analytics.html has an overview of a larger scale AWS install.
@@ -56,6 +56,9 @@ Values for `<OPERATING SYSTEM>/<OS VARIANT>`:
 
 Running the Tests
 -----------------
+
+### Unit tests
+
 Run `make test` to install the Python requirements and run the unit tests.
 
 Some of the tests rely on AWS. If you encounter errors such as `NoAuthHandlerFound: No handler was ready to authenticate. 1 handlers were checked. ['HmacAuthV1Handler'] Check your credentials`,
@@ -65,6 +68,111 @@ valid credentials for the tests to pass, so the commands below should fix the fa
     export AWS_ACCESS_KEY_ID='AK123'
     export AWS_SECRET_ACCESS_KEY='abc123'
 
+### Acceptance tests
+
+**Preconditions**
+
+To be able to run acceptance tests on an instance of the Analytics
+Devstack, the following conditions must hold:
+
+- [`/var/tmp/acceptance.json`](https://github.com/edx/configuration/blob/master/playbooks/roles/analytics_pipeline/files/acceptance.json)
+  is present on your instance of Analytics Devstack. This file
+  contains the default configuration for running acceptance tests.
+
+- The `pipeline001` user has access to tables storing acceptance test
+  data. You can verify this by doing the following (as `vagrant` user):
+
+  ```sh
+  mysql -u root
+  SHOW GRANTS FOR 'pipeline001'@'localhost';
+  ```
+
+  If your instance is configured correctly, you should get the
+  following output:
+
+  ```
+  +----------------------------------------------------------------------+
+  | Grants for pipeline001@localhost                                     |
+  +----------------------------------------------------------------------+
+  | ...                                                                  |
+  | GRANT ALL PRIVILEGES ON `acceptance%`.* TO 'pipeline001'@'localhost' |
+  +----------------------------------------------------------------------+
+  ```
+
+- The pipeline has installed itself on your instance of Analytics
+  Devstack. This happens when you run a pipeline task on the instance
+  as described in [this section](https://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/latest/devstack/analytics_devstack.html#run-the-open-edx-analytics-pipeline)
+  of the [official installation instructions](https://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/latest/devstack/analytics_devstack.html).
+
+If you are running a recent version of the Analytics Devstack (and
+followed the official installation instructions to set it up), the
+conditions above should already be satisfied.
+
+**Steps**
+
+1. If you haven't already, check out a local copy of this repository
+   into the local directory of your Analytics Devstack installation.
+   Restart the instance and make sure the repository is mounted at
+   `/edx/app/analytics_pipeline/analytics_pipeline`.
+
+2. If the code you would like to test lives on a different branch than
+   `master`, navigate to `/edx/app/analytics_pipeline/analytics_pipeline`
+   and check out that branch.
+
+3. Navigate to `/var/lib/analytics-tasks/devstack/repo/scripts`
+   (this is where the pipeline installs itself by default) and check
+   out the branch that contains the test code you would like to use.
+   *This step is only necessary if you modified existing tests or
+   created new tests that you'd like to run. You can skip it if you
+   want to run acceptance tests to verify changes to existing pipeline
+   tasks*.
+
+4. From `/var/lib/analytics-tasks/devstack/repo/scripts`, run the
+   following command to launch the entire test suite:
+
+   ```sh
+   ./run_acceptance.sh --update
+   ```
+
+   The `--update`/`-u` option ensures that the venv in which the tests
+   will be executed is up-to-date; you can leave it off when running
+   another test.
+
+   You can also limit test execution to a certain module, class, or
+   method. To do this, use the `--test`/`-t` option:
+
+   ```sh
+   ./run_acceptance.sh --test test_course_catalog
+   ./run_acceptance.sh --test test_course_catalog:CourseSubjectsAcceptanceTest
+   ./run_acceptance.sh --test test_course_catalog:CourseSubjectsAcceptanceTest.test_course_subjects
+   ```
+
+   The `--test`/`t` option allows you to specify multiple test
+   modules/classes/methods at the same time:
+
+   ```sh
+   ./run_acceptance.sh -t test_course_catalog -t test_video
+   ```
+
+   Note that when running multiple tests, execution will stop
+   after the first error or failure. (This is helpful because
+   acceptance tests can take a long time to finish.)
+
+   Note also that some tests depend on the availability of specific
+   services to run successfully. When running these tests on an
+   instance of the Analytics Devstack, they will be skipped with
+   output similar to this:
+
+   ```
+   Tests the workflow for the course subjects, end to end. ... SKIP: S3 is not available
+
+   ----------------------------------------------------------------------
+   XML: nosetests.xml
+   ----------------------------------------------------------------------
+   Ran 1 test in 0.001s
+
+   OK (SKIP=1)
+   ```
 
 How to Contribute
 -----------------

--- a/edx/analytics/tasks/tests/acceptance/services/vertica.py
+++ b/edx/analytics/tasks/tests/acceptance/services/vertica.py
@@ -63,8 +63,6 @@ class VerticaService(object):
         """
         Connect to the Vertica server.
         """
-        if self.disabled:
-            raise unittest.SkipTest('The vertica service is disabled')
         return vertica_python.connect(user=self.credentials.get('user'), password=self.credentials.get('password'),
                                       database='', host=self.credentials.get('host'))
 

--- a/edx/analytics/tasks/tests/acceptance/test_answer_dist.py
+++ b/edx/analytics/tasks/tests/acceptance/test_answer_dist.py
@@ -7,7 +7,7 @@ import logging
 
 from luigi.s3 import S3Target
 
-from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase
+from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase, when_s3_available
 from edx.analytics.tasks.url import url_path_join
 
 
@@ -41,6 +41,7 @@ class BaseAnswerDistributionAcceptanceTest(AcceptanceTestCase):
 class AnswerDistributionAcceptanceTest(BaseAnswerDistributionAcceptanceTest):
     """Acceptance test for the CSV-generating Answer Distribution Task"""
 
+    @when_s3_available
     def test_answer_distribution(self):
         self.task.launch([
             'AnswerDistributionOneFilePerCourseTask',
@@ -78,6 +79,7 @@ class AnswerDistributionAcceptanceTest(BaseAnswerDistributionAcceptanceTest):
 class AnswerDistributionMysqlAcceptanceTests(BaseAnswerDistributionAcceptanceTest):
     """Acceptance tests for Answer Distribution Tasks -> MySQL"""
 
+    @when_s3_available
     def test_answer_distribution_mysql(self):
         self.task.launch([
             'AnswerDistributionToMySQLTaskWorkflow',

--- a/edx/analytics/tasks/tests/acceptance/test_course_catalog.py
+++ b/edx/analytics/tasks/tests/acceptance/test_course_catalog.py
@@ -7,7 +7,7 @@ import logging
 
 import pandas
 
-from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase
+from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase, when_s3_available, when_vertica_available
 from edx.analytics.tasks.url import url_path_join
 
 
@@ -37,6 +37,8 @@ class BaseCourseCatalogAcceptanceTest(AcceptanceTestCase):
 class CourseSubjectsAcceptanceTest(BaseCourseCatalogAcceptanceTest):
     """End-to-end test of pulling the course subject data into Vertica."""
 
+    @when_s3_available
+    @when_vertica_available
     def test_course_subjects(self):
         """Tests the workflow for the course subjects, end to end."""
 

--- a/edx/analytics/tasks/tests/acceptance/test_database_export.py
+++ b/edx/analytics/tasks/tests/acceptance/test_database_export.py
@@ -17,7 +17,7 @@ import gnupg
 
 from edx.analytics.tasks.url import url_path_join
 from edx.analytics.tasks.tests import unittest
-from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase
+from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase, when_s3_available, when_exporter_available
 from edx.analytics.tasks.tests.acceptance.services import shell
 from edx.analytics.tasks.util.opaque_key_util import get_filename_safe_course_id, get_org_id_for_course
 
@@ -63,7 +63,8 @@ class ExportAcceptanceTest(AcceptanceTestCase):
         # The exporter expects this directory to already exist.
         os.makedirs(os.path.join(self.working_dir, 'course-data'))
 
-    @unittest.skipIf(os.getenv('EXPORTER') is None, "requires private Exporter code")
+    @when_s3_available
+    @when_exporter_available
     def test_database_export(self):
         # An S3 bucket to store the output in.
         assert('exporter_output_bucket' in self.config)

--- a/edx/analytics/tasks/tests/acceptance/test_enrollment_validation.py
+++ b/edx/analytics/tasks/tests/acceptance/test_enrollment_validation.py
@@ -9,8 +9,8 @@ import StringIO
 
 from luigi.s3 import S3Target
 
+from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase, when_s3_available
 from edx.analytics.tasks.url import url_path_join
-from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase
 
 
 log = logging.getLogger(__name__)
@@ -28,6 +28,7 @@ class EnrollmentValidationAcceptanceTest(AcceptanceTestCase):
     WIDER_DATE_INTERVAL = "{}-{}".format(START_DATE, END_DATE + datetime.timedelta(days=1))
     SQL_FIXTURE = 'load_student_courseenrollment_for_enrollment_validation.sql'
 
+    @when_s3_available
     def test_enrollment_validation(self):
         # Initial setup.
         self.upload_tracking_log(self.INPUT_FILE, self.START_DATE)

--- a/edx/analytics/tasks/tests/acceptance/test_event_export.py
+++ b/edx/analytics/tasks/tests/acceptance/test_event_export.py
@@ -6,12 +6,11 @@ import os
 import logging
 import tempfile
 import textwrap
-import time
 import shutil
 
 from luigi.s3 import S3Target
 
-from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase
+from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase, when_s3_available
 from edx.analytics.tasks.tests.acceptance.services import fs, shell
 from edx.analytics.tasks.url import url_path_join
 
@@ -77,6 +76,7 @@ class EventExportAcceptanceTest(AcceptanceTestCase):
             if not key_filename.endswith('.key'):
                 self.s3_client.put(full_local_path, remote_url)
 
+    @when_s3_available
     def test_event_log_exports_using_manifest(self):
         config_override = {
             'manifest': {

--- a/edx/analytics/tasks/tests/acceptance/test_financial_reports.py
+++ b/edx/analytics/tasks/tests/acceptance/test_financial_reports.py
@@ -9,7 +9,7 @@ from cStringIO import StringIO
 import pandas
 
 from edx.analytics.tasks.tests import unittest
-from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase
+from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase, when_vertica_available
 from edx.analytics.tasks.url import url_path_join
 from edx.analytics.tasks.reports.reconcile import LoadInternalReportingOrderTransactionsToWarehouse
 
@@ -23,9 +23,6 @@ class FinancialReportsAcceptanceTest(AcceptanceTestCase):
 
     def setUp(self):
         super(FinancialReportsAcceptanceTest, self).setUp()
-
-        if self.vertica.disabled:
-            raise unittest.SkipTest('The vertica service is disabled')
 
         for input_file_name in ('paypal.tsv', 'cybersource_test.tsv'):
             src = url_path_join(self.data_dir, 'input', input_file_name)
@@ -44,6 +41,7 @@ class FinancialReportsAcceptanceTest(AcceptanceTestCase):
         for filename in os.listdir(sql_fixture_base_url):
             self.execute_sql_fixture_file(url_path_join(sql_fixture_base_url, filename), database=database)
 
+    @when_vertica_available
     def test_end_to_end(self):
         self.task.launch([
             'BuildFinancialReportsTask',

--- a/edx/analytics/tasks/tests/acceptance/test_internal_reporting_course.py
+++ b/edx/analytics/tasks/tests/acceptance/test_internal_reporting_course.py
@@ -12,7 +12,7 @@ import pandas
 
 from datetime import date
 
-from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase
+from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase, when_s3_available, when_vertica_available
 from edx.analytics.tasks.url import url_path_join
 
 
@@ -46,6 +46,8 @@ class DCourseLoadAcceptanceTest(AcceptanceTestCase):
         # Upload mocked results of the API call
         self.s3_client.put(src, dst)
 
+    @when_s3_available
+    @when_vertica_available
     def test_internal_reporting_course(self):
         """Tests the workflow for the d_course table, end to end."""
 

--- a/edx/analytics/tasks/tests/acceptance/test_internal_reporting_user.py
+++ b/edx/analytics/tasks/tests/acceptance/test_internal_reporting_user.py
@@ -5,12 +5,13 @@ End to end test of the internal reporting user table loading task.
 import os
 import logging
 import datetime
+import unittest
 
 import pandas
 
 from luigi.date_interval import Date
 
-from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase
+from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase, when_vertica_available
 from edx.analytics.tasks.url import url_path_join
 
 
@@ -33,6 +34,7 @@ class InternalReportingUserLoadAcceptanceTest(AcceptanceTestCase):
         # Put up the mock tracking log for user locations.
         self.upload_tracking_log(self.INPUT_FILE, datetime.datetime(2014, 7, 21))
 
+    @when_vertica_available
     def test_internal_reporting_user(self):
         """Tests the workflow for the internal reporting user table, end to end."""
 

--- a/edx/analytics/tasks/tests/acceptance/test_internal_reporting_user_activity.py
+++ b/edx/analytics/tasks/tests/acceptance/test_internal_reporting_user_activity.py
@@ -7,7 +7,7 @@ import logging
 import datetime
 import luigi
 import pandas
-from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase
+from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase, when_vertica_available
 from edx.analytics.tasks.url import url_path_join
 
 
@@ -40,6 +40,7 @@ class InternalReportingUserActivityLoadAcceptanceTest(AcceptanceTestCase):
             log.debug(insert_query)
             cursor.execute(insert_query)
 
+    @when_vertica_available
     def test_internal_reporting_user_activity(self):
         """Tests the workflow for the internal reporting user activity table, end to end."""
 

--- a/edx/analytics/tasks/tests/acceptance/test_location_per_course.py
+++ b/edx/analytics/tasks/tests/acceptance/test_location_per_course.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from luigi.date_interval import Date
 
 from edx.analytics.tasks.url import url_path_join
-from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase
+from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase, when_geolocation_data_available
 
 
 class LocationByCourseAcceptanceTest(AcceptanceTestCase):
@@ -20,6 +20,7 @@ class LocationByCourseAcceptanceTest(AcceptanceTestCase):
         'load_auth_user_for_location_by_course.sql'
     ]
 
+    @when_geolocation_data_available
     def test_location_by_course(self):
         self.upload_tracking_log(self.INPUT_FILE, self.START_DATE)
 

--- a/edx/analytics/tasks/tests/acceptance/test_student_engagement.py
+++ b/edx/analytics/tasks/tests/acceptance/test_student_engagement.py
@@ -10,7 +10,7 @@ import re
 
 from luigi.s3 import S3Target
 
-from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase
+from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase, when_s3_available
 from edx.analytics.tasks.url import url_path_join
 
 from pandas import read_csv
@@ -47,6 +47,7 @@ class StudentEngagementAcceptanceTest(AcceptanceTestCase):
         },
     }
 
+    @when_s3_available
     def test_student_engagement(self):
         self.upload_tracking_log(self.INPUT_FILE, datetime.date(2015, 4, 10))
         self.execute_sql_fixture_file('load_student_engagement.sql')

--- a/scripts/run_acceptance.sh
+++ b/scripts/run_acceptance.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Use this script to run the entire suite of acceptance tests
+# or one or more specific test modules/classes/methods
+#
+
+function usage
+{
+    echo "Usage: ./run_acceptance.sh [[[-t test] [-u]] | [-h]]"
+}
+
+TESTS=()
+UPDATE_VENV=
+
+while [ "$1" != "" ]; do
+    case "$1" in
+        -t | --test )
+            shift
+            TEST="$1"
+            TESTS+=("edx.analytics.tasks.tests.acceptance."$TEST)
+            ;;
+        -u | --update )
+            UPDATE_VENV=1
+            ;;
+        -h | --help )
+            usage
+            exit
+            ;;
+        * )
+            usage
+            exit 1
+    esac
+    shift
+done
+
+# Environment
+
+WORKING_DIRECTORY=/var/lib/analytics-tasks/devstack/repo
+
+TASKS_REPO=/edx/app/analytics_pipeline/analytics_pipeline
+
+# Check if repo has been cloned and mounted at default location
+if [ ! -d "$TASKS_REPO" ]
+then
+    echo "Please make sure edx-analytics-pipeline is mounted at ${TASKS_REPO}. See README.md for more info."
+    exit 1
+fi
+
+# Prepare environment as "vagrant" user
+if [ -n "$UPDATE_VENV" ]
+then
+    sudo -Hu vagrant /bin/bash<<-PREPARE
+cd $WORKING_DIRECTORY
+
+# Activate virtualenv
+source ../venv/bin/activate
+
+# Prepare virtualenv for testing
+make develop-local
+make test-requirements
+PREPARE
+fi
+
+# Tests
+
+# Run tests as "hadoop" user
+sudo -Hu hadoop /bin/bash<<-RUN
+cd $WORKING_DIRECTORY
+
+# Activate virtualenv
+source ../venv/bin/activate
+
+# Run tests
+make test-acceptance-local ONLY_TESTS="${TESTS[@]}"
+RUN

--- a/share/task.yml
+++ b/share/task.yml
@@ -82,7 +82,7 @@
         - "{{ log_dir }}"
 
     - name: analytics tasks repository checked out
-      git: repo={{ repo }} dest={{ working_repo_dir }} version=release
+      git: repo={{ repo }} dest={{ working_repo_dir }} version=master
 
     - name: branch fetched
       command: git fetch --all chdir={{ working_repo_dir }}


### PR DESCRIPTION
This PR aims to improve the workflow for running acceptance tests in instances of the Analytics Devstack. It introduces a wrapper script that can run the whole test suite or just a specific test module/class/method. It also adds code that makes sure tests depending on services that are unavailable in a local test environment are skipped correctly.

**Test instructions**

To prepare for testing, complete the following steps:
- Test https://github.com/edx/configuration/pull/2790.
- Starting from the `analyticstack` directory, update the version of edx-analytics-pipeline that you checked out while testing https://github.com/edx/configuration/pull/2790 and run a pipeline task (make sure to adjust `--vagrant-path` before):
  
  ``` sh
  cd ../edx-analytics-pipeline
  source venv/bin/activate
  git remote add fork https://github.com/open-craft/edx-analytics-pipeline.git
  git fetch fork
  git checkout tim/improve-pipeline-workflow
  make bootstrap
  export WHEEL_URL=https://edx-wheelhouse.s3-website-us-east-1.amazonaws.com/Ubuntu/precise
  remote-task --vagrant-path /path/to/analytics/analyticstack --remote-name devstack --override-config ${PWD}/config/devstack.cfg --wheel-url $WHEEL_URL --wait ImportEnrollmentsIntoMysql --local-scheduler --interval-end $(date +%Y-%m-%d -d "tomorrow") --n-reduce-tasks 1 
  ```
  
  This will cause edx-analytics-pipeline to "install itself" on your Analytics Devstack (which is necessary because edx-analytics-pipeline is currently _not_ installed like any other repo when creating an instance of Analytics Devstack).

To test the changes in this PR, follow these steps:
- Starting from the `analyticstack` directory, shut down Analytics Devstack and check out another copy of edx-analytics-pipeline:
  
  ``` sh
  cd ../analyticstack
  vagrant halt
  git clone https://github.com/open-craft/edx-analytics-pipeline.git
  cd edx-analytics-pipeline
  git checkout tim/improve-pipeline-workflow
  ```
- Modify Vagrantfile to mount the repository at `/edx/app/analytics_pipeline/analytics_pipeline`:
  
  ``` ruby
    :analytics_pipeline => {:repo => "edx-analytics-pipeline", :local => "/edx/app/analytics_pipeline/analytics_pipeline", :owner => "hadoop"},
  ```
  
  **Note**: As of https://github.com/edx/configuration/commit/3f6082eedf862a2729679ba51a542b0d5d5aafe5, this step is no longer necessary.
- Bring Analytics Devstack back up and use new script to run acceptance tests:
  
  ``` sh
  vagrant up
  cd /var/lib/analytics-tasks/devstack/repo/scripts  # This is where edx-analytics-pipeline installed itself
  ./run_acceptance.sh --test test_video --update
  ```
  
  As mentioned above, you can also specify that you want to limit execution to a certain test class (e.g., `test_video:VideoAcceptanceTest`) or method (e.g., `test_video:VideoAcceptanceTest.test_video_timeline`) when running tests. The `--update` option ensures that the venv in which the tests will be executed is up-to-date; you can leave it off when running another test.
- Verify that the tests that have been annotated to require specific services (such as S3) are skipped when you try to run them. For example, the following command
  
  ``` sh
  ./run_acceptance.sh --test test_course_catalog
  ```
  
  should output:
  
  ```
  Tests the workflow for the course subjects, end to end. ... SKIP: S3 is not available
  
  ----------------------------------------------------------------------
  XML: nosetests.xml
  ----------------------------------------------------------------------
  Ran 1 test in 0.001s
  
  OK (SKIP=1)
  ```
