### PR TITLE
Support explicit decimal precision and scale in Hive >0.13

### DIFF
--- a/config/devstack.cfg
+++ b/config/devstack.cfg
@@ -1,5 +1,6 @@
 [hive]
 release = apache
+version = 0.11
 database = default
 warehouse_path = hdfs://localhost:9000/edx-analytics-pipeline/warehouse/
 

--- a/config/test.cfg
+++ b/config/test.cfg
@@ -2,6 +2,7 @@
 
 [hive]
 release = apache
+version = 0.11
 database = default
 warehouse_path = s3://fake/warehouse/
 

--- a/edx/analytics/tasks/database_imports.py
+++ b/edx/analytics/tasks/database_imports.py
@@ -11,7 +11,7 @@ from luigi.hive import HiveQueryTask, HivePartitionTarget
 from edx.analytics.tasks.sqoop import SqoopImportFromMysql
 from edx.analytics.tasks.url import url_path_join
 from edx.analytics.tasks.util.overwrite import OverwriteOutputMixin
-from edx.analytics.tasks.util.hive import hive_database_name
+from edx.analytics.tasks.util.hive import hive_database_name, hive_decimal_type
 
 log = logging.getLogger(__name__)
 
@@ -374,14 +374,14 @@ class ImportShoppingCartOrderItem(ImportMysqlToHiveTableTask):
             ('user_id', 'INT'),
             ('status', 'STRING'),
             ('qty', 'int'),
-            ('unit_cost', 'DECIMAL'),
+            ('unit_cost', hive_decimal_type(12, 2)),
             ('line_desc', 'STRING'),
             ('currency', 'STRING'),
             ('fulfilled_time', 'TIMESTAMP'),
             ('report_comments', 'STRING'),
             ('refund_requested_time', 'TIMESTAMP'),
-            ('service_fee', 'DECIMAL'),
-            ('list_price', 'DECIMAL'),
+            ('service_fee', hive_decimal_type(12, 2)),
+            ('list_price', hive_decimal_type(12, 2)),
             ('created', 'TIMESTAMP'),
             ('modified', 'TIMESTAMP'),
         ]
@@ -641,7 +641,7 @@ class ImportCurrentRefundRefundLineState(ImportMysqlToHiveTableTask):
     def columns(self):
         return [
             ('id', 'INT'),
-            ('line_credit_excl_tax', 'DECIMAL'),
+            ('line_credit_excl_tax', hive_decimal_type(12, 2)),
             ('quantity', 'INT'),
             ('status', 'STRING'),
             ('order_line_id', 'INT'),
@@ -667,10 +667,10 @@ class ImportCurrentOrderState(ImportMysqlToHiveTableTask):
             ('id', 'INT'),
             ('number', 'STRING'),
             ('currency', 'STRING'),
-            ('total_incl_tax', 'DECIMAL'),
-            ('total_excl_tax', 'DECIMAL'),
-            ('shipping_incl_tax', 'DECIMAL'),
-            ('shipping_excl_tax', 'DECIMAL'),
+            ('total_incl_tax', hive_decimal_type(12, 2)),
+            ('total_excl_tax', hive_decimal_type(12, 2)),
+            ('shipping_incl_tax', hive_decimal_type(12, 2)),
+            ('shipping_excl_tax', hive_decimal_type(12, 2)),
             ('shipping_method', 'STRING'),
             ('shipping_code', 'STRING'),
             ('status', 'STRING'),
@@ -705,14 +705,14 @@ class ImportCurrentOrderLineState(ImportMysqlToHiveTableTask):
             ('title', 'STRING'),
             ('upc', 'STRING'),
             ('quantity', 'INT'),
-            ('line_price_incl_tax', 'DECIMAL'),
-            ('line_price_excl_tax', 'DECIMAL'),
-            ('line_price_before_discounts_incl_tax', 'DECIMAL'),
-            ('line_price_before_discounts_excl_tax', 'DECIMAL'),
-            ('unit_cost_price', 'DECIMAL'),
-            ('unit_price_incl_tax', 'DECIMAL'),
-            ('unit_price_excl_tax', 'DECIMAL'),
-            ('unit_retail_price', 'DECIMAL'),
+            ('line_price_incl_tax', hive_decimal_type(12, 2)),
+            ('line_price_excl_tax', hive_decimal_type(12, 2)),
+            ('line_price_before_discounts_incl_tax', hive_decimal_type(12, 2)),
+            ('line_price_before_discounts_excl_tax', hive_decimal_type(12, 2)),
+            ('unit_cost_price', hive_decimal_type(12, 2)),
+            ('unit_price_incl_tax', hive_decimal_type(12, 2)),
+            ('unit_price_excl_tax', hive_decimal_type(12, 2)),
+            ('unit_retail_price', hive_decimal_type(12, 2)),
             ('status', 'STRING'),
             ('est_dispatch_date', 'TIMESTAMP'),
             ('order_id', 'INT'),
@@ -742,7 +742,7 @@ class ImportCurrentOrderDiscountState(ImportMysqlToHiveTableTask):
             ('voucher_id', 'INT'),
             ('voucher_code', 'STRING'),
             ('frequency', 'INT'),
-            ('amount', 'DECIMAL'),
+            ('amount', hive_decimal_type(12, 2)),
             ('message', 'STRING'),
             ('order_id', 'INT'),
         ]

--- a/edx/analytics/tasks/reports/ed_services_financial_report.py
+++ b/edx/analytics/tasks/reports/ed_services_financial_report.py
@@ -6,7 +6,7 @@ from edx.analytics.tasks.database_imports import (
     DatabaseImportMixin, ImportCourseModeTask, ImportStudentCourseEnrollmentTask
 )
 from edx.analytics.tasks.mapreduce import MapReduceJobTaskMixin
-from edx.analytics.tasks.util.hive import HiveTableFromQueryTask, HivePartition, WarehouseMixin
+from edx.analytics.tasks.util.hive import HiveTableFromQueryTask, HivePartition, WarehouseMixin, hive_decimal_type
 from edx.analytics.tasks.vertica_load import VerticaCopyTask
 
 
@@ -48,11 +48,11 @@ class BuildEdServicesReportTask(DatabaseImportMixin, MapReduceJobTaskMixin, Hive
             ('professional_currently_enrolled', 'INT'),
             ('no_id_professional_currently_enrolled', 'INT'),
             ('refunded_seat_count', 'INT'),
-            ('refunded_amount', 'DECIMAL'),
-            ('net_seat_revenue', 'DECIMAL'),
+            ('refunded_amount', hive_decimal_type(12, 2)),
+            ('net_seat_revenue', hive_decimal_type(12, 2)),
             ('net_seat_count', 'INT'),
             ('donation_count', 'INT'),
-            ('net_donation_revenue', 'DECIMAL'),
+            ('net_donation_revenue', hive_decimal_type(12, 2)),
         ]
 
     @property

--- a/edx/analytics/tasks/reports/orders_import.py
+++ b/edx/analytics/tasks/reports/orders_import.py
@@ -1,10 +1,9 @@
-
 """Import Orders: Shopping Cart Tables from the LMS, Orders from Otto."""
 
 import luigi
 import luigi.hdfs
 
-from edx.analytics.tasks.util.hive import HiveTableFromQueryTask, HivePartition
+from edx.analytics.tasks.util.hive import HiveTableFromQueryTask, HivePartition, hive_decimal_type
 from edx.analytics.tasks.database_imports import (
     DatabaseImportMixin,
     ImportShoppingCartCertificateItem,
@@ -103,8 +102,8 @@ class OrderTableTask(DatabaseImportMixin, HiveTableFromQueryTask):
             ('order_id', 'INT'),
             ('line_item_id', 'INT'),
             ('line_item_product_id', 'INT'),
-            ('line_item_price', 'DECIMAL'),
-            ('line_item_unit_price', 'DECIMAL'),
+            ('line_item_price', hive_decimal_type(12, 2)),
+            ('line_item_unit_price', hive_decimal_type(12, 2)),
             ('line_item_quantity', 'INT'),
             ('product_class', 'STRING'),
             ('course_key', 'STRING'),
@@ -114,11 +113,11 @@ class OrderTableTask(DatabaseImportMixin, HiveTableFromQueryTask):
             ('date_placed', 'TIMESTAMP'),
             ('iso_currency_code', 'STRING'),
             ('coupon_id', 'INT'),
-            ('discount_amount', 'DECIMAL'),  # Total discount in currency amount, i.e. unit_discount * qty
+            ('discount_amount', hive_decimal_type(12, 2)),  # Total discount in currency amount, i.e. unit_discount * qty
             ('voucher_id', 'INT'),
             ('voucher_code', 'STRING'),
             ('status', 'STRING'),
-            ('refunded_amount', 'DECIMAL'),
+            ('refunded_amount', hive_decimal_type(12, 2)),
             ('refunded_quantity', 'INT'),
             ('payment_ref_id', 'STRING'),
             ('partner_short_code', 'STRING'),

--- a/edx/analytics/tasks/reports/reconcile.py
+++ b/edx/analytics/tasks/reports/reconcile.py
@@ -12,7 +12,7 @@ import luigi.date_interval
 
 from edx.analytics.tasks.mapreduce import MapReduceJobTask, MapReduceJobTaskMixin
 from edx.analytics.tasks.url import get_target_from_url, url_path_join
-from edx.analytics.tasks.util.hive import HiveTableTask, HivePartition, WarehouseMixin
+from edx.analytics.tasks.util.hive import HiveTableTask, HivePartition, WarehouseMixin, hive_decimal_type
 from edx.analytics.tasks.util.id_codec import encode_id
 from edx.analytics.tasks.util.opaque_key_util import get_org_id_for_course
 from edx.analytics.tasks.reports.orders_import import OrderTableTask
@@ -770,22 +770,22 @@ class ReconciledOrderTransactionTableTask(ReconcileOrdersAndTransactionsDownstre
             ('transaction_payment_gateway_account_id', 'STRING'),
             ('transaction_type', 'STRING'),
             ('transaction_payment_method', 'STRING'),
-            ('transaction_amount', 'DECIMAL'),
+            ('transaction_amount', hive_decimal_type(12, 2)),
             ('transaction_iso_currency_code', 'STRING'),
-            ('transaction_fee', 'DECIMAL'),
-            ('transaction_amount_per_item', 'DECIMAL'),
-            ('transaction_fee_per_item', 'DECIMAL'),
+            ('transaction_fee', hive_decimal_type(12, 2)),
+            ('transaction_amount_per_item', hive_decimal_type(12, 2)),
+            ('transaction_fee_per_item', hive_decimal_type(12, 2)),
             ('order_line_item_id', 'INT'),
             ('unique_order_line_item_id', 'STRING'),
             ('order_line_item_product_id', 'INT'),
-            ('order_line_item_price', 'DECIMAL'),
-            ('order_line_item_unit_price', 'DECIMAL'),
+            ('order_line_item_price', hive_decimal_type(12, 2)),
+            ('order_line_item_unit_price', hive_decimal_type(12, 2)),
             ('order_line_item_quantity', 'INT'),
             ('order_coupon_id', 'INT'),
-            ('order_discount_amount', 'DECIMAL'),
+            ('order_discount_amount', hive_decimal_type(12, 2)),
             ('order_voucher_id', 'INT'),
             ('order_voucher_code', 'STRING'),
-            ('order_refunded_amount', 'DECIMAL'),
+            ('order_refunded_amount', hive_decimal_type(12, 2)),
             ('order_refunded_quantity', 'INT'),
             ('order_user_id', 'INT'),
             ('order_username', 'STRING'),

--- a/edx/analytics/tasks/tests/acceptance/__init__.py
+++ b/edx/analytics/tasks/tests/acceptance/__init__.py
@@ -211,6 +211,8 @@ class AcceptanceTestCase(unittest.TestCase):
             }
         if 'manifest_input_format' in self.config:
             task_config_override['manifest']['input_format'] = self.config['manifest_input_format']
+        if 'hive_version' in self.config:
+            task_config_override['hive']['version'] = self.config['hive_version']
 
         log.info('Running test: %s', self.id())
         log.info('Using executor: %s', self.config['identifier'])


### PR DESCRIPTION
This should resolve the issue we were seeing where decimal values were being interpreted as integers in Hive 1.0.0 but appeared to be working properly in Hive 0.11.

EMR 4.X is using hive 1.0.0 which corresponds to version number 0.14.1. We are currently using 0.11 in production. Apparently the handling of DECIMAL types changed in 0.13.

https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=27838462#LanguageManualTypes-Decimals

If you specify the type as simply "DECIMAL" in 0.11 it "does the right thing", but in 0.13 it assumes you mean "decimal(10,0)" which appears to translate to "a 10 digit integer". This rounds off any fractional part of the number. So "25.60" was being rounded up to 26.

> With the changes in the Decimal data type in Hive 0.13.0, the pre-Hive 0.13.0 columns (of type "decimal") will be treated as being of type decimal(10,0).  What this means is that existing data being read from these tables will be treated as 10-digit integer values, and data being written to these tables will be converted to 10-digit integer values before being written. To avoid these issues, Hive users on 0.12 or earlier with tables containing Decimal columns will be required to migrate their tables, after upgrading to Hive 0.13.0 or later.

This should fix the finance report w/o vertica acceptance tests on Hive 1.0.0.

Reviewers:
- [x] @brianhw 
- [x] @HassanJaveed84 

FYI:
- @bradenmacdonald 
