### PR TITLE
Fix reinstall pip dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ system-requirements:
 
 requirements:
 	$(PIP_INSTALL) -U -r requirements/pre.txt
-	$(PIP_INSTALL) -U -r requirements/default.txt
+	$(PIP_INSTALL) -r requirements/default.txt
 
 test-requirements: requirements
 	$(PIP_INSTALL) -U -r requirements/test.txt


### PR DESCRIPTION
Fixes alternating failures to build pip requirements for edx-analytics-pipeline on ubuntu, when using a virtualenv path that contains a symlink.

**Context**:

The issue occurs on the jenkins analytics server, when running the analytics task jobs.  Each job re-installs the analytics pipeline, which invokes `make requirements`, and re-installs the pip requirements using `--upgrade`, causing a re-install of pyinstrument.  The pyinstrument uninstall step fails to remove the pyinstrument binary, due to the [symlink created for the jenkins home directory from `/var/lib/jenkins` to `/edx/var/jenkins`](https://github.com/edx/configuration/blob/master/playbooks/roles/jenkins_master/tasks/main.yml#L62), and the ubuntu system version of `shutil.py`.

**JIRA tickets**: Cleanup for OLIVE-22, OC-1512

**Discussions**: See [discussion on PR 15](https://github.com/edx-ops/edx-jenkins-job-dsl/pull/15#issuecomment-204265069).

**Dependencies**: None

**Sandbox URL**: 

http://52.20.136.133:8080/job/AnswerDistributionWorkflow/ - ping me for login credentials.

**Testing instructions**:

Must run on ubuntu.  I've tested on vagrant-ubuntu-trusty-64 3.13.0-79-generic and 3.2.0-98-virtual.
###### Shortcut to demonstrate the issue:
1. Create a symlinked directory for the virtualenv:
   
   ```
   mkdir testdir
   ln -s testdir symlink
   virtualenv symlink/venv
   . symlink/venv/bin/activate
   ```
2. Install pip version used by edx-analytics-pipeline.  (Note that the issue occurs even for pip 7.1.2.)
   
   ```
   pip install pip==1.5.6
   ```
3. Install the pyinstrument version used by edx-analytics-pipeline
   
   ```
   pip install -U git+https://github.com/edx/pyinstrument.git@a35ff76df4c3d5ff9a2876d859303e33d895e78f#egg=pyinstrument
   ```
4. Run the above install step again to see the uninstall fail.  
   
   ```
   pip install -U git+https://github.com/edx/pyinstrument.git@a35ff76df4c3d5ff9a2876d859303e33d895e78f#egg=pyinstrument
   ```
   
   Message is something like:
   
   ```
   Installing collected packages: pyinstrument
     Found existing installation: pyinstrument 0.13.1
       Uninstalling pyinstrument-0.13.1:
   Exception:
   Traceback (most recent call last):
     File "/home/vagrant/symlink/venv/local/lib/python2.7/site-packages/pip/basecommand.py", line 211, in main
       status = self.run(options, args)
     File "/home/vagrant/symlink/venv/local/lib/python2.7/site-packages/pip/commands/install.py", line 311, in run
       root=options.root_path,
     File "/home/vagrant/symlink/venv/local/lib/python2.7/site-packages/pip/req/req_set.py", line 640, in install
       requirement.uninstall(auto_confirm=True)
     File "/home/vagrant/symlink/venv/local/lib/python2.7/site-packages/pip/req/req_install.py", line 716, in uninstall
       paths_to_remove.remove(auto_confirm)
     File "/home/vagrant/symlink/venv/local/lib/python2.7/site-packages/pip/req/req_uninstall.py", line 125, in remove
       renames(path, new_path)
     File "/home/vagrant/symlink/venv/local/lib/python2.7/site-packages/pip/utils/__init__.py", line 315, in renames
       shutil.move(old, new)
     File "/usr/lib/python2.7/shutil.py", line 302, in move
       copy2(src, real_dst)
     File "/usr/lib/python2.7/shutil.py", line 130, in copy2
       copyfile(src, dst)
     File "/usr/lib/python2.7/shutil.py", line 82, in copyfile
       with open(src, 'rb') as fsrc:
   IOError: [Errno 2] No such file or directory: '/home/vagrant/testdir/venv/bin/pyinstrument'
   ```
5. Run the above install step without -U to watch it succeed:
   
   ```
   pip install git+https://github.com/edx/pyinstrument.git@a35ff76df4c3d5ff9a2876d859303e33d895e78f#egg=pyinstrument
   ```
###### To demonstrate the failure using upstream/master:
1. Install the [required packages](https://github.com/edx/edx-analytics-pipeline#requirements):
   - Python 2.7.x
   - GCC (to compile numpy)
   - MySQL
   - GnuPG 1.4.x  
   - libpq-dev
2. Create a symlinked directory for the virtualenv:
   
   ```
   mkdir testdir
   ln -s testdir symlink
   virtualenv symlink/venv
   . symlink/venv/bin/activate
   ```
3. Clone the edx-analytics-pipeline repo:
   
   ```
   git clone https://github.com/edx/edx-analytics-pipeline.git
   ```
4. Install the pip requirements
   
   ```
   cd edx-analytics-pipeline
   make requirements  # takes a while to build numpy, go make a pot of tea or something
   ```
5. Re-install the pip requirements.  This will fail when re-installing pyinstrument
   
   ```
   make requirements
   ```
6. Re-re-install the pip requirements.  This build will succeed.
   
   ```
   make requirements
   ```
###### To illustrate the patch:
1. Use the same virtualenv created above, so you don't have to rebuild numpy.
2. Checkout the patched edx-analytics-pipeline branch:
   
   ```
   git remote add patched https://github.com/open-craft/edx-analytics-pipeline.git
   git fetch patched
   git checkout patched/jill/olive-22-pyinstrument
   ```
3. Re-re-install the pip requirements.  This build will succeed.
   
   ```
   make requirements
   ```
4. Re-re-install the pip requirements.  This build will succeed too.
   
   ```
   make requirements
   ```

**Author notes and concerns**:

There's a few ways to workaround this issue.
1. Remove the jenkins home symlink.  However, this [symlink is created by jenkins_master](https://github.com/edx/configuration/blob/master/playbooks/roles/jenkins_master/tasks/main.yml#L62), and I'm unsure of the effect of removing it.
2. Upgrade pip to >=8.1.1.  The edx-analytics-pipeline uses pip 1.5.6, and the issue persists at least through pip 7.1.2, but is fixed by [pip PR 3145](https://github.com/pypa/pip/pull/3154).  However, this may  have unintended consequences to edx-analytics-pipeline?
3. Split pyinstrument into a separate requirements file, and don't run `--upgrade` for it alone.  I'm fine with this solution if it's preferable, but didn't want to complicate the multiple requirements/ files and their Makefile dependencies.

**Reviewers**
- [ ] @jbzdak 
- [ ] @mulby 
- [ ] @e0d  
