### PR TITLE
Bump edx-opaque-keys to 0.3.2 (perf fixes)

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -3,7 +3,7 @@ argparse==1.2.1 	# Python Software Foundation License
 cffi==1.1.0             # MIT
 ciso8601==1.0.1         # MIT
 cryptography==0.9       # BSD or Apache 2.0
-edx-opaque-keys==0.2.1  # AGPL
+edx-opaque-keys==0.3.2  # AGPL
 edx-ccx-keys==0.1.2     # AGPL
 elasticsearch==1.7.0    # Apache
 enum34==1.0.4           # BSD
@@ -29,7 +29,7 @@ python-gnupg==0.3.6	# BSD
 pytz==2014.4		# ZPL
 requests==2.7.0         # Apache 2.0
 setuptools==23.1.0
-six==1.6.1		# MIT
+six==1.10.0		# MIT
 stevedore==0.14.1 	# Apache 2.0
 tornado==3.1.1 		# Apache 2.0
 urllib3==1.10.4         # MIT


### PR DESCRIPTION
@mulby: Bumping OpaqueKeys to 0.3.2
