### PR TITLE
Upgrade numpy to it's latest version

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -14,7 +14,7 @@ isoweek==1.3.0		# BSD
 mechanize==0.2.5	# BSD
 http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-1.2.2.zip  	# GPL v2 with FOSS License Exception
 ndg-httpsclient==0.4.0  # BSD
-numpy==1.8.0 		# BSD
+numpy==1.11.0 		# BSD
 pandas==0.13.0 		# BSD
 paypalrestsdk==1.9.0    # Paypal SDK License
 pbr==0.5.23 		# Apache


### PR DESCRIPTION
We need to upgrade this to keep the numpy versions in-sync across different repos. 
Platform PR: https://github.com/edx/edx-platform/pull/12444
