### PR TITLE
Ability to pass extra args to virtualenv command.

### DIFF
--- a/edx/analytics/tasks/launchers/remote.py
+++ b/edx/analytics/tasks/launchers/remote.py
@@ -40,6 +40,7 @@ def main():
     parser.add_argument('--sudo-user', help='execute the shell command as this user on the cluster', default='hadoop')
     parser.add_argument('--workflow-profiler', choices=['pyinstrument'], help='profiler to run on the launch-task process', default=None)
     parser.add_argument('--wheel-url', help='url of the wheelhouse', default=None)
+    parser.add_argument('--virtualenv-extra-args', help='additional arguments passed to virtualenv command when creating the virtual environment', default=None)
     parser.add_argument('--skip-setup', action='store_true', help='assumes the environment has already been configured and you can simply run the task')
     arguments, extra_args = parser.parse_known_args()
     arguments.launch_task_arguments = extra_args
@@ -160,6 +161,8 @@ def convert_args_to_extra_vars(arguments, uid):
         }
     if arguments.vagrant_path or arguments.host:
         extra_vars['write_luigi_config'] = False
+    if arguments.virtualenv_extra_args:
+        extra_vars['virtualenv_extra_args'] = arguments.virtualenv_extra_args
     return json.dumps(extra_vars)
 
 

--- a/share/task.yml
+++ b/share/task.yml
@@ -31,6 +31,7 @@
     - working_repo_dir: "{{ working_dir }}/repo"
     - working_venv_dir: "{{ working_dir }}/venv"
     - virtualenv_python: "/usr/bin/python2.7"
+    - virtualenv_extra_args: ''
     - git_servers:
         # Analytics repositories are currently hosted on github.
       - hostname: github.com
@@ -134,7 +135,7 @@
 
     - name: virtualenv created
       command: >
-        virtualenv --python={{ virtualenv_python }} {{ working_venv_dir }}
+        virtualenv --python={{ virtualenv_python }} {{ virtualenv_extra_args }} {{ working_venv_dir }}
 
     - name: update pip
       command: >


### PR DESCRIPTION
Allows you to pass arguments such as `--system-site-packages` to the `virtualenv` command when creating the virtual environment on EMR nodes.

Using system site-packages lowers pipeline deployment time for around 3 minutes according to my tests. I believe the speedup comes from using system scipy, which is a transitive dependency.

Additional 2-3 minute speedup can be achieved by changing numpy requirement in requirements/default.txt to 1.10.4, which is the version that comes pre-installed on EMR 4.4.0 nodes.
This PR does not update numpy to 1.10.4, we will probably want to do that in a separate pull request.

cf. [OLIVE-29](https://openedx.atlassian.net/browse/OLIVE-29)
