### PR TITLE
Acceptance tests support without vertica.

### DIFF
--- a/edx/analytics/tasks/tests/acceptance/test_internal_reporting_user_course.py
+++ b/edx/analytics/tasks/tests/acceptance/test_internal_reporting_user_course.py
@@ -8,7 +8,7 @@ import datetime
 import pandas
 import luigi
 
-from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase
+from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase, when_vertica_available
 from edx.analytics.tasks.url import url_path_join
 
 log = logging.getLogger(__name__)
@@ -23,6 +23,7 @@ class InternalReportingUserCourseLoadAcceptanceTest(AcceptanceTestCase):
         super(InternalReportingUserCourseLoadAcceptanceTest, self).setUp()
         self.upload_file(os.path.join(self.data_dir, 'input', 'course_enrollment'), url_path_join(self.warehouse_path, 'course_enrollment', 'dt=2014-07-01', 'course_enrollment'))
 
+    @when_vertica_available
     def test_internal_reporting_user_course(self):
         """Tests the workflow for the internal reporting user course table, end to end."""
 


### PR DESCRIPTION
@mulby @brianhw 
- Fixed financial reports acceptance test(when vertica is not available).
- Skip internal reporting user_course test when vertica is not available.

I've started a run here:
http://jenkins-ci.analytics.edx.org/view/ad-hoc/job/edx-analytics-pipeline-acceptance-test-manual/805
