### PR TITLE
Identify EMR server using master_public_dns_name instead of master_private_ip

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,5 +6,4 @@ httplib2==0.9 		# MIT
 paramiko==1.14.0 	# LGPL
 pycrypto==2.6.1 	# public domain
 ansible==1.4.5          # GPL v3 License
-boto==2.22.1            # MIT
-
+boto==2.39.0            # MIT

--- a/share/ec2.ini
+++ b/share/ec2.ini
@@ -1,7 +1,7 @@
 [ec2]
 regions=us-east-1
 destination_variable=route53_domain_name
-backup_destination_variable=private_ip_address
+backup_destination_variable=public_dns_name
 cache_path=/tmp
 cache_max_age=300
 regions_exclude=


### PR DESCRIPTION
Allows access to the EMR master node by servers (e.g. devstacks) that sit outside the AWS VPC.

Without this change, EMR services used in task.yml are referenced by their AWS internal IP addresses, which are not accessible outside of the VPC.

**JIRA tickets**: Cleanup for [OLIVE-22](https://openedx.atlassian.net/browse/OLIVE-20), [OC-1512](https://tasks.opencraft.com/browse/OC-1512)

**Dependencies**: None

**Sandbox URL**: 

http://52.20.136.133:8080/ - ping me for login credentials.

**Testing instructions**:

See [edx/configuration PR #2939](https://github.com/edx/configuration/pull/2939) for full test instructions.

Expected result is the remote task will run successfully (if your configuration is correct).

Without this page, the EMR provisioning fails with AWS access errors:

```
Running command = ['/edx/var/jenkins/workspace/AnswerDistributionWorkflow/venvs/analytics-tasks/share/edx.analytics.tasks/ec2.py', '--refresh-cache']
...
RuntimeError: Unable to refresh ansible inventory cache.
```

**Reviewers**
- [ ] @jbzdak 
- [ ] @mulby 
- [ ] @e0d  
