### PR TITLE
Ansible apt module does not work on debian squeeze

### DIFF
--- a/share/task.yml
+++ b/share/task.yml
@@ -96,7 +96,7 @@
         - "{{ log_dir }}"
 
     - name: make sure git is available on the Debian server
-      apt: pkg=git state=present
+      command: apt-get install -q -y git
       sudo: True
       when: ansible_distribution in common_debian_variants
 


### PR DESCRIPTION
The `python-apt` package is required for the ansible apt module to work, but it is not available in the debian squeeze package repositories. So we have to install git with a shell command instead.
