### PR TITLE
overwrite N days of module engagement history

### DIFF
--- a/edx/analytics/tasks/tests/map_reduce_mixins.py
+++ b/edx/analytics/tasks/tests/map_reduce_mixins.py
@@ -29,7 +29,8 @@ class MapperTestMixin(object):
         'user_country_output': 'test://output/',
         'name': 'test',
         'src': ['test://input/'],
-        'dest': 'test://output/'
+        'dest': 'test://output/',
+        'overwrite_from_date': datetime.date(2014, 4, 1),
     }
 
     task_class = None
@@ -149,6 +150,7 @@ class ReducerTestMixin(object):
         'src': ['test://input/'],
         'dest': 'test://output/',
         'date': datetime.datetime.strptime('2014-04-01', '%Y-%m-%d').date(),
+        'overwrite_from_date': datetime.date(2014, 4, 1),
     }
 
     reduce_key = tuple()

--- a/edx/analytics/tasks/tests/test_module_engagement.py
+++ b/edx/analytics/tasks/tests/test_module_engagement.py
@@ -544,7 +544,8 @@ class ModuleEngagementUserSegmentDataTaskReducerTest(ReducerTestMixin, unittest.
 
         self.task = self.task_class(  # pylint: disable=not-callable
             date=self.date,
-            output_root=self.DEFAULT_ARGS['output_root']
+            output_root=self.DEFAULT_ARGS['output_root'],
+            overwrite_from_date=datetime.date(2014, 4, 1),
         )
 
     def initialize_task(self, metric_ranges):
@@ -981,6 +982,7 @@ class ModuleEngagementRosterPartitionTaskTest(ReducerTestMixin, unittest.TestCas
     def setUp(self):
         self.task = self.task_class(  # pylint: disable=not-callable
             date=luigi.DateParameter().parse(self.DATE),
+            overwrite_from_date=datetime.date(2014, 4, 1),
         )
 
     def test_interval(self):


### PR DESCRIPTION
Given the incremental nature of this workflow, we need to handle "late" events. The short term solution for this problem is to simply reprocess the last N days of data to pick up any stragglers.

Reviewers:
- [x] @brianhw 
- [ ] @HassanJaveed84 
