### PR TITLE
Create missing enrollment hive table

### DIFF
--- a/edx/analytics/tasks/enrollments.py
+++ b/edx/analytics/tasks/enrollments.py
@@ -9,7 +9,7 @@ import luigi.task
 from edx.analytics.tasks.database_imports import ImportAuthUserProfileTask
 from edx.analytics.tasks.mapreduce import MapReduceJobTaskMixin, MapReduceJobTask
 from edx.analytics.tasks.pathutil import EventLogSelectionDownstreamMixin, EventLogSelectionMixin
-from edx.analytics.tasks.url import get_target_from_url, url_path_join
+from edx.analytics.tasks.url import get_target_from_url, url_path_join, ExternalURL
 from edx.analytics.tasks.util import eventlog, opaque_key_util
 from edx.analytics.tasks.util.hive import WarehouseMixin, HiveTableTask, HivePartition, HiveQueryToMysqlTask
 from edx.analytics.tasks.decorators import workflow_entry_point
@@ -331,6 +331,14 @@ class CourseEnrollmentTableTask(CourseEnrollmentTableDownstreamMixin, HiveTableT
             interval=self.interval,
             pattern=self.pattern,
             output_root=self.partition_location,
+        )
+
+
+class ExternalCourseEnrollmentTableTask(CourseEnrollmentTableTask):
+
+    def requires(self):
+        yield ExternalURL(
+            url=url_path_join(self.warehouse_path, 'course_enrollment', self.partition.path_spec) + '/'
         )
 
 

--- a/edx/analytics/tasks/module_engagement.py
+++ b/edx/analytics/tasks/module_engagement.py
@@ -26,7 +26,7 @@ from edx.analytics.tasks.database_imports import ImportAuthUserTask, ImportCours
 from edx.analytics.tasks.database_imports import ImportCourseUserGroupTask
 from edx.analytics.tasks.decorators import workflow_entry_point
 from edx.analytics.tasks.elasticsearch_load import ElasticsearchIndexTask
-from edx.analytics.tasks.enrollments import CourseEnrollmentTableTask
+from edx.analytics.tasks.enrollments import ExternalCourseEnrollmentTableTask
 
 from edx.analytics.tasks.mapreduce import MapReduceJobTask, MapReduceJobTaskMixin
 from edx.analytics.tasks.pathutil import EventLogSelectionMixin, EventLogSelectionDownstreamMixin
@@ -1134,8 +1134,8 @@ class ModuleEngagementRosterPartitionTask(WeekIntervalMixin, ModuleEngagementDow
                 overwrite=self.overwrite,
                 overwrite_from_date=self.overwrite_from_date,
             ),
-            ExternalURL(
-                url=url_path_join(self.warehouse_path, 'course_enrollment', self.partition.path_spec) + '/'
+            ExternalCourseEnrollmentTableTask(
+                interval_end=self.date
             ),
             ImportAuthUserTask(**kwargs_for_db_import),
             ImportCourseUserGroupTask(**kwargs_for_db_import),


### PR DESCRIPTION
When running on a different cluster than the enrollment workflow we need to create the Hive table. The acceptance test passes because the two jobs are run in succession, so the Hive table persists unfortunately.

@brianhw 
@HassanJaveed84 
