### PR TITLE
WIP: Fix d_course.

### DIFF
--- a/edx/analytics/tasks/tests/test_course_information.py
+++ b/edx/analytics/tasks/tests/test_course_information.py
@@ -116,11 +116,10 @@ class TestCourseInformation(unittest.TestCase):
         input_data = {
             "results": [
                 {
-                    "id": "foo",
+                    "id": "bar/foo/2T2015",
                     "name": "Foo",
                     "org": "bar",
-                    "course": "Baz",
-                    "run": "2T2015",
+                    "number": "foo",
                     "start": "2015-08-24T00:00:00Z",
                     "end": "2016-08-25T00:00:00Z"
                 }
@@ -131,10 +130,10 @@ class TestCourseInformation(unittest.TestCase):
         # We expect to see this course with the mock structure information.
         self.assertEquals(data.shape[0], 1)
         expected = {
-            'course_id': 'foo',
+            'course_id': 'bar/foo/2T2015',
             'course_name': 'Foo',
             'course_org_id': 'bar',
-            'course_number': 'Baz',
+            'course_number': 'foo',
             'course_run': '2T2015',
             'course_start': '2015-08-24T00:00:00+00:00',
             'course_end': '2016-08-25T00:00:00+00:00'
@@ -146,20 +145,18 @@ class TestCourseInformation(unittest.TestCase):
         input_data = {
             "results": [
                 {
-                    "id": "foo",
+                    "id": "bar/foo/2T2015",
                     "name": "Foo",
                     "org": "bar",
-                    "course": "Baz",
-                    "run": "2T2015",
+                    "number": "foo",
                     "start": "2015-08-24T00:00:00Z",
                     "end": "2016-08-25T00:00:00Z"
                 },
                 {
-                    "id": "foo2",
+                    "id": "bar2/foo2/2T2015",
                     "name": "Foo2",
                     "org": "bar2",
-                    "course": "Baz",
-                    "run": "2T2015",
+                    "number": "foo2",
                     "start": "2015-08-24T00:00:00Z"
                 }
             ]
@@ -169,19 +166,19 @@ class TestCourseInformation(unittest.TestCase):
         # We expect to see two courses.
         self.assertEquals(data.shape[0], 2)
         course1 = {
-            'course_id': 'foo',
+            'course_id': 'bar/foo/2T2015',
             'course_name': 'Foo',
             'course_org_id': 'bar',
-            'course_number': 'Baz',
+            'course_number': 'foo',
             'course_run': '2T2015',
             'course_start': '2015-08-24T00:00:00+00:00',
             'course_end': '2016-08-25T00:00:00+00:00'
         }
         course2 = {
-            'course_id': 'foo2',
+            'course_id': 'bar2/foo2/2T2015',
             'course_name': 'Foo2',
             'course_org_id': 'bar2',
-            'course_number': 'Baz',
+            'course_number': 'foo2',
             'course_run': '2T2015',
             'course_start': '2015-08-24T00:00:00+00:00',
             'course_end': '\N'
@@ -199,10 +196,10 @@ class TestCourseInformation(unittest.TestCase):
             "results": [
                 [],
                 {
-                    "id": "foo2",
+                    "id": "bar2/foo2/2T2015",
                     "name": "Foo2",
                     "org": "bar2",
-                    "course": "Baz",
+                    "number": "foo2",
                     "run": "2T2015",
                     "start": "2015-08-24T00:00:00Z"
                 }
@@ -212,10 +209,10 @@ class TestCourseInformation(unittest.TestCase):
         # We expect to see the second course, which is well-formed, but nothing from the first.
         self.assertEquals(data.shape[0], 1)
         expected = {
-            'course_id': 'foo2',
+            'course_id': 'bar2/foo2/2T2015',
             'course_name': 'Foo2',
             'course_org_id': 'bar2',
-            'course_number': 'Baz',
+            'course_number': 'foo2',
             'course_run': '2T2015',
             'course_start': '2015-08-24T00:00:00+00:00',
             'course_end': '\N'
@@ -227,11 +224,10 @@ class TestCourseInformation(unittest.TestCase):
         input_data = {
             "results": [
                 {
-                    "id": "foo",
+                    "id": "bar/foo/2T2015",
                     "name": u"Fo\u263a",
                     "org": "bar",
-                    "course": "Baz",
-                    "run": "2T2015",
+                    "number": "foo",
                     "start": "2015-08-24T00:00:00Z",
                     "end": "2016-08-25T00:00:00Z"
                 }
@@ -244,10 +240,10 @@ class TestCourseInformation(unittest.TestCase):
         # but can't handle the unicode strings.  This "error" really indicates a test failure.
         self.assertEquals(data.shape[0], 1)
         expected = {
-            'course_id': 'foo',
+            'course_id': 'bar/foo/2T2015',
             'course_name': 'Fo\xe2\x98\xba',
             'course_org_id': 'bar',
-            'course_number': 'Baz',
+            'course_number': 'foo',
             'course_run': '2T2015',
             'course_start': '2015-08-24T00:00:00+00:00',
             'course_end': '2016-08-25T00:00:00+00:00'

--- a/edx/analytics/tasks/vertica_load.py
+++ b/edx/analytics/tasks/vertica_load.py
@@ -421,6 +421,8 @@ class VerticaCopyTask(VerticaCopyTaskMixin, luigi.Task):
             # that would commit the transaction.
             self.init_copy(connection)
 
+            connection.cursor().execute("SET TIMEZONE TO 'GMT';")
+
             cursor = connection.cursor()
             self.copy_data_table_from_target(cursor)
 


### PR DESCRIPTION
@mulby @brianhw 

This attempts to fix d_course job using the new API(http://edx.readthedocs.io/projects/edx-platform-api/en/latest/courses/courses.html#get-a-list-of-courses). 

The API does not return 'run' and 'course' fields in the response JSON. 
