### PR TITLE
Fix event-export acceptance tests on EMR 4.5.0

### DIFF
--- a/edx/analytics/tasks/tests/acceptance/__init__.py
+++ b/edx/analytics/tasks/tests/acceptance/__init__.py
@@ -247,3 +247,12 @@ class AcceptanceTestCase(unittest.TestCase):
             database = self.import_db
         log.debug('Executing SQL fixture %s on %s', sql_file_name, database.database_name)
         database.execute_sql_file(os.path.join(self.data_dir, 'input', sql_file_name))
+
+    def assertEventLogEqual(self, expected_filepath, actual_filepath):
+        """Compares event log files to confirm they are equal."""
+        # Brute force:  read in entire file, and then compare dicts.
+        with open(expected_filepath) as expected_output_file:
+            with open(actual_filepath) as actual_output_file:
+                expected = sorted([json.loads(eventline) for eventline in expected_output_file])
+                actual = sorted([json.loads(eventline) for eventline in actual_output_file])
+                self.assertListEqual(expected, actual)

--- a/edx/analytics/tasks/tests/acceptance/test_event_export.py
+++ b/edx/analytics/tasks/tests/acceptance/test_event_export.py
@@ -149,4 +149,5 @@ class EventExportAcceptanceTest(AcceptanceTestCase):
         decompressed_file_name = decrypted_file_name[:-len(',gz')]
         fs.decompress_file(decrypted_file_name, decompressed_file_name)
 
-        shell.run(['diff', decompressed_file_name, os.path.join(self.data_dir, 'output', local_file_name)])
+        original_filename = os.path.join(self.data_dir, 'output', local_file_name)
+        self.assertEventLogEqual(decompressed_file_name, original_filename)

--- a/edx/analytics/tasks/tests/acceptance/test_event_export_by_course.py
+++ b/edx/analytics/tasks/tests/acceptance/test_event_export_by_course.py
@@ -88,7 +88,9 @@ class EventExportByCourseAcceptanceTest(AcceptanceTestCase):
     def validate_output(self):
         for output_file in self.output_files:
             local_file_name = self.generate_file_name(output_file)
-            shell.run(['diff', output_file['downloaded_path'], os.path.join(self.data_dir, 'output', local_file_name)])
+            expected_output = os.path.join(self.data_dir, 'output', local_file_name)
+            actual_output = output_file['downloaded_path']
+            self.assertEventLogEqual(expected_output, actual_output)
 
     def generate_file_name(self, output_file):
         """Generates file_name for a given course and date."""


### PR DESCRIPTION
Compare log files with assertEventLogEqual.

This is instead of using 'diff' for event files, since events may not be
in the same order, and may not have the dict keys in the same order.
Use new method for testing event exports, both regular and per-course.

@mulby @HassanJaveed84 
