### PR TITLE
Prevent duplicate data insertion as part of the module_engagement workflow

### DIFF
--- a/edx/analytics/tasks/answer_dist.py
+++ b/edx/analytics/tasks/answer_dist.py
@@ -841,7 +841,7 @@ class AnswerDistributionToMySQLTaskWorkflow(
 ):
 
     # Override the parameter that normally defaults to false. This ensures that the table will always be overwritten.
-    overwrite = luigi.BooleanParameter(default=True)
+    overwrite = luigi.BooleanParameter(default=True, significant=False)
 
     @property
     def insert_source_task(self):

--- a/edx/analytics/tasks/load_warehouse.py
+++ b/edx/analytics/tasks/load_warehouse.py
@@ -43,7 +43,7 @@ class WarehouseWorkflowMixin(WarehouseMixin):
         description='Path to the external access credentials file.',
     )
 
-    overwrite = luigi.BooleanParameter(default=False)
+    overwrite = luigi.BooleanParameter(default=False, significant=False)
 
     # We rename the schema after warehouse loading step. This causes
     # Luigi to think that tasks are not complete as it cannot find the

--- a/edx/analytics/tasks/mysql_load.py
+++ b/edx/analytics/tasks/mysql_load.py
@@ -220,6 +220,7 @@ class MysqlInsertTask(MysqlInsertTaskMixin, luigi.Task):
                     marker_table=marker_table,
                     target_table=self.table,
                 )
+                log.debug(query)
                 connection.cursor().execute(query)
             except mysql.connector.Error as excp:  # handle the case where the marker_table has yet to be created
                 if excp.errno == errorcode.ER_NO_SUCH_TABLE:
@@ -230,6 +231,7 @@ class MysqlInsertTask(MysqlInsertTaskMixin, luigi.Task):
             # Use "DELETE" instead of TRUNCATE since TRUNCATE forces an implicit commit before it executes which would
             # commit the currently open transaction before continuing with the copy.
             query = "DELETE FROM {table}".format(table=self.table)
+            log.debug(query)
             connection.cursor().execute(query)
 
     def _execute_insert_query(self, cursor, value_list, column_names):
@@ -452,6 +454,7 @@ class IncrementalMysqlInsertTask(MysqlInsertTask):
                     marker_table=marker_table,
                     update_id=self.update_id(),
                 )
+                log.debug(query)
                 connection.cursor().execute(query)
             except mysql.connector.Error as excp:  # handle the case where the marker_table has yet to be created
                 if excp.errno == errorcode.ER_NO_SUCH_TABLE:
@@ -465,6 +468,7 @@ class IncrementalMysqlInsertTask(MysqlInsertTask):
                 table=self.table,
                 record_filter=self.record_filter
             )
+            log.debug(query)
             connection.cursor().execute(query)
 
     @property

--- a/edx/analytics/tasks/tags_dist.py
+++ b/edx/analytics/tasks/tags_dist.py
@@ -155,7 +155,8 @@ class TagsDistributionWorkflow(
     # Override the parameter that normally defaults to false. This ensures that the table will always be overwritten.
     overwrite = luigi.BooleanParameter(
         default=True,
-        description="Whether or not to overwrite existing outputs"
+        description="Whether or not to overwrite existing outputs",
+        significant=False
     )
 
     @property

--- a/edx/analytics/tasks/util/overwrite.py
+++ b/edx/analytics/tasks/util/overwrite.py
@@ -27,6 +27,7 @@ class OverwriteOutputMixin(object):
     overwrite = luigi.BooleanParameter(
         default=False,
         description='Whether or not to overwrite existing outputs; set to False by default for now.',
+        significant=False
     )
     attempted_removal = False
 


### PR DESCRIPTION
## Problem
- We overwrite the last 3 days of granular engagement data in S3 and mysql every night by setting the overwrite parameter to `True`.
- This means that task for 4 days ago will have previously always been run with overwrite set to `True` and now, for the first time, be running with overwrite set to `False`.
- Since overwrite is a significant parameter it is used to generate the hash code stored in the `table_updates` table that indicates whether the task has run successfully or not. When its value changes, the computed hash changes and luigi _thinks_ that it hasn't successfully run.
- At this point luigi schedules the MySQL task for execution with overwrite set to `False`.
- When the task executes, it inserts the data from S3 into the MySQL table. Note that the data was already in the table from the last time the task executed when overwrite was set to `True`.
- This results in duplicate data in the table.
## Fix included in this patch
1. Make the overwrite parameter insignificant. It does not affect the content of the output so it never should have been significant to begin with.
2. Change the `update_id()` function so that only the date determines whether the task should re-run or not.
## Reproduction Steps

Run the module engagement workflow on subsequent days when there is at least 4 days of data available for processing.

Find a course_id that is very active and run this query on your result store, substituting <course_id> with your course_id. If you don't have much data in your system, you can remove the where clause that specifies the course_id.

``` sql
select date, max(num_rows) from (select *, count(*) as num_rows from (select course_id, username, date, entity_type, entity_id, event from module_engagement where course_id='<course_id>') a group by 1, 2, 3, 4, 5, 6 having count(*) > 1) b group by date order by date desc;
```

If the above query does not return any rows, then there is no duplicate data in your system. If it returns any rows than those dates have duplicate data.
## Applying the Patch

The easiest way to apply this patch is to write to a new result store database. You can update the `database` key of the `database-export` section of the config file. You then need to update the API configuration to point at that new database once it is fully populated. You will have to run all tasks again using the updated configuration to populate the new database.

If you want to update your existing database in place, you will need to do execute something like the following procedure.

Using this branch, run a task that looks like:

``` bash
  ModuleEngagementIntervalTask --local-scheduler \
     --interval $(date +%Y-%m-%d -d "$FROM_DATE")-$(date +%Y-%m-%d -d "$TO_DATE") \
     --n-reduce-tasks $NUM_REDUCE_TASKS \
     --overwrite-from-date $(date +%Y-%m-%d -d "$FROM_DATE")
```

Where FROM_DATE is set to the first date you have data for and TO_DATE is the day after the last (usually "today").

This task will overwrite all of your duplicated data with de-duplicated data and insert a new record into `table_updates` with the new update_id format.

Note that this task will require fairly expensive I/O operations on the database since there is no index on the date column. This could affect reads issued by your users if you are executing this on a production system. You can avoid this by truncating the table before running the task above, however, that will cause the charts to be unavailable while the data is reinserted.

Clean out any old records from table_updates:

``` sql
DELETE FROM table_updates WHERE target_table='module_engagement' AND update_id NOT LIKE 'ModuleEngagementMysqlTask%'
```

In the future run the workflow using a version of the code that includes the changes from this branch.
## Reviewers
- [x] @HassanJaveed84 
- [x] @brianhw 
## FYI
- [ ] @renevatium - since I think you are running this workflow?
- [ ] @pomegranited - since you are also touching this code (or will be soon)
