### PR TITLE
remove combiners

### DIFF
--- a/edx/analytics/tasks/user_activity.py
+++ b/edx/analytics/tasks/user_activity.py
@@ -117,8 +117,6 @@ class UserActivityTask(EventLogSelectionMixin, MapReduceJobTask):
         if num_events > 0:
             yield key, num_events
 
-    combiner = reducer
-
     def output(self):
         return get_target_from_url(self.output_root)
 


### PR DESCRIPTION
We are seeing significant performance degradation using combiners on the user activity job.

Given that they are supposed to be a performance optimization, we simply remove them here. We can investigate this further in the future if we think they will provide a significant boost in performance once we identify and resolve the issue that is rendering them useless.

FYI @brianhw @HassanJaveed84 
