### PR TITLE
Add non-Debian support and patch Luigi.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,14 @@ develop-local: uninstall
 	python setup.py install_data
 
 system-requirements:
+ifeq (,$(wildcard /usr/bin/yum))
 	sudo apt-get update -q
 	# This is not great, we can't use these libraries on slave nodes using this method.
 	sudo apt-get install -y -q libmysqlclient-dev libatlas3gf-base libpq-dev python-dev libffi-dev libssl-dev libxml2-dev libxslt1-dev
+else
+	sudo yum update -q -y
+	sudo yum install -y -q postgresql-devel libffi-devel
+endif
 
 requirements:
 	$(PIP_INSTALL) -U -r requirements/pre.txt

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -4,6 +4,7 @@ cffi==1.1.0             # MIT
 ciso8601==1.0.1         # MIT
 cryptography==0.9       # BSD or Apache 2.0
 edx-opaque-keys==0.2.1
+edx-ccx-keys==0.1.2
 elasticsearch==1.7.0    # Apache
 enum34==1.0.4           # BSD
 filechunkio==1.5	# MIT
@@ -35,8 +36,5 @@ urllib3==1.10.4         # MIT
 vertica-python==0.5.1   # MIT
 wsgiref==0.1.2 		# ZPL
 pip==1.5.6
-git+https://github.com/edx/luigi.git@1b57ce298255de14e09d29351c8e7ee8b7d24a7d#egg=luigi 		# Apache License 2.0
-# git+https://github.com/edx/opaque-keys.git@9f07da1abf699d10bc3252d3081017e8aa37c302#egg=opaque-keys
+git+https://github.com/edx/luigi.git@babffe13335f28ce8de3e3f5de61d2e02cd84277#egg=luigi 		# Apache License 2.0
 git+https://github.com/edx/pyinstrument.git@a35ff76df4c3d5ff9a2876d859303e33d895e78f#egg=pyinstrument     # BSD
-# custom opaque-key implementations for CCX
-git+https://github.com/edx/ccx-keys.git@0.1.1#egg=ccx-keys==0.1.1

--- a/share/roles/luigi/defaults/main.yml
+++ b/share/roles/luigi/defaults/main.yml
@@ -3,3 +3,7 @@
 luigi_hadoop_version: apache1
 luigi_hadoop_command: /home/hadoop/bin/hadoop
 luigi_hadoop_streaming_jar: /home/hadoop/.versions/1.0.3/share/hadoop/contrib/streaming/hadoop-streaming.jar
+
+luigi_amazon_hadoop_version: cdh4
+luigi_amazon_hadoop_command: /usr/bin/hadoop
+luigi_amazon_hadoop_streaming_jar: /usr/lib/hadoop/hadoop-streaming.jar

--- a/share/roles/luigi/tasks/main.yml
+++ b/share/roles/luigi/tasks/main.yml
@@ -5,3 +5,9 @@
 
 - name: configuration file written
   template: src=client.cfg.j2 dest=/etc/luigi/client.cfg mode=644
+  when: ansible_distribution in common_debian_variants
+
+- name: configuration file written
+  template: src=client_amazon.cfg.j2 dest=/etc/luigi/client.cfg mode=644
+  when: ansible_distribution in common_redhat_variants
+

--- a/share/roles/luigi/templates/client_amazon.cfg.j2
+++ b/share/roles/luigi/templates/client_amazon.cfg.j2
@@ -1,0 +1,4 @@
+[hadoop]
+version: {{ luigi_amazon_hadoop_version }}
+command: {{ luigi_amazon_hadoop_command }}
+streaming-jar: {{ luigi_amazon_hadoop_streaming_jar }}

--- a/share/task.yml
+++ b/share/task.yml
@@ -2,17 +2,24 @@
 
 - name: Configure luigi
   hosts: "{{ name }}"
-  gather_facts: False
+  gather_facts: True
   sudo: True
   vars:
     write_luigi_config: "yes"
+    common_debian_variants:
+      - Ubuntu
+      - Debian
+    common_redhat_variants:
+      - CentOS
+      - Red Hat Enterprise Linux
+      - Amazon
   roles:
     - role: luigi
       when: write_luigi_config|bool
 
 - name: Run a task
   hosts: "{{ name }}"
-  gather_facts: False
+  gather_facts: True
 
   vars:
     - repo: https://github.com/edx/edx-analytics-pipeline.git
@@ -29,11 +36,18 @@
       - hostname: github.com
         public_key: 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
     - local_log_dir: build/logs
-    - install_env:
-        # EMR runs a modified version of Debian 6 (squeeze)
+    - install_env_debian:
+        # EMR runs a modified version of Debian 6 (squeeze) on early AMIs, before switching their own RHEL variant.
         WHEEL_URL: http://edx-wheelhouse.s3-website-us-east-1.amazonaws.com/Debian/squeeze
-        # EMR ships with python 2.7
+        # Match the version of Python define in virtualenv_python above.
         WHEEL_PYVER: 2.7
+    - common_debian_variants:
+      - Ubuntu
+      - Debian
+    - common_redhat_variants:
+      - CentOS
+      - Red Hat Enterprise Linux
+      - Amazon
 
     # - override_config: path/to/config.cfg (optionally adds a luigi config override)
 
@@ -81,6 +95,16 @@
       with_items:
         - "{{ log_dir }}"
 
+    - name: make sure git is available on the Debian server
+      command: apt-get install -q -y git
+      sudo: True
+      when: ansible_distribution in common_debian_variants
+
+    - name: make sure git is available on the RHEL server
+      yum: pkg=git state=present
+      sudo: True
+      when: ansible_distribution in common_redhat_variants
+      
     - name: analytics tasks repository checked out
       git: repo={{ repo }} dest={{ working_repo_dir }} version=master
 
@@ -94,9 +118,15 @@
       command: make system-requirements chdir={{ working_repo_dir }}
       sudo: True
 
-    - name: bootstrap pip
+    - name: bootstrap pip on Debian
       command: apt-get install -q -y python-pip
       sudo: True
+      when: ansible_distribution in common_debian_variants
+
+    - name: bootstrap pip on RHEL
+      command: yum install -q -y python-pip
+      sudo: True
+      when: ansible_distribution in common_redhat_variants
 
     - name: virtualenv installed
       pip: name=virtualenv version=1.10.1
@@ -110,11 +140,18 @@
       command: >
         {{ working_venv_dir }}/bin/pip install -U pip
 
-    - name: virtualenv initialized
+    - name: virtualenv initialized on Debian
       shell: >
         . {{ working_venv_dir }}/bin/activate && make install
         chdir={{ working_repo_dir }}
-      environment: install_env
+      environment: install_env_debian
+      when: ansible_distribution in common_debian_variants
+
+    - name: virtualenv initialized on RHEL
+      shell: >
+        . {{ working_venv_dir }}/bin/activate && make install
+        chdir={{ working_repo_dir }}
+      when: ansible_distribution in common_redhat_variants
 
     - name: logging configured
       template: src=logging.cfg.j2 dest={{ working_repo_dir }}/logging.cfg


### PR DESCRIPTION
This PR includes two important fixes.  The first allows the pipeline to deploy to more modern versions of AWS EMR clusters.  The second permits the pipeline to find metadata for packages that have different names than their egg-info name.

EMR clusters after 2.x switched to RHEL from Debian Squeeze.
This PR provides support for deploying to such clusters.
- Add yum option to Makefile.
- Identify system requirements for installation by yum.
- Don't use Debian wheel settings if platform is not debian.
- Change hadoop variables in Luigi config.

(Note that the Ansible apt module does not work on debian squeeze.  The python-apt module required by ansible is no longer in the package repositories.)

The second change points to a patched version of Luigi, intended to get the pipeline working again with versions of opaque-keys and ccx-keys that are now available on PyPi as edx-opaque-keys and edx-ccx-keys.  With the fix, we can also pin to use the new versions of these packages.

@mulby @HassanJaveed84 
