### PR TITLE
Added ccx-keys to requirements.

### DIFF
--- a/edx/analytics/tasks/tests/test_event_exports.py
+++ b/edx/analytics/tasks/tests/test_event_exports.py
@@ -108,6 +108,25 @@ class EventExportTestCase(EventExportTestCaseBase):
         self.assertItemsEqual(task.org_id_whitelist, ['Bar2X', 'bar'])
         self.assertEqual(task.primary_org_ids_for_org_id, {'Bar2X': ['Bar2X'], 'bar': ['Bar2X']})
 
+    def test_ccx_course(self):
+        event = {
+            "event_type": "/courses/ccx-v1:FooX+CourseX+3T2015+ccx@82/ccx_coach",
+            "event_source": "server",
+            "time": self.EXAMPLE_TIME,
+            "context": {
+                "course_id": "ccx-v1:FooX+CourseX+3T2015+ccx@82"
+            }
+        }
+        line = json.dumps(event)
+
+        expected_output = [(
+            (self.EXAMPLE_DATE, 'FooX'),
+            line
+        )]
+        self.task.init_local()
+        result = self.run_mapper_for_server_file(self.SERVER_NAME_1, line)
+        self.assertItemsEqual(result, expected_output)
+
     def test_mapper(self):
         # The following should produce one output per input:
         expected_single_org_output = [

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -36,3 +36,5 @@ pip==1.5.6
 git+https://github.com/edx/luigi.git@1b57ce298255de14e09d29351c8e7ee8b7d24a7d#egg=luigi 		# Apache License 2.0
 git+https://github.com/edx/opaque-keys.git@9f07da1abf699d10bc3252d3081017e8aa37c302#egg=opaque-keys
 git+https://github.com/edx/pyinstrument.git@a35ff76df4c3d5ff9a2876d859303e33d895e78f#egg=pyinstrument     # BSD
+# custom opaque-key implementations for CCX
+git+https://github.com/edx/ccx-keys.git@0.1.1#egg=ccx-keys==0.1.1


### PR DESCRIPTION
@mulby @brianhw need to add this, otherwise it can possibly skip events which do no have an explicit org_id.
