### PR TITLE
Remove psycopg2 requirement.

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -15,7 +15,6 @@ numpy==1.8.0 		# BSD
 pandas==0.13.0 		# BSD
 paypalrestsdk==1.9.0    # Paypal SDK License
 pbr==0.5.23 		# Apache
-psycopg2==2.6.1         # LGPL
 pyOpenSSL==0.15.1       # Apache 2.0
 pyasn1==0.1.7           # BSD
 pycparser==2.13         # BSD


### PR DESCRIPTION
It does not seem to be used anywhere and requires installing libpq-dev to build on ubuntu.

JIRA ticket: https://openedx.atlassian.net/browse/OLIVE-25
