### PR TITLE
Uses master as initial branch when cloning secure_config_repo

### DIFF
--- a/share/task.yml
+++ b/share/task.yml
@@ -160,7 +160,7 @@
       file: path={{ working_repo_dir }}/override.cfg state=absent
 
     - name: secure config repository checked out
-      git: repo={{ secure_config_repo }} dest={{ secure_config_repo_dir }} version=release
+      git: repo={{ secure_config_repo }} dest={{ secure_config_repo_dir }} version=master
       when: secure_config is defined
 
     - name: secure config branch fetched


### PR DESCRIPTION
If there happens to be no 'release' branch present in the `secure_config_repo`, the tasks.yml playbook fails when cloning the `secure_config_repo`.

**JIRA tickets**: Cleanup for [OLIVE-22](https://openedx.atlassian.net/browse/OLIVE-20), [OC-1512](https://tasks.opencraft.com/browse/OC-1512)

**Dependencies**: None

**Sandbox URL**: 

http://52.20.136.133:8080/ - ping me for login credentials.

**Testing instructions**:

See [edx/configuration PR #2939](https://github.com/edx/configuration/pull/2939) for full test instructions.

Expected result is the remote task will successfully clone the secure repo (if your configuration is correct).

Without this fix, if you happen to have no branch named 'release' in your secure config, the tasks.yml fails with:

```
TASK: [secure config repository checked out] ********************************** 
failed: [172.30.2.184] => {"failed": true}
msg: Failed to checkout release
```

**Reviewers**
- [x] @jbzdak 
- [x] @itsjeyd  
- [x] @mulby 
