### PR TITLE
Support more customization via environment variables

### DIFF
--- a/edx/analytics/tasks/tests/acceptance/__init__.py
+++ b/edx/analytics/tasks/tests/acceptance/__init__.py
@@ -105,6 +105,10 @@ class AcceptanceTestCase(unittest.TestCase):
 
         self.config = get_test_config()
 
+        for env_var in ('TASKS_REPO', 'TASKS_BRANCH', 'IDENTIFIER', 'JOB_FLOW_NAME'):
+            if env_var in os.environ:
+                self.config[env_var.lower()] = os.environ[env_var]
+
         # The name of an existing job flow to run the test on
         assert('job_flow_name' in self.config or 'host' in self.config)
         # The git URL of the pipeline repository to check this code out from.

--- a/edx/analytics/tasks/tests/acceptance/test_answer_dist.py
+++ b/edx/analytics/tasks/tests/acceptance/test_answer_dist.py
@@ -27,6 +27,7 @@ class BaseAnswerDistributionAcceptanceTest(AcceptanceTestCase):
         assert 'oddjob_jar' in self.config
 
         self.oddjob_jar = self.config['oddjob_jar']
+        self.input_format = self.config.get('manifest_input_format', self.INPUT_FORMAT)
 
         self.upload_data()
 
@@ -51,7 +52,7 @@ class AnswerDistributionAcceptanceTest(BaseAnswerDistributionAcceptanceTest):
             '--output-root', self.test_out,
             '--include', '"*"',
             '--manifest', url_path_join(self.test_root, 'manifest.txt'),
-            '--base-input-format', self.INPUT_FORMAT,
+            '--base-input-format', self.input_format,
             '--lib-jar', self.oddjob_jar,
             '--n-reduce-tasks', str(self.NUM_REDUCERS),
         ])
@@ -88,7 +89,7 @@ class AnswerDistributionMysqlAcceptanceTests(BaseAnswerDistributionAcceptanceTes
             '--name', 'test',
             '--include', '"*"',
             '--manifest', url_path_join(self.test_root, 'manifest.txt'),
-            '--base-input-format', self.INPUT_FORMAT,
+            '--base-input-format', self.input_format,
             '--lib-jar', self.oddjob_jar,
             '--n-reduce-tasks', str(self.NUM_REDUCERS),
             '--credentials', self.export_db.credentials_file_url,

--- a/share/ec2.py
+++ b/share/ec2.py
@@ -189,7 +189,9 @@ class Ec2Inventory(object):
 
         # Regions
         self.regions = []
-        configRegions = config.get('ec2', 'regions')
+        configRegions = os.getenv('AWS_REGION')
+        if configRegions is None:
+            configRegions = config.get('ec2', 'regions')
         configRegions_exclude = config.get('ec2', 'regions_exclude')
         if (configRegions == 'all'):
             if self.eucalyptus_host:


### PR DESCRIPTION
Provides the following features:
1. Allow AWS region used by the dynamic inventory script (ec2.py) to be configured via an environment variable instead of the hardcoded value in ec2.ini
2. Allow the acceptance tests to read some configuration settings from environment variables as well. This allows us to use a static configuration file for most acceptance tests variables and use Jenkins parameters to override a few critical ones.
3. Fix the answer distribution test so that it uses the configured manifest class if it's provided.

Reviewers:
- [x] @brianhw
- [ ] @HassanJaveed84 

FYI: @itsjeyd 

TODO:
- [x] Run acceptance tests on jenkins-ci and locally
