### PR TITLE
Fix wheel override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # If a wheel repository is defined, then have pip use that.  But don't require the use of wheel.
-ifdef WHEEL_PYVER
+ifneq ($(strip $(WHEEL_URL)),)
 	PIP_INSTALL = pip install --use-wheel --find-links=$$WHEEL_URL/Python-$$WHEEL_PYVER --allow-external mysql-connector-python
 else
 	PIP_INSTALL = pip install --allow-external mysql-connector-python

--- a/edx/analytics/tasks/launchers/remote.py
+++ b/edx/analytics/tasks/launchers/remote.py
@@ -154,11 +154,8 @@ def convert_args_to_extra_vars(arguments, uid):
         extra_vars['secure_config_branch'] = arguments.secure_config_branch
     if arguments.secure_config:
         extra_vars['secure_config'] = arguments.secure_config
-    if arguments.wheel_url:
-        extra_vars['install_env'] = {
-            'WHEEL_URL': arguments.wheel_url,
-            'WHEEL_PYVER': '2.7'
-        }
+    if arguments.wheel_url is not None:
+        extra_vars['wheel_url'] = arguments.wheel_url
     if arguments.vagrant_path or arguments.host:
         extra_vars['write_luigi_config'] = False
     if arguments.virtualenv_extra_args:

--- a/share/task.yml
+++ b/share/task.yml
@@ -37,11 +37,7 @@
       - hostname: github.com
         public_key: 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
     - local_log_dir: build/logs
-    - install_env_debian:
-        # EMR runs a modified version of Debian 6 (squeeze) on early AMIs, before switching their own RHEL variant.
-        WHEEL_URL: http://edx-wheelhouse.s3-website-us-east-1.amazonaws.com/Debian/squeeze
-        # Match the version of Python define in virtualenv_python above.
-        WHEEL_PYVER: 2.7
+    - wheel_pyver: 2.7
     - common_debian_variants:
       - Ubuntu
       - Debian
@@ -148,13 +144,18 @@
       shell: >
         . {{ working_venv_dir }}/bin/activate && make install
         chdir={{ working_repo_dir }}
-      environment: install_env_debian
+      environment:
+        WHEEL_URL: "{{ wheel_url | default('http://edx-wheelhouse.s3-website-us-east-1.amazonaws.com/Debian/squeeze') }}"
+        WHEEL_PYVER: "{{ wheel_pyver }}"
       when: ansible_distribution in common_debian_variants
 
     - name: virtualenv initialized on RHEL
       shell: >
         . {{ working_venv_dir }}/bin/activate && make install
         chdir={{ working_repo_dir }}
+      environment:
+        WHEEL_URL: "{{ wheel_url | default('http://edx-wheelhouse.s3-website-us-east-1.amazonaws.com/Amazon/emr4') }}"
+        WHEEL_PYVER: "{{ wheel_pyver }}"
       when: ansible_distribution in common_redhat_variants
 
     - name: logging configured


### PR DESCRIPTION
## Steps to reproduce

Attempt to setup a new analytics devstack using the [official instructions](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/installation/analytics/index.html).
## Symptom

When you go to run the pipeline it will fail with an error message that looks like this:

```
Traceback (most recent call last):
  File "/var/lib/analytics-tasks/devstack/venv/bin/launch-task", line 6, in <module>
    from edx.analytics.tasks.launchers.local import main
  File "/var/lib/analytics-tasks/devstack/venv/local/lib/python2.7/site-packages/edx/analytics/tasks/launchers/local.py", line 16, in <module>
    import cjson
ImportError: /var/lib/analytics-tasks/devstack/venv/local/lib/python2.7/site-packages/cjson.so: undefined symbol: PyUnicodeUCS2_DecodeUnicodeEscape
```
## Root cause
- When we went to update the pipeline to support both EMR 4.X and EMR 2.4.11 we added support for installing the pipeline on either RHEL variants or Debian variants. This was necessary since the base AMI for EMR 4.X is amazon linux, which is a RHEL variant.
- When adding this support we renamed "install_env" to "install_env_debian". The remote-task script was explicitly overriding "install_env" with the value passed into the CLI using the `--wheel-url` parameter. Since that variable was no longer used by ansible, the `--wheel-url` parameter value was not actual being used by ansible.
## Context

Storing wheels on S3 dramatically speeds up installation times since compiling numpy, scipy, and pandas takes a very long time. Since these libraries rely on system-wide shared libraries, the compiled wheels have to match the runtime environment very closely. You can see this play out in the Traceback above. I haven't done a full analysis of the issue, but I suspect that the result of [this ifndef](https://github.com/python/cpython/blob/2.7/Include/unicodeobject.h#L146) statement results in different compiled code on ubuntu precise and debian squeeze. So if you try to run using a debian squeeze wheel on ubuntu precise, it will be very unhappy (like it is above). One work around for this issue is to simply pass in `--wheel-url ""`, which forces pip to recompile those libraries on the machine that will be running the code. However, since `--wheel-url` no longer had any effect, it became impossible to install to any other debian variant than "squeeze".
## Other notes

I was unable to merge this for a while since my original commit broke the Debian squeeze case (EMR 2.4.11) which is what we run in production. I just found the bug this morning and revised the patch accordingly.
## Summary of the fix

Define top level "wheel_url" and "wheel_pyver" variables. This simplifies the override logic and allows them to be overridden independently.
## Reviewers
- [ ] @pomegranited 
- [x] @brianhw 
