### PR TITLE
Support missing ES config in acceptance tests and allow empty overwrite in acceptance tests

### DIFF
--- a/edx/analytics/tasks/tests/acceptance/services/elasticsearch_service.py
+++ b/edx/analytics/tasks/tests/acceptance/services/elasticsearch_service.py
@@ -14,8 +14,12 @@ class ElasticsearchService(object):
         else:
             connection_class = None
 
-        self._elasticsearch_client = elasticsearch.Elasticsearch(hosts=[config['elasticsearch_host']], connection_class=connection_class)
+        self._disabled = bool(config.get('elasticsearch_host'))
         self._alias = alias
+        if not self._disabled:
+            self._elasticsearch_client = elasticsearch.Elasticsearch(hosts=[config['elasticsearch_host']], connection_class=connection_class)
+        else:
+            self._elasticsearch_client = None
 
     @property
     def client(self):
@@ -26,6 +30,9 @@ class ElasticsearchService(object):
         return self._alias
 
     def reset(self):
+        if self._disabled:
+            return
+
         response = self._elasticsearch_client.indices.get_aliases(name=self._alias)
         for index, alias_info in response.iteritems():
             for alias in alias_info['aliases'].keys():

--- a/edx/analytics/tasks/tests/acceptance/services/elasticsearch_service.py
+++ b/edx/analytics/tasks/tests/acceptance/services/elasticsearch_service.py
@@ -14,7 +14,7 @@ class ElasticsearchService(object):
         else:
             connection_class = None
 
-        self._disabled = bool(config.get('elasticsearch_host'))
+        self._disabled = not bool(config.get('elasticsearch_host'))
         self._alias = alias
         if not self._disabled:
             self._elasticsearch_client = elasticsearch.Elasticsearch(hosts=[config['elasticsearch_host']], connection_class=connection_class)

--- a/edx/analytics/tasks/tests/acceptance/test_module_engagement.py
+++ b/edx/analytics/tasks/tests/acceptance/test_module_engagement.py
@@ -34,11 +34,18 @@ class ModuleEngagementAcceptanceTest(AcceptanceTestCase):
         self.execute_sql_fixture_file('load_course_groups_courseusergroup.sql')
         self.execute_sql_fixture_file('load_course_groups_courseusergroup_users.sql')
 
-        self.task.launch([
-            'ModuleEngagementWorkflowTask',
-            '--date', '2015-04-17',
-            '--n-reduce-tasks', str(self.NUM_REDUCERS),
-        ])
+        self.task.launch(
+            [
+                'ModuleEngagementWorkflowTask',
+                '--date', '2015-04-17',
+                '--n-reduce-tasks', str(self.NUM_REDUCERS),
+            ],
+            config_override={
+                'module-engagement': {
+                    'allow_empty_insert': True
+                }
+            }
+        )
 
         query = {"query": {"match_all": {}}}
         response = self.elasticsearch.client.search(index=self.elasticsearch.alias, body=query)


### PR DESCRIPTION
The first change should allow the "elasticsearch_host" to be omitted from the configuration dictionary, which will simply disable the service.

The second change fixes the broken roster engagement test.

Reviewers:
- [ ] @HassanJaveed84 
- [ ] @brianhw 
