### PR TITLE
In obfuscation, check for IPv6 addresses.

### DIFF
--- a/edx/analytics/tasks/events_obfuscation.py
+++ b/edx/analytics/tasks/events_obfuscation.py
@@ -338,13 +338,12 @@ class ObfuscateCourseEventsTask(ObfuscatorMixin, GeolocationMixin, GeolocationTa
                 event['event'] = event_data
 
         ip_address = event.get('ip')
-        country_code = "UNKNOWN"
-        if ip_address:
+        # Skip over IPv6-format ip_address values for now.
+        if ip_address and ':' not in ip_address:
             country_code = self.geoip.country_code_by_addr(ip_address)
-
             if country_code is None or len(country_code.strip()) <= 0:
                 country_code = "UNKNOWN"
-        event.update({'augmented': {'country_code': country_code}})
+            event.update({'augmented': {'country_code': country_code}})
 
         # Delete base properties other than username.
         for key in ['host', 'ip', 'page', 'referer']:


### PR DESCRIPTION
We are getting IPv6 addresses, and asking for location throws a GeoIPException with the message "Invalid database type; expected IPv4 address".  Just avoid doing so by checking for colons in ip_address, and skipping output in such cases.

@mulby @HassanJaveed84 
