### PR TITLE
Made a minor documentation edit, to test the ReadTheDocs service in t…

### DIFF
--- a/edx/analytics/tasks/data_obfuscation.py
+++ b/edx/analytics/tasks/data_obfuscation.py
@@ -1,4 +1,4 @@
-"""Obfuscate course state files by removing/stubbing user information."""
+"""Obfuscate course state files by removing and stubbing user information."""
 import csv
 import json
 import logging


### PR DESCRIPTION
## [DOC-2802](https://openedx.atlassian.net/browse/DOC-2802)

This is an extremely small documentation change:

-"""Obfuscate course state files by removing/stubbing user information."""
+"""Obfuscate course state files by removing and stubbing user information."""

I am making the change to test the ReadTheDocs service that IT added to the repository. I expect that merging this change will prompt a build at https://readthedocs.org/projects/edx-analytics-pipeline-reference/builds/.
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @mulby 
- [x] Subject matter expert: @brianhw 
### Post-review
- [ ] Squash commits
