### PR TITLE
Move edx.analytics.task parameter documentation into description fields

### DIFF
--- a/edx/analytics/tasks/calendar_task.py
+++ b/edx/analytics/tasks/calendar_task.py
@@ -37,12 +37,11 @@ class CalendarTask(CalendarDownstreamMixin, luigi.Task):
     It is also intended to contain business-specific metadata about dates in the future, such as fiscal year boundaries,
     fiscal quarter boundaries and even holidays or other days of special interest for analysis purposes.
 
-    Parameters:
-
-        output_root (str): path to store the calendar data
     """
 
-    output_root = luigi.Parameter()
+    output_root = luigi.Parameter(
+        description='URL to store the calendar data.',
+    )
 
     def output(self):
         return get_target_from_url(url_path_join(self.output_root, 'data.tsv'))

--- a/edx/analytics/tasks/course_catalog.py
+++ b/edx/analytics/tasks/course_catalog.py
@@ -22,8 +22,14 @@ urllib3.contrib.pyopenssl.inject_into_urllib3()
 class PullCatalogMixin(OverwriteOutputMixin, WarehouseMixin):
     """Define common parameters for the course catalog API pull and downstream tasks."""
 
-    run_date = luigi.DateParameter(default=datetime.datetime.utcnow().date())
-    catalog_path = luigi.Parameter(config_path={'section': 'course-catalog', 'name': 'catalog_path'})
+    run_date = luigi.DateParameter(
+        default=datetime.datetime.utcnow().date(),
+        description='Default is today, UTC.',
+    )
+    catalog_path = luigi.Parameter(
+        config_path={'section': 'course-catalog', 'name': 'catalog_path'},
+        description='Base URL for the drupal catalog API, e.g. https://www.edx.org/api/catalog/v2/courses',
+    )
 
 
 class DailyPullCatalogTask(PullCatalogMixin, luigi.Task):

--- a/edx/analytics/tasks/course_enroll.py
+++ b/edx/analytics/tasks/course_enroll.py
@@ -179,22 +179,32 @@ class BaseCourseEnrollmentTaskDownstreamMixin(OverwriteOutputMixin, MapReduceJob
     """
     Base class mixin for course enrollment calculations.
 
-    Parameters:
-      name: a unique identifier to distinguish one run from another.  It is used in
-          the construction of output filenames, so each run will have distinct outputs.
-      src:  a URL to the root location of input tracking log files.
-      dest:  a URL to the root location to write output file(s).
-      include:  a list of patterns to be used to match input files, relative to `src` URL.
-          The default value is ['*'].
-      manifest: a URL to a file location that can store the complete set of input files.
-      run_date: the date to use as the partition version
     """
-    name = luigi.Parameter()
-    src = luigi.Parameter(is_list=True)
-    dest = luigi.Parameter()
-    include = luigi.Parameter(is_list=True, default=('*',))
-    manifest = luigi.Parameter(default=None)
-    run_date = luigi.Parameter(default=datetime.date.today())
+    name = luigi.Parameter(
+        description='A unique identifier to distinguish one run from another.  It is used in '
+        'the construction of output filenames, so each run will have distinct outputs.',
+    )
+    src = luigi.Parameter(
+        is_list=True,
+        description='A list of URLs to the root location of input tracking log files.',
+    )
+    dest = luigi.Parameter(
+        description='A URL to the root location to write output file(s).',
+    )
+    include = luigi.Parameter(
+        is_list=True,
+        default=('*',),
+        description='A list of patterns to be used to match input files, relative to `src` URL. '
+        'The default value is [\'*\'].',
+    )
+    manifest = luigi.Parameter(
+        default=None,
+        description='A URL to a file location that can store the complete set of input files.',
+    )
+    run_date = luigi.Parameter(
+        default=datetime.date.today(),
+        description='The date to use as the partition version. Default is today.',
+    )
 
 
 ##################################

--- a/edx/analytics/tasks/database_exports.py
+++ b/edx/analytics/tasks/database_exports.py
@@ -54,12 +54,14 @@ class StudentModulePerCourseTask(MultiOutputMapReduceJobTask):
     Separates a raw SQL dump of a courseware_studentmodule table into
     a different tsv file for each course.
 
-    Parameters:
-        dump_root: a URL location of the database dump.
-        output_suffix: added to the filenames for identification.
     """
-    dump_root = luigi.Parameter()
-    output_suffix = luigi.Parameter(default=None)
+    dump_root = luigi.Parameter(
+        description='A URL input path pointing to the raw output from the sqoop job.',
+    )
+    output_suffix = luigi.Parameter(
+        default=None,
+        description='Added to the filenames for identification.',
+    )
 
     def requires(self):
         return PathSetTask(self.dump_root)
@@ -114,23 +116,26 @@ class StudentModulePerCourseAfterImportWorkflow(StudentModulePerCourseTask):
     Generates a raw SQL dump of a courseware_studentmodule table
     and separates it into a different tsv file for each course.
 
-    Parameters:
-        dump_root: a URL location of the database dump.
-        output_root: a URL location where the split files will be stored.
-        output_suffix: added to the filenames for identification.
-        delete_output_root: if True, recursively deletes the output_root at task creation.
-        credentials: Path to the external access credentials file.
-        num_mappers: The number of map tasks to ask Sqoop to use.
-        where:  A 'where' clause to be passed to Sqoop.
-        verbose: Sqoop prints more information while working.
-
     """
     credentials = luigi.Parameter(
-        config_path={'section': 'database-import', 'name': 'credentials'}
+        config_path={'section': 'database-import', 'name': 'credentials'},
+        description='Path to the external access credentials file. '
+        'The database will be read, not written to.',
     )
-    num_mappers = luigi.Parameter(default=None, significant=False)  # TODO: move to config
-    where = luigi.Parameter(default=None)
-    verbose = luigi.BooleanParameter(default=False, significant=False)
+    num_mappers = luigi.Parameter(  # TODO: move to config
+        default=None,
+        significant=False,
+        description='The number of map tasks to ask Sqoop to use.',
+    )
+    where = luigi.Parameter(
+        default=None,
+        description='A "where" clause to be passed to Sqoop.',
+    )
+    verbose = luigi.BooleanParameter(
+        default=False,
+        significant=False,
+        description='Sqoop prints more information while working.',
+    )
 
     def requires(self):
         table_name = 'courseware_studentmodule'

--- a/edx/analytics/tasks/database_imports.py
+++ b/edx/analytics/tasks/database_imports.py
@@ -20,14 +20,6 @@ class DatabaseImportMixin(object):
     """
     Provides general parameters needed for accessing RDBMS databases.
 
-    Parameters:
-
-        destination: The directory to write the output files to.
-        credentials: Path to the external access credentials file.
-        num_mappers: The number of map tasks to ask Sqoop to use.
-        verbose: Print more information while working.  Default is False.
-        import_date:  Date to assign to Hive partition.  Default is today's date.
-
     Example Credentials File::
 
         {
@@ -38,18 +30,30 @@ class DatabaseImportMixin(object):
         }
     """
     destination = luigi.Parameter(
-        config_path={'section': 'database-import', 'name': 'destination'}
+        config_path={'section': 'database-import', 'name': 'destination'},
+        description='The directory to write the output files to.'
     )
     credentials = luigi.Parameter(
-        config_path={'section': 'database-import', 'name': 'credentials'}
+        config_path={'section': 'database-import', 'name': 'credentials'},
+        description='Path to the external access credentials file.',
     )
     database = luigi.Parameter(
         default_from_config={'section': 'database-import', 'name': 'database'}
     )
-
-    import_date = luigi.DateParameter(default=None)
-    num_mappers = luigi.Parameter(default=None, significant=False)
-    verbose = luigi.BooleanParameter(default=False, significant=False)
+    import_date = luigi.DateParameter(
+        default=None,
+        description='Date to assign to Hive partition.  Default is today\'s date, UTC.',
+    )
+    num_mappers = luigi.Parameter(
+        default=None,
+        significant=False,
+        description='The number of map tasks to ask Sqoop to use.',
+    )
+    verbose = luigi.BooleanParameter(
+        default=False,
+        significant=False,
+        description='Print more information while working.',
+    )
 
     def __init__(self, *args, **kwargs):
         super(DatabaseImportMixin, self).__init__(*args, **kwargs)

--- a/edx/analytics/tasks/enrollments.py
+++ b/edx/analytics/tasks/enrollments.py
@@ -275,14 +275,24 @@ class CourseEnrollmentTableDownstreamMixin(WarehouseMixin, EventLogSelectionDown
     """All parameters needed to run the CourseEnrollmentTableTask task."""
 
     # Make the interval be optional:
-    interval = luigi.DateIntervalParameter(default=None)
+    interval = luigi.DateIntervalParameter(
+        default=None,
+        description='The range of dates to export logs for. '
+        'If not specified, `interval_start` and `interval_end` are used to construct the `interval`.',
+    )
 
     # Define optional parameters, to be used if 'interval' is not defined.
     interval_start = luigi.DateParameter(
         config_path={'section': 'enrollments', 'name': 'interval_start'},
         significant=False,
+        description='The start date to export logs for.  Ignored if `interval` is provided.',
     )
-    interval_end = luigi.DateParameter(default=datetime.datetime.utcnow().date(), significant=False)
+    interval_end = luigi.DateParameter(
+        default=datetime.datetime.utcnow().date(),
+        significant=False,
+        description='The end date to export logs for.  Ignored if `interval` is provided. '
+        'Default is today, UTC.',
+    )
 
     def __init__(self, *args, **kwargs):
         super(CourseEnrollmentTableDownstreamMixin, self).__init__(*args, **kwargs)

--- a/edx/analytics/tasks/event_exports.py
+++ b/edx/analytics/tasks/event_exports.py
@@ -24,42 +24,34 @@ class EventExportTask(EventLogSelectionMixin, MultiOutputMapReduceJobTask):
     """
     Group events by institution and export them for research purposes.
 
-    Parameters:
-        output_root: Directory to store the output in.
-        config: A URL to a YAML file that contains the list of organizations and servers to export events for.
-        org_id: A list of organizations to process data for. If provided, only these organizations will be processed.
-            Otherwise, all valid organizations will be processed.
-        environment: A single string that describe the single environment that generated the events.
-        interval: The range of dates to export logs for.
-
-        The following are defined in EventLogSelectionMixin:
-        source: A URL to a path that contains log files that contain the events.
-        pattern: A regex with a named capture group for the date that approximates the date that the events within were
-            emitted. Note that the search interval is expanded, so events don't have to be in exactly the right file
-            in order for them to be processed.
-
     """
 
     output_root = luigi.Parameter(
-        config_path={'section': 'event-export', 'name': 'output_root'}
+        config_path={'section': 'event-export', 'name': 'output_root'},
+        description='Directory to store the output in.',
     )
     config = luigi.Parameter(
-        config_path={'section': 'event-export', 'name': 'config'}
+        config_path={'section': 'event-export', 'name': 'config'},
+        description='A URL to a YAML file that contains the list of organizations and servers to export events for.',
     )
-    org_id = luigi.Parameter(is_list=True, default=[])
-
+    org_id = luigi.Parameter(
+        is_list=True,
+        default=[],
+        description='A list of organizations to process data for. If provided, only these organizations will be '
+        'processed.  Otherwise, all valid organizations will be processed.',
+    )
     gpg_key_dir = luigi.Parameter(
-        config_path={'section': 'event-export', 'name': 'gpg_key_dir'}
+        config_path={'section': 'event-export', 'name': 'gpg_key_dir'},
     )
     gpg_master_key = luigi.Parameter(
-        config_path={'section': 'event-export', 'name': 'gpg_master_key'}
+        config_path={'section': 'event-export', 'name': 'gpg_master_key'},
     )
     environment = luigi.Parameter(
-        config_path={'section': 'event-export', 'name': 'environment'}
+        config_path={'section': 'event-export', 'name': 'environment'},
+        description='A single string that describe the single environment that generated the events.',
     )
-
     required_path_text = luigi.Parameter(
-        config_path={'section': 'event-export', 'name': 'required_path_text'}
+        config_path={'section': 'event-export', 'name': 'required_path_text'},
     )
 
     def requires_local(self):

--- a/edx/analytics/tasks/load_internal_reporting_course.py
+++ b/edx/analytics/tasks/load_internal_reporting_course.py
@@ -27,7 +27,10 @@ class LoadInternalReportingCourseMixin(WarehouseMixin, OverwriteOutputMixin):
     Mixin to handle parameters common to the tasks involved in loading the internal reporting course table,
     including calling the course structure API.
     """
-    run_date = luigi.DateParameter(default=datetime.datetime.utcnow().date())
+    run_date = luigi.DateParameter(
+        default=datetime.datetime.utcnow().date(),
+        description='Default is today, UTC.',
+    )
     api_root_url = luigi.Parameter(
         config_path={'section': 'course-structure', 'name': 'api_root_url'}
     )

--- a/edx/analytics/tasks/load_internal_reporting_user.py
+++ b/edx/analytics/tasks/load_internal_reporting_user.py
@@ -74,18 +74,19 @@ class LoadInternalReportingUserToWarehouse(WarehouseMixin, VerticaCopyTask):
     """
     Loads the user table from Hive into the Vertica data warehouse.
 
-    Parameters:
-        interval: a date_interval object containing the interval over which to pull data for user location.
-                  Should usually be from the beginning of the Open edX installation to the present day
-                  (i.e. through the previous day).
-        user_country_output: location for intermediate output of location_per_course task.
-        n_reduce_tasks: number of reduce tasks
     """
-    interval = luigi.DateIntervalParameter()
-    user_country_output = luigi.Parameter(
-        config_path={'section': 'last-country-of-user', 'name': 'user_country_output'}
+    interval = luigi.DateIntervalParameter(
+        description='A date_interval object containing the interval over which to pull data for user location. '
+        'Should usually be from the beginning of the Open edX installation to the present day '
+        '(i.e. through the previous day).',
     )
-    n_reduce_tasks = luigi.Parameter()
+    user_country_output = luigi.Parameter(
+        config_path={'section': 'last-country-of-user', 'name': 'user_country_output'},
+        description='Location for intermediate output of location_per_course task.',
+    )
+    n_reduce_tasks = luigi.Parameter(
+        description='Number of reduce tasks',
+    )
 
     @property
     def partition(self):

--- a/edx/analytics/tasks/load_internal_reporting_user_activity.py
+++ b/edx/analytics/tasks/load_internal_reporting_user_activity.py
@@ -66,14 +66,14 @@ class LoadInternalReportingUserActivityToWarehouse(WarehouseMixin, VerticaCopyTa
     """
     Loads the user activity table from Hive into the Vertica data warehouse.
 
-    Parameters:
-        interval: a date_interval object containing the interval over which to pull data for user location.  Should
-                  usually be from the beginning of edX to the present day (i.e. through the previous day).
-        n_reduce_tasks: number of reduce tasks
-        overwrite: whether or not to overwrite existing outputs; set to False by default for now
     """
-    interval = luigi.DateIntervalParameter()
-    n_reduce_tasks = luigi.Parameter()
+    interval = luigi.DateIntervalParameter(
+        description='A date_interval object containing the interval over which to pull data for user location. '
+        'Should usually be from the beginning of edX to the present day (i.e. through the previous day).',
+    )
+    n_reduce_tasks = luigi.Parameter(
+        description='Number of reduce tasks',
+    )
 
     @property
     def partition(self):
@@ -226,7 +226,10 @@ class InternalReportingUserActivityWorkflow(VerticaCopyTaskMixin, WarehouseMixin
 
 class UserActivityWorkflow(luigi.WrapperTask):
 
-    end_date = luigi.DateParameter(default=datetime.datetime.utcnow().date())
+    end_date = luigi.DateParameter(
+        default=datetime.datetime.utcnow().date(),
+        description='Default is today, UTC.',
+    )
     weeks = luigi.IntParameter(default=24)
     n_reduce_tasks = luigi.Parameter()
     interval = luigi.DateIntervalParameter()

--- a/edx/analytics/tasks/location_per_course.py
+++ b/edx/analytics/tasks/location_per_course.py
@@ -30,15 +30,10 @@ class LastCountryOfUserMixin(
     """
     Defines parameters for LastCountryOfUser task and downstream tasks that require it.
 
-    Parameters:
-        user_country_output: location of the resulting Hadoop output.
-
-    Also inherits parameters from :py:class:`MapReduceJobTaskMixin, :py:class:`EventLogSelectionDownstreamMixin`,
-    :py:class:`GeolocationMixin` and :py:class:`OverwriteOutputMixin` classes.
-
     """
     user_country_output = luigi.Parameter(
-        config_path={'section': 'last-country-of-user', 'name': 'user_country_output'}
+        config_path={'section': 'last-country-of-user', 'name': 'user_country_output'},
+        description='Location of the resulting Hadoop output.',
     )
 
 
@@ -104,7 +99,6 @@ class ImportLastCountryOfUserToHiveTask(LastCountryOfUserMixin, ImportIntoHiveTa
     """
     Creates a Hive Table that points to Hadoop output of LastCountryOfUser task.
 
-    Parameters are defined by :py:class:`LastCountryOfUserMixin`.
     """
 
     @property
@@ -182,11 +176,10 @@ class QueryLastCountryPerCourseMixin(object):
     """
     Defines parameters for QueryLastCountryPerCourseTask
 
-    Parameters:
-        course_country_output:  location to write query results.
     """
     course_country_output = luigi.Parameter(
-        config_path={'section': 'query-country-per-course', 'name': 'course_country_output'}
+        config_path={'section': 'query-country-per-course', 'name': 'course_country_output'},
+        description='Location to write query results.',
     )
 
 

--- a/edx/analytics/tasks/mapreduce.py
+++ b/edx/analytics/tasks/mapreduce.py
@@ -28,19 +28,31 @@ class MapReduceJobTaskMixin(object):
 
     mapreduce_engine = luigi.Parameter(
         config_path={'section': 'map-reduce', 'name': 'engine'},
-        significant=False
+        significant=False,
+        description='Name of the map reduce job engine to use.  Use `hadoop` (the default) or `local`.',
     )
     # TODO: remove these parameters
-    input_format = luigi.Parameter(default=None, significant=False)
-    lib_jar = luigi.Parameter(is_list=True, default=[], significant=False)
-
-    # Override the parent class definition of this parameter. This typically wants to scale with the cluster size so the
-    # user should be able to tweak it depending on their particular configuration.
-    n_reduce_tasks = luigi.Parameter(default=25, significant=False)
-
+    input_format = luigi.Parameter(
+        default=None,
+        significant=False,
+        description='The input_format for Hadoop job to use. For example, when '
+        'running with manifest file, specify "oddjob.ManifestTextInputFormat" for input_format.',
+    )
+    lib_jar = luigi.Parameter(
+        is_list=True,
+        default=[],
+        significant=False,
+        description='A list of library jars that the Hadoop job can make use of.',
+    )
+    n_reduce_tasks = luigi.Parameter(
+        default=25,
+        significant=False,
+        description='Number of reducer tasks to use in upstream tasks.  Scale this to your cluster size.',
+    )
     remote_log_level = luigi.Parameter(
         config_path={'section': 'map-reduce', 'name': 'remote_log_level'},
-        significant=False
+        significant=False,
+        description='Level of logging for the map reduce tasks.',
     )
 
 
@@ -237,16 +249,19 @@ class MultiOutputMapReduceJobTask(MapReduceJobTask):
     processed by the same reduce task, we only allow a single file to be output per key for safety.  In the future, the
     reducer output key could be used to determine the output file name, however.
 
-    Parameters:
-        output_root: a URL location where the split files will be stored.
-        delete_output_root: if True, recursively deletes the output_root at task creation.
-        marker:  a URL location to a directory where a marker file will be written on task completion.
     """
-    output_root = luigi.Parameter()
-    delete_output_root = luigi.BooleanParameter(default=False, significant=False)
+    output_root = luigi.Parameter(
+        description='A URL location where the split files will be stored.',
+    )
+    delete_output_root = luigi.BooleanParameter(
+        default=False,
+        significant=False,
+        description='If True, recursively deletes the `output_root` at task creation.',
+    )
     marker = luigi.Parameter(
         config_path={'section': 'map-reduce', 'name': 'marker'},
-        significant=False
+        significant=False,
+        description='A URL location to a directory where a marker file will be written on task completion.',
     )
 
     def output(self):

--- a/edx/analytics/tasks/mysql_dump.py
+++ b/edx/analytics/tasks/mysql_dump.py
@@ -22,11 +22,6 @@ class MysqlSelectTask(luigi.Task):
     credentials file is expected to be JSON formatted and contain a simple map specifying the host, port, username
     and password.
 
-    Parameters:
-        credentials: Path to the external access credentials file.
-        destination: The directory to write the TSV file to.
-        database: The name of the database to execute the query on.
-
     Example Credentials File::
 
         {
@@ -38,13 +33,16 @@ class MysqlSelectTask(luigi.Task):
     """
 
     credentials = luigi.Parameter(
-        config_path={'section': 'database-import', 'name': 'credentials'}
+        config_path={'section': 'database-import', 'name': 'credentials'},
+        description='Path to the external access credentials file.',
     )
     destination = luigi.Parameter(
-        config_path={'section': 'database-import', 'name': 'destination'}
+        config_path={'section': 'database-import', 'name': 'destination'},
+        description='The directory to write the TSV file to.',
     )
     database = luigi.Parameter(
-        config_path={'section': 'database-import', 'name': 'database'}
+        config_path={'section': 'database-import', 'name': 'database'},
+        description='The name of the database to execute the query on.',
     )
 
     converters = [

--- a/edx/analytics/tasks/mysql_load.py
+++ b/edx/analytics/tasks/mysql_load.py
@@ -30,18 +30,20 @@ class MysqlInsertTaskMixin(OverwriteOutputMixin):
     """
     Parameters for inserting a data set into RDBMS.
 
-        credentials: Path to the external access credentials file.
-        database:  The name of the database to which to write.
-        insert_chunk_size:  The number of rows to insert at a time.
-
     """
     database = luigi.Parameter(
-        config_path={'section': 'database-export', 'name': 'database'}
+        config_path={'section': 'database-export', 'name': 'database'},
+        description='The name of the database to which to write.',
     )
     credentials = luigi.Parameter(
-        config_path={'section': 'database-export', 'name': 'credentials'}
+        config_path={'section': 'database-export', 'name': 'credentials'},
+        description='Path to the external access credentials file.',
     )
-    insert_chunk_size = luigi.IntParameter(default=100, significant=False)
+    insert_chunk_size = luigi.IntParameter(
+        default=100,
+        significant=False,
+        description='The number of rows to insert at a time.',
+    )
 
 
 class MysqlInsertTask(MysqlInsertTaskMixin, luigi.Task):

--- a/edx/analytics/tasks/pathutil.py
+++ b/edx/analytics/tasks/pathutil.py
@@ -32,19 +32,25 @@ class PathSetTask(luigi.Task):
     """
     A task to select a subset of files in an S3 bucket or local FS.
 
-    Parameters:
-
-      src: a URL pointing to a folder in s3:// or local FS.
-      include:  a list of patterns to use to select.  Multiple patterns are OR'd.
-      manifest: a URL pointing to a manifest file location.
     """
     src = luigi.Parameter(
         is_list=True,
-        config_path={'section': 'event-logs', 'name': 'source'}
+        config_path={'section': 'event-logs', 'name': 'source'},
+        description='A URL pointing to a folder in s3:// or local FS.',
     )
-    include = luigi.Parameter(is_list=True, default=('*',))
-    manifest = luigi.Parameter(default=None)
-    include_zero_length = luigi.BooleanParameter(default=False)
+    include = luigi.Parameter(
+        is_list=True,
+        default=('*',),
+        description='A list of patterns to use to select.  Multiple patterns are OR\'d.',
+    )
+    manifest = luigi.Parameter(
+        default=None,
+        description='A URL pointing to a manifest file location.',
+    )
+    include_zero_length = luigi.BooleanParameter(
+        default=False,
+        description='If True, include files/directories with size zero.',
+    )
 
     def __init__(self, *args, **kwargs):
         super(PathSetTask, self).__init__(*args, **kwargs)
@@ -107,15 +113,23 @@ class EventLogSelectionDownstreamMixin(object):
 
     source = luigi.Parameter(
         is_list=True,
-        config_path={'section': 'event-logs', 'name': 'source'}
+        config_path={'section': 'event-logs', 'name': 'source'},
+        description='A URL to a path that contains log files that contain the events. (e.g., s3://my_bucket/foo/).',
     )
-    interval = luigi.DateIntervalParameter()
+    interval = luigi.DateIntervalParameter(
+        description='The range of dates to export logs for.',
+    )
     expand_interval = luigi.TimeDeltaParameter(
-        config_path={'section': 'event-logs', 'name': 'expand_interval'}
+        config_path={'section': 'event-logs', 'name': 'expand_interval'},
+        description='A time interval to add to the beginning and end of the interval to expand the windows of '
+        'files captured.',
     )
     pattern = luigi.Parameter(
         is_list=True,
-        config_path={'section': 'event-logs', 'name': 'pattern'}
+        config_path={'section': 'event-logs', 'name': 'pattern'},
+        description='A regex with a named capture group for the date that approximates the date that the events '
+        'within were emitted. Note that the search interval is expanded, so events don\'t have to be in exactly '
+        'the right file in order for them to be processed.',
     )
 
 
@@ -127,14 +141,6 @@ class EventLogSelectionTask(EventLogSelectionDownstreamMixin, luigi.WrapperTask)
     that a pattern can be used to find them. Filenames are expected to contain a date which represents an approximation
     of the date found in the events themselves.
 
-    Parameters:
-        source: A URL to a path that contains log files that contain the events.
-        interval: The range of dates to export logs for.
-        expand_interval: A time interval to add to the beginning and end of the interval to expand the windows of files
-            captured.
-        pattern: A regex with a named capture group for the date that approximates the date that the events within were
-            emitted. Note that the search interval is expanded, so events don't have to be in exactly the right file
-            in order for them to be processed.
     """
 
     def __init__(self, *args, **kwargs):
@@ -232,12 +238,6 @@ class EventLogSelectionMixin(EventLogSelectionDownstreamMixin):
     """
     Extract events corresponding to a specified time interval and outputs them from a mapper.
 
-    Parameters:
-        source: A URL to a path that contains log files that contain the events.
-        interval: The range of dates to export logs for.
-        pattern: A regex with a named capture group for the date that approximates the date that the events within were
-            emitted. Note that the search interval is expanded, so events don't have to be in exactly the right file
-            in order for them to be processed.
     """
 
     def requires(self):

--- a/edx/analytics/tasks/reports/cybersource.py
+++ b/edx/analytics/tasks/reports/cybersource.py
@@ -19,9 +19,12 @@ log = logging.getLogger(__name__)
 class PullFromCybersourceTaskMixin(OverwriteOutputMixin):
     """Define common parameters for Cybersource pull and downstream tasks."""
 
-    merchant_id = luigi.Parameter()
-    # URL of location to write output.
-    output_root = luigi.Parameter()
+    merchant_id = luigi.Parameter(
+        description='Cybersource merchant identifier.',
+    )
+    output_root = luigi.Parameter(
+        description='URL of location to write output.',
+    )
 
     def __init__(self, *args, **kwargs):
         super(PullFromCybersourceTaskMixin, self).__init__(*args, **kwargs)
@@ -48,7 +51,10 @@ class DailyPullFromCybersourceTask(PullFromCybersourceTaskMixin, luigi.Task):
 
     """
     # Date to fetch Cybersource report.
-    run_date = luigi.DateParameter(default=datetime.date.today())
+    run_date = luigi.DateParameter(
+        default=datetime.date.today(),
+        description='Default is today.',
+    )
 
     # This is the table that we had been using for gathering and
     # storing historical Cybersource data.  It adds one additional
@@ -110,11 +116,13 @@ class DailyProcessFromCybersourceTask(PullFromCybersourceTaskMixin, luigi.Task):
     other payment accounts.
 
     """
-    # Date to fetch Cybersource report.
-    run_date = luigi.DateParameter(default=datetime.date.today())
-
-    # URL of location to write output.
-    output_root = luigi.Parameter()
+    run_date = luigi.DateParameter(
+        default=datetime.date.today(),
+        description='Date to fetch Cybersource report. Default is today.',
+    )
+    output_root = luigi.Parameter(
+        description='URL of location to write output.',
+    )
 
     def requires(self):
         args = {
@@ -182,11 +190,20 @@ class DailyProcessFromCybersourceTask(PullFromCybersourceTaskMixin, luigi.Task):
 class IntervalPullFromCybersourceTask(PullFromCybersourceTaskMixin, WarehouseMixin, luigi.WrapperTask):
     """Determines a set of dates to pull, and requires them."""
 
-    interval = luigi.DateIntervalParameter(default=None)
-    interval_end = luigi.DateParameter(default=datetime.datetime.utcnow().date(), significant=False)
+    interval = luigi.DateIntervalParameter(
+        default=None,
+    )
+    interval_end = luigi.DateParameter(
+        default=datetime.datetime.utcnow().date(),
+        significant=False,
+        description='Default is today, UTC.',
+    )
 
     # Overwrite parameter definition to make it optional.
-    output_root = luigi.Parameter(default=None)
+    output_root = luigi.Parameter(
+        default=None,
+        description='URL of location to write output.',
+    )
 
     def __init__(self, *args, **kwargs):
         super(IntervalPullFromCybersourceTask, self).__init__(*args, **kwargs)

--- a/edx/analytics/tasks/reports/enrollments.py
+++ b/edx/analytics/tasks/reports/enrollments.py
@@ -25,18 +25,45 @@ class CourseEnrollmentCountMixin(MapReduceJobTaskMixin):
     src = luigi.Parameter(
         is_list=True,
         config_path={'section': 'enrollment-reports', 'name': 'src'},
+        description='Location of daily enrollments per date. The format is a '
+        'Hadoop TSV file, with fields `course_id`, `date` and `count`.',
     )
     include = luigi.Parameter(is_list=True, default=('*',))
-    weeks = luigi.IntParameter(default=DEFAULT_NUM_WEEKS)
-    days = luigi.Parameter(default=DEFAULT_NUM_DAYS)
-    offsets = luigi.Parameter(default=None)
-    history = luigi.Parameter(default=None)
-    date = luigi.DateParameter(default=date.today())
+    weeks = luigi.IntParameter(
+        default=DEFAULT_NUM_WEEKS,
+        description='Number of weeks from the end date to request.',
+    )
+    days = luigi.Parameter(
+        default=DEFAULT_NUM_DAYS,
+        description='Number of days from the end date to request.',
+    )
+    offsets = luigi.Parameter(
+        default=None,
+        description='Location of seed values for each course. The format is a '
+        'Hadoop TSV file, with fields `course_id`, `date` and `offset`.',
+    )
+    history = luigi.Parameter(
+        default=None,
+        description='Location of historical values for total course enrollment. '
+        'The format is a TSV file, with fields `date` and `enrollments`.',
+    )
+    date = luigi.DateParameter(
+        default=date.today(),
+        description='End date of the last week requested. Default is today.',
+    )
     statuses = luigi.Parameter(default=None)
     manifest = luigi.Parameter(default=None)
     manifest_path = luigi.Parameter(default=None)
-    destination_directory = luigi.Parameter(default=None)
-    destination = luigi.Parameter(config_path={'section': 'enrollment-reports', 'name': 'destination'})
+    destination_directory = luigi.Parameter(
+        default=None,
+        description='Directory to store the resulting report and intermediate '
+        'results. The output format is an excel-compatible CSV file.',
+    )
+    destination = luigi.Parameter(
+        config_path={'section': 'enrollment-reports', 'name': 'destination'},
+        description='Location of the resulting report. The output format is a '
+        'Excel-compatible CSV file with `course_id` and one column per requested week.',
+    )
     credentials = luigi.Parameter(
         config_path={'section': 'database-import', 'name': 'credentials'}
     )
@@ -156,17 +183,7 @@ class CourseEnrollmentCountMixin(MapReduceJobTaskMixin):
 class EnrollmentsByWeek(luigi.Task, CourseEnrollmentCountMixin):
     """Calculates cumulative enrollments per week per course.
 
-    Parameters:
-        source: Location of daily enrollments per date. The format is a hadoop
-            tsv file, with fields course_id, date and count.
-        destination: Location of the resulting report. The output format is a
-            excel csv file with course_id and one column per requested week.
-        offsets: Location of seed values for each course. The format is a
-            hadoop tsv file, with fields course_id, date and offset.
-        date: End date of the last week requested.
-        weeks: Number of weeks from the end date to request.
-
-    Output:
+    Returns:
         Excel CSV file with one row per course. The columns are
         the cumulative enrollments counts for each week requested.
 

--- a/edx/analytics/tasks/reports/incremental_enrollments.py
+++ b/edx/analytics/tasks/reports/incremental_enrollments.py
@@ -18,18 +18,7 @@ class WeeklyIncrementalUsersAndEnrollments(luigi.Task, AllCourseEnrollmentCountM
     """
     Calculates weekly incremental changes in users and enrollments across courses.
 
-    Parameters:
-        registrations: Location of daily registrations per date. The format is a
-            TSV file, with fields date and count.
-        enrollments: Location of daily enrollments per date. The format is a
-            TSV file, with fields course_id, date and count.
-        destination: Location of the resulting report. The output format is an
-            excel-compatible CSV file.
-        date: End date of the last week requested.
-        weeks: Number of weeks from the end date to request.
-
-    Output:
-
+    Returns:
         Excel-compatible CSV file with a header row and four
         non-header rows.  The first column is a title for the row, and
         subsequent columns are the incremental counts for each week
@@ -197,17 +186,7 @@ class DailyRegistrationsEnrollmentsAndCourses(luigi.Task,
     """
     Calculates users registration and total enrollments across courses.
 
-    Parameters:
-        registrations: Location of daily registrations per date. The format is a
-            TSV file, with fields date and count.
-        enrollments: Location of daily enrollments per date. The format is a
-            TSV file, with fields course_id, date and count.
-        destination: Location of the resulting report. The output format is an
-            excel-compatible CSV file.
-        date: End date of the last week requested.
-        days: Number of days from the end date to request.
-
-    Output:
+    Returns:
         Excel-compatible CSV file with a header row.
         Columns are the days requested.
         First row is number of user registrations.

--- a/edx/analytics/tasks/reports/paypal.py
+++ b/edx/analytics/tasks/reports/paypal.py
@@ -562,10 +562,16 @@ class SettlementReportRecord(BaseSettlementReportRecord):
 class PaypalTaskMixin(OverwriteOutputMixin):
     """The parameters needed to run the paypal reports."""
 
-    output_root = luigi.Parameter()
-    date = luigi.DateParameter(default=datetime.datetime.utcnow().date())
+    output_root = luigi.Parameter(
+        description='The parent folder to write the paypal transaction data to.',
+    )
+    date = luigi.DateParameter(
+        default=datetime.datetime.utcnow().date(),
+        description='The date to generate a report for. Default is today, UTC.',
+    )
     account_id = luigi.Parameter(
-        default_from_config={'section': 'paypal', 'name': 'account_id'}
+        default_from_config={'section': 'paypal', 'name': 'account_id'},
+        description='A human readable name for the paypal account data is being gathered for.',
     )
 
 
@@ -573,10 +579,6 @@ class PaypalTransactionsByDayTask(PaypalTaskMixin, luigi.Task):
     """
     Run a report, gather the data for the report and write it to the output as a TSV file.
 
-    Parameters:
-        output_root: The parent folder to write the paypal transaction data to.
-        date: The date to generate a report for.
-        account_id: A human readable name for the paypal account data is being gathered for.
     """
     # pylint: disable=no-member
 
@@ -673,10 +675,17 @@ class PaypalTransactionsIntervalTask(PaypalTaskMixin, WarehouseMixin, luigi.Wrap
     interval = luigi.DateIntervalParameter(default=None)
     interval_start = luigi.DateParameter(
         default_from_config={'section': 'paypal', 'name': 'interval_start'},
-        significant=False
+        significant=False,
     )
-    interval_end = luigi.DateParameter(default=datetime.datetime.utcnow().date(), significant=False)
-    output_root = luigi.Parameter(default=None)
+    interval_end = luigi.DateParameter(
+        default=datetime.datetime.utcnow().date(),
+        significant=False,
+        description='Default is today, UTC.',
+    )
+    output_root = luigi.Parameter(
+        default=None,
+        description='URL of location to write output.',
+    )
 
     def __init__(self, *args, **kwargs):
         super(PaypalTransactionsIntervalTask, self).__init__(*args, **kwargs)

--- a/edx/analytics/tasks/reports/total_enrollments.py
+++ b/edx/analytics/tasks/reports/total_enrollments.py
@@ -145,19 +145,7 @@ class WeeklyAllUsersAndEnrollments(luigi.Task, AllCourseEnrollmentCountMixin):
     """
     Calculates total users and enrollments across all (known) courses per week.
 
-    Parameters:
-        enrollments: Location of daily enrollments per date. The format is a
-            TSV file, with fields course_id, date and count.
-        destination: Directory to store the resulting report and intermediate
-            results. The output format is an excel-compatible CSV file.
-        history:  Location of historical values for total course enrollment.
-            The format is a TSV file, with fields "date" and "enrollments".
-        offsets: Location of seed values for each course. The format is a
-            Hadoop TSV file, with fields "course_id", "date" and "offset".
-        date: End date of the last week requested.
-        weeks: Number of weeks from the end date to request.
-
-    Output:
+    Returns:
         Excel-compatible CSV file with a header row and two non-header
         rows.  The first column is a title for the row, and subsequent
         columns are the total counts for each week requested.  The

--- a/edx/analytics/tasks/reports/total_events_report.py
+++ b/edx/analytics/tasks/reports/total_events_report.py
@@ -16,14 +16,16 @@ class TotalEventsReport(luigi.Task):
     """
     Calculates TSV file containing count of events
 
-    Parameters:
-        report: Location of the resulting report. The output format is a
-            excel csv file with date and count of events for that day.
-        counts: Location for the map reduce output. It is a collection of output
-            files that are consolidated to produce the report.
     """
-    report = luigi.Parameter()
-    counts = luigi.Parameter()
+    report = luigi.Parameter(
+        description='Location of the resulting report. The output format is a '
+        'Excel CSV file with date and count of events for that day.',
+    )
+    counts = luigi.Parameter(
+        description='Location of event counts per day. It is a collection of output '
+        'files that are consolidated to produce the report. The format is a '
+        'Hadoop TSV file, with fields "country", "count", and "date".',
+    )
 
     def requires(self):
         return ExternalURL(self.counts)
@@ -67,24 +69,6 @@ class TotalEventsReportWorkflow(MapReduceJobTaskMixin, TotalEventsReport, EventL
     """
     Generates report for an event count by date for all events.
 
-    Parameters required for :py:class `EventLogSelectionDownstreamMixin`:
-
-        source:  a URL to the root location of input tracking log files (e.g., s3://my_bucket/foo/).
-        interval: events within this date range are counted.
-        pattern: regex pattern for files to be included when counting total events.
-        (See :py:class `EventLogSelectionTask` for more details.)
-
-    Additional parameters are passed through to :py:class:`TotalEventsReport`:
-
-        counts: Location of event counts per day. The format is a hadoop
-            tsv file, with fields country, count, and date.
-        report: Location of the resulting report. The output format is an
-            excel csv file with country and count.
-
-    The following optional parameters are passed through to :py:class:`MapReduceJobTask`:
-
-        mapreduce_engine
-        n_reduce_tasks
     """
 
     def requires(self):

--- a/edx/analytics/tasks/sqoop.py
+++ b/edx/analytics/tasks/sqoop.py
@@ -34,21 +34,6 @@ class SqoopImportTask(OverwriteOutputMixin, luigi.hadoop.BaseHadoopJobTask):
     a simple map specifying the host, port, username password and
     database.
 
-    Parameters:
-        credentials: Path to the external access credentials file.
-        destination: The directory to write the output files to.
-        table_name: The name of the table to import.
-        num_mappers: The number of map tasks to ask Sqoop to use.
-        where:  A 'where' clause to be passed to Sqoop.  Note that
-            no spaces should be embedded and special characters should
-            be escaped.  For example:  --where "id\<50".
-        verbose: Print more information while working.
-        columns: A list of column names to be included.  Default is to include all columns.
-        null_string:  String to use to represent NULL values in output data.
-        fields_terminated_by:  defines the file separator to use on output.
-        delimiter_replacement:  defines a character to use as replacement for delimiters
-            that appear within data values, for use with Hive.  (Not specified by default.)
-
     Inherited parameters:
         overwrite:  Overwrite any existing imports.  Default is false.
 
@@ -62,22 +47,51 @@ class SqoopImportTask(OverwriteOutputMixin, luigi.hadoop.BaseHadoopJobTask):
         }
     """
     destination = luigi.Parameter(
-        config_path={'section': 'database-import', 'name': 'destination'}
+        config_path={'section': 'database-import', 'name': 'destination'},
+        description='The directory to write the output files to.',
     )
     credentials = luigi.Parameter(
-        config_path={'section': 'database-import', 'name': 'credentials'}
+        config_path={'section': 'database-import', 'name': 'credentials'},
+        description='Path to the external access credentials file.',
     )
     database = luigi.Parameter(
         config_path={'section': 'database-import', 'name': 'database'}
     )
-    num_mappers = luigi.Parameter(default=None)
-    verbose = luigi.BooleanParameter(default=False)
-    table_name = luigi.Parameter()
-    where = luigi.Parameter(default=None)
-    columns = luigi.Parameter(is_list=True, default=[])
-    null_string = luigi.Parameter(default=None)
-    fields_terminated_by = luigi.Parameter(default=None)
-    delimiter_replacement = luigi.Parameter(default=None)
+    num_mappers = luigi.Parameter(
+        default=None,
+        description='The number of map tasks to ask Sqoop to use.',
+    )
+    verbose = luigi.BooleanParameter(
+        default=False,
+        description='Print more information while working.',
+    )
+    table_name = luigi.Parameter(
+        description='The name of the table to import.',
+    )
+    where = luigi.Parameter(
+        default=None,
+        description='A "where" clause to be passed to Sqoop.  Note that '
+        'no spaces should be embedded and special characters should '
+        'be escaped.  For example:  --where "id\<50". ',
+    )
+    columns = luigi.Parameter(
+        is_list=True,
+        default=[],
+        description='A list of column names to be included.  Default is to include all columns.'
+    )
+    null_string = luigi.Parameter(
+        default=None,
+        description='String to use to represent NULL values in output data.',
+    )
+    fields_terminated_by = luigi.Parameter(
+        default=None,
+        description='Defines the file separator to use on output.',
+    )
+    delimiter_replacement = luigi.Parameter(
+        default=None,
+        description='Defines a character to use as replacement for delimiters '
+        'that appear within data values, for use with Hive.  Not specified by default.'
+    )
 
     def requires(self):
         return {
@@ -172,12 +186,16 @@ class SqoopImportFromMysql(SqoopImportTask):
     * delimiters escaped by backslash
     * delimiters optionally enclosed by single quotes (')
 
-    Parameters:
-        direct: use mysqldump's "direct" mode.  Requires that no set of columns be selected. Defaults to True.
-        mysql-delimiters:  use standard mysql delimiters (on by default).
     """
-    mysql_delimiters = luigi.BooleanParameter(default=True)
-    direct = luigi.BooleanParameter(default=True, significant=False)
+    mysql_delimiters = luigi.BooleanParameter(
+        default=True,
+        description='Use standard mysql delimiters (on by default).',
+    )
+    direct = luigi.BooleanParameter(
+        default=True,
+        significant=False,
+        description='Use mysqldumpi\'s "direct" mode.  Requires that no set of columns be selected.',
+    )
 
     def connection_url(self, cred):
         """Construct connection URL from provided credentials."""

--- a/edx/analytics/tasks/studentmodule_dist.py
+++ b/edx/analytics/tasks/studentmodule_dist.py
@@ -32,20 +32,26 @@ class HistogramTaskFromSqoopParamsMixin(object):
     """
     Mixin the parameters for HistogramsFromStudentModule that involve Sqoop
 
-    Parameters:
-        * name: Name of this run
-        * dest: URL of S3 location/directory where the task outputs
-        * credentials: creds for the edx-platform db
-        * sqoop_overwrite:  Overwrite any existing imports.  Default is false.
-        * num_mappers: number of mappers for Sqoop to use
     """
-    name = luigi.Parameter()
-    dest = luigi.Parameter()
-    credentials = luigi.Parameter(
-        config_path={'section': 'database-import', 'name': 'credentials'}
+    name = luigi.Parameter(
+        description='Name of this run',
     )
-    sqoop_overwrite = luigi.BooleanParameter(default=False)  # prefixed with sqoop for disambiguation
-    num_mappers = luigi.Parameter(default=None, significant=False)  # TODO: move to config
+    dest = luigi.Parameter(
+        description='URL of S3 location/directory where the task outputs',
+    )
+    credentials = luigi.Parameter(
+        config_path={'section': 'database-import', 'name': 'credentials'},
+        description='Credentials for the edx-platform db',
+    )
+    sqoop_overwrite = luigi.BooleanParameter(  # prefixed with sqoop for disambiguation
+        default=False,
+        description='Overwrite any existing imports.',
+    )
+    num_mappers = luigi.Parameter(   # TODO: move to config
+        default=None,
+        significant=False,
+        description='Number of mappers for Sqoop to use',
+    )
 
 
 class HistogramFromStudentModuleSqoopWorkflowBase(

--- a/edx/analytics/tasks/user_activity.py
+++ b/edx/analytics/tasks/user_activity.py
@@ -35,12 +35,11 @@ class UserActivityTask(EventLogSelectionMixin, MapReduceJobTask):
     The output from this job is a table that represents the number of events seen for each user in each course in each
     category on each day.
 
-    Parameters:
-
-        output_root (str): path to store the output in.
     """
 
-    output_root = luigi.Parameter()
+    output_root = luigi.Parameter(
+        description='String path to store the output in.',
+    )
 
     def mapper(self, line):
         value = self.get_event_and_date_string(line)
@@ -216,17 +215,19 @@ class CourseActivityWeeklyTask(CourseActivityTask):
 
     TODO: update table name and schema to be consistent with other tables.
 
-    Parameters:
-
-        end_date (date): A day within the upper bound week. The week that contains this date will *not* be included in
-            the analysis, however, all of the data up to the first day of this week will be included. This is consistent
-            with all of our existing closed-open intervals.
-        weeks (int): The number of weeks to include in the analysis, counting back from the week that contains the
-            end_date.
     """
 
-    end_date = luigi.DateParameter(default=datetime.datetime.utcnow().date())
-    weeks = luigi.IntParameter(default=24)
+    end_date = luigi.DateParameter(
+        default=datetime.datetime.utcnow().date(),
+        description='A day within the upper bound week. The week that contains this date will *not* be included '
+        'in the analysis, however, all of the data up to the first day of this week will be included. This is '
+        'consistent with all of our existing closed-open intervals. Default is today, UTC.',
+    )
+    weeks = luigi.IntParameter(
+        default=24,
+        description='The number of weeks to include in the analysis, counting back from the week that contains '
+        'the end_date.',
+    )
 
     @property
     def interval(self):
@@ -338,15 +339,18 @@ class CourseActivityMonthlyTask(CourseActivityTask):
     following month pass in 1 to the "months" parameter. This will not analyze data for the month that contains the
     current day (since it is not complete). It will only compute data for the previous month.
 
-    Parameters:
-        end_date (date): A date within the month that will be the upper bound of the closed-open interval.
-        months (int): The number of months to include in the analysis, counting back from the month that contains the
-            end_date.
-
     """
 
-    end_date = luigi.DateParameter(default=datetime.datetime.utcnow().date())
-    months = luigi.IntParameter(default=6)
+    end_date = luigi.DateParameter(
+        default=datetime.datetime.utcnow().date(),
+        description='A date within the month that will be the upper bound of the closed-open interval. '
+        'Default is today, UTC.',
+    )
+    months = luigi.IntParameter(
+        default=6,
+        description='The number of months to include in the analysis, counting back from the month that contains '
+        'the end_date.',
+    )
 
     @property
     def interval(self):

--- a/edx/analytics/tasks/user_location.py
+++ b/edx/analytics/tasks/user_location.py
@@ -23,39 +23,44 @@ class GeolocationMixin(object):
     """
     Defines parameters needed for geolocation lookups.
 
-    Parameters:
-        geolocation_data: a URL to the location of country-level geolocation data.
     """
     geolocation_data = luigi.Parameter(
-        config_path={'section': 'geolocation', 'name': 'geolocation_data'}
+        config_path={'section': 'geolocation', 'name': 'geolocation_data'},
+        description='A URL to the location of country-level geolocation data.',
     )
 
 
 class BaseUserLocationTask(GeolocationMixin):
     """
-    Parameters:
-        name: a unique identifier to distinguish one run from another.  It is used in
-            the construction of output filenames, so each run will have distinct outputs.
-        src:  a URL to the root location of input tracking log files.
-        dest:  a URL to the root location to write output file(s).
-        include:  a list of patterns to be used to match input files, relative to `src` URL.
-            The default value is ['*'].
-        manifest: a URL to a file location that can store the complete set of input files.
-        end_date: events before or on this date are kept, and after this date are filtered out.
-        geolocation_data: a URL to the location of country-level geolocation data.
+    Defines parameters needed for user location tasks.
 
     """
-    name = luigi.Parameter()
-    src = luigi.Parameter(is_list=True)
-    dest = luigi.Parameter()
-    include = luigi.Parameter(is_list=True, default=('*',))
-
-    # A manifest file is required by hadoop if there are too many
-    # input paths. It hits an operating system limit on the
-    # number of arguments passed to the mapper process on the task nodes.
-    manifest = luigi.Parameter(default=None)
-
-    end_date = luigi.DateParameter()
+    name = luigi.Parameter(
+        description='A unique identifier to distinguish one run from another.  It is used in '
+        'the construction of output filenames, so each run will have distinct outputs.',
+    )
+    src = luigi.Parameter(
+        is_list=True,
+        description='A list of URLs to the root location of input tracking log files.',
+    )
+    dest = luigi.Parameter(
+        description='A URL to the root location to write output file(s).',
+    )
+    include = luigi.Parameter(
+        is_list=True,
+        default=('*',),
+        description='A list of patterns to be used to match input files, relative to `src` URL. '
+        'The default value is [\'*\'].',
+    )
+    manifest = luigi.Parameter(
+        default=None,
+        description='A URL to a file location that can store the complete set of input files. '
+        'A manifest file is required by hadoop if there are too many input paths. It hits an operating system '
+        'limit on the number of arguments passed to the mapper process on the task nodes.',
+    )
+    end_date = luigi.DateParameter(
+        description='Events before or on this date are kept, and after this date are filtered out.',
+    )
 
 
 class BaseGeolocation(object):
@@ -264,14 +269,15 @@ class UsersPerCountryReport(luigi.Task):
     """
     Calculates TSV file containing number of users per country.
 
-    Parameters:
-        counts: Location of counts per country. The format is a hadoop
-            tsv file, with fields country, count, and date.
-        report: Location of the resulting report. The output format is a
-            excel csv file with country and count.
     """
-    counts = luigi.Parameter()
-    report = luigi.Parameter()
+    counts = luigi.Parameter(
+        description='Location of counts per country. The format is a Hadoop '
+        'TSV file, with fields `country`, `count`, and `date`.',
+    )
+    report = luigi.Parameter(
+        description='Location of the resulting report. The output format is a '
+        'Excel CSV file with `country` and `count`.',
+    )
 
     def requires(self):
         return ExternalURL(self.counts)
@@ -322,40 +328,32 @@ class UsersPerCountryReportWorkflow(MapReduceJobTaskMixin, UsersPerCountryReport
     """
     Generates report containing number of users per location (country).
 
-    Most parameters are passed through to :py:class:`LastCountryForEachUser`
-    via :py:class:`UsersPerCountry`.  These are:
-
-        name: a unique identifier to distinguish one run from another.  It is used in
-            the construction of output filenames, so each run will have distinct outputs.
-        src:  a URL to the root location of input tracking log files.
-        include:  a list of patterns to be used to match input files, relative to `src` URL.
-            The default value is ['*'].
-        manifest: a URL to a file location that can store the complete set of input files.
-        end_date: events before or on this date are kept, and after this date are filtered out.
-        geolocation_data: a URL to the location of country-level geolocation data.
-
-    Additional optional parameters are passed through to :py:class:`MapReduceJobTask`:
-
-        mapreduce_engine:  'hadoop' (the default) or 'local'.
-        base_input_format: override the input_format for Hadoop job to use. For example, when
-            running with manifest file above, specify "oddjob.ManifestTextInputFormat" for input_format.
-        lib_jar:  points to jar defining input_format, if any.
-        n_reduce_tasks: number of reducer tasks to use in upstream tasks.
-
-    Additional parameters are passed through to :py:class:`UsersPerCountryReport`:
-
-        counts: Location of counts per country. The format is a hadoop
-            tsv file, with fields country, count, and date.
-        report: Location of the resulting report. The output format is a
-            excel csv file with country and count.
     """
-
-    name = luigi.Parameter()
-    src = luigi.Parameter(is_list=True)
-    include = luigi.Parameter(is_list=True, default=('*',))
-    manifest = luigi.Parameter(default=None)
-    base_input_format = luigi.Parameter(default=None)
-    end_date = luigi.DateParameter()
+    name = luigi.Parameter(
+        description='A unique identifier to distinguish one run from another.  It is used in '
+        'the construction of output filenames, so each run will have distinct outputs.',
+    )
+    src = luigi.Parameter(
+        is_list=True,
+        description='A list of URLs to the root location of input tracking log files.',
+    )
+    include = luigi.Parameter(
+        is_list=True,
+        default=('*',),
+        description='A list of patterns to be used to match input files, relative to `src` URL. '
+        'The default value is [\'*\'].',
+    )
+    manifest = luigi.Parameter(
+        default=None,
+        description='A URL to a file location that can store the complete set of input files.',
+    )
+    base_input_format = luigi.Parameter(
+        default=None,
+        description='Events before or on this date are kept, and after this date are filtered out.',
+    )
+    end_date = luigi.DateParameter(
+        description='A URL to the location of country-level geolocation data.',
+    )
     geolocation_data = luigi.Parameter()
 
     def requires(self):

--- a/edx/analytics/tasks/user_registrations.py
+++ b/edx/analytics/tasks/user_registrations.py
@@ -15,11 +15,11 @@ class UserRegistrationsPerDay(MysqlSelectTask):
     """
     Determine the number of users that registered accounts each day.
 
-    Parameters:
-        date_interval: The range of dates to gather data for.
     """
 
-    date_interval = luigi.DateIntervalParameter()
+    date_interval = luigi.DateIntervalParameter(
+        description='The range of dates to gather data for.',
+    )
 
     @property
     def query(self):

--- a/edx/analytics/tasks/util/hive.py
+++ b/edx/analytics/tasks/util/hive.py
@@ -25,7 +25,8 @@ class WarehouseMixin(object):
     """Task that is aware of the data warehouse."""
 
     warehouse_path = luigi.Parameter(
-        config_path={'section': 'hive', 'name': 'warehouse_path'}
+        config_path={'section': 'hive', 'name': 'warehouse_path'},
+        description='A URL location of the data warehouse.',
     )
 
 
@@ -375,8 +376,14 @@ class HiveTableFromParameterQueryTask(HiveTableFromQueryTask):  # pylint: disabl
 class HiveQueryToMysqlTask(WarehouseMixin, MysqlInsertTask):
     """Populates a MySQL table with the results of a hive query."""
 
-    overwrite = luigi.BooleanParameter(default=True)  # Overwrite the MySQL data?
-    hive_overwrite = luigi.BooleanParameter(default=False)
+    overwrite = luigi.BooleanParameter(
+        default=True,
+        description='If True, overwrite the MySQL data.',
+    )
+    hive_overwrite = luigi.BooleanParameter(
+        default=False,
+        description='If True, overwrite the hive data.',
+    )
 
     SQL_TO_HIVE_TYPE = {
         'varchar': 'STRING',

--- a/edx/analytics/tasks/util/overwrite.py
+++ b/edx/analytics/tasks/util/overwrite.py
@@ -24,7 +24,10 @@ class OverwriteOutputMixin(object):
     Note that this should be included in a task definition *before*
     the Task base class, so that the complete() method is overridden.
     """
-    overwrite = luigi.BooleanParameter(default=False)
+    overwrite = luigi.BooleanParameter(
+        default=False,
+        description='Whether or not to overwrite existing outputs; set to False by default for now.',
+    )
     attempted_removal = False
 
     def complete(self):

--- a/edx/analytics/tasks/vertica_load.py
+++ b/edx/analytics/tasks/vertica_load.py
@@ -27,15 +27,14 @@ class VerticaCopyTaskMixin(OverwriteOutputMixin):
     """
     Parameters for copying a database into Vertica.
 
-        credentials: Path to the external access credentials file.
-        schema:  The schema to which to write.
-        insert_chunk_size:  The number of rows to insert at a time.
     """
     schema = luigi.Parameter(
-        config_path={'section': 'vertica-export', 'name': 'schema'}
+        config_path={'section': 'vertica-export', 'name': 'schema'},
+        description='The schema to which to write.',
     )
     credentials = luigi.Parameter(
-        config_path={'section': 'vertica-export', 'name': 'credentials'}
+        config_path={'section': 'vertica-export', 'name': 'credentials'},
+        description='Path to the external access credentials file.',
     )
     read_timeout = luigi.IntParameter(
         config_path={'section': 'vertica-export', 'name': 'read_timeout'}


### PR DESCRIPTION
This PR separates the task description changes from the sphinx changes in PR #207 .  This change is solely to move task parameter descriptions out of docstrings and into `luigi.Task.description` fields.

See PR #207 for details, including screenshots.

Generated documentation: [docs.zip](https://github.com/edx/edx-analytics-pipeline/files/155981/docs.zip)

JIRA tickets: Implements OC-1391, OLIVE-16, OLIVE-15

Reviewers

[] Code: (@e-kolpakov)
[] Product: (TBD)
[] Platform: (TBD)
[] UX: (TBD)
[] TNL: (TBD)
[] a11y: (TBD)
[] doc/strings: (TBD)
