### PR TITLE
Update origin/HEAD before running a remote task.

### DIFF
--- a/share/task.yml
+++ b/share/task.yml
@@ -87,6 +87,9 @@
     - name: branch fetched
       command: git fetch --all chdir={{ working_repo_dir }}
 
+    - name: update origin/HEAD
+      command: git remote set-head origin --auto chdir={{ working_repo_dir }}
+
     - name: branch checked out
       command: git checkout {{ branch }} chdir={{ working_repo_dir }}
 


### PR DESCRIPTION
When running the acceptance tests locally, the branch [defaults to origin/HEAD](https://github.com/edx/configuration/blob/master/playbooks/roles/analytics_pipeline/files/acceptance.json#L11).  However, git does not update origin/HEAD when running `git fetch`, so it will always point to the first branch we ran the acceptance tests for.  This change adds a task to the playbook for running remote tasks that makes sure origin/HEAD gets updated before checking out the branch, thus allowing to run the acceptance tests more easily on different branches.
