### PR TITLE
Fix multiple runs of tasks when executing with --overwrite

### DIFF
--- a/edx/analytics/tasks/elasticsearch_load.py
+++ b/edx/analytics/tasks/elasticsearch_load.py
@@ -151,6 +151,8 @@ class ElasticsearchIndexTask(ElasticsearchIndexTaskMixin, MapReduceJobTask):
                 )
             )
 
+        self.attempted_removal = True
+
         if elasticsearch_client.indices.exists(index=self.index):
             elasticsearch_client.indices.delete(index=self.index)
 

--- a/edx/analytics/tasks/module_engagement.py
+++ b/edx/analytics/tasks/module_engagement.py
@@ -1087,7 +1087,6 @@ class ModuleEngagementRosterPartitionTask(WeekIntervalMixin, ModuleEngagementDow
             CourseEnrollmentTableTask(
                 interval_end=self.date,
                 n_reduce_tasks=self.n_reduce_tasks,
-                overwrite=self.overwrite,
             ),
             ImportAuthUserTask(**kwargs_for_db_import),
             ImportCourseUserGroupTask(**kwargs_for_db_import),

--- a/edx/analytics/tasks/tests/test_elasticsearch_load.py
+++ b/edx/analytics/tasks/tests/test_elasticsearch_load.py
@@ -401,6 +401,7 @@ class ElasticsearchIndexTaskCommitTest(BaseIndexTest, ReducerTestMixin, unittest
             self.mock_es.mock_calls,
             [
                 call.indices.refresh(index=self.task.index),
+                call.indices.exists(index='foo_alias_old'),
                 call.indices.update_aliases(
                     {
                         'actions': [


### PR DESCRIPTION
Ensure the roster task sets `self.attempted_removal` without this the overwrite mixin will not recognize the task as complete. This was causing the task to run twice, however, since it was intitialized once, the first time it runs it was deleting the "old" index and the second time `self.indexes_for_alias` still contained the old index, so it tried to clean it up _again_. This was causing the error we were seeing.

Reviewers:
- [x] @HassanJaveed84 
- [x] @brianhw 
