### PR TITLE
Appends 10 auth_userprofile fields to ModuleEngagementRosterRecord

### DIFF
--- a/edx/analytics/tasks/database_imports.py
+++ b/edx/analytics/tasks/database_imports.py
@@ -275,6 +275,12 @@ class ImportAuthUserProfileTask(ImportMysqlToHiveTableTask):
             ('gender', 'STRING'),
             ('year_of_birth', 'INT'),
             ('level_of_education', 'STRING'),
+            ('language', 'STRING'),
+            ('location', 'STRING'),
+            ('mailing_address', 'STRING'),
+            ('city', 'STRING'),
+            ('country', 'STRING'),
+            ('goals', 'STRING'),
         ]
 
 

--- a/edx/analytics/tasks/module_engagement.py
+++ b/edx/analytics/tasks/module_engagement.py
@@ -996,6 +996,17 @@ class ModuleEngagementRosterRecord(Record):
                     ' (problem_attempts_per_completed ASC, attempt_ratio_order DESC). To see struggling learners sort'
                     ' by (problem_attempts_per_completed DESC, attempt_ratio_order ASC).'
     )
+    # More user profile fields, appended after initial schema creation
+    user_id = IntegerField(description='Learner\'s user ID.')
+    language = StringField(description='Learner\'s preferred language.')
+    location = StringField(description='Learner\'s reported location.')
+    year_of_birth = IntegerField(description='Learner\'s reported year of birth.')
+    level_of_education = StringField(description='Learner\'s reported level of education.')
+    gender = StringField(description='Learner\'s reported gender.')
+    mailing_address = StringField(description='Learner\'s reported mailing address.')
+    city = StringField(description='Learner\'s reported city.')
+    country = StringField(description='Learner\'s reported country.')
+    goals = StringField(description='Learner\'s reported goals.')
 
 
 class ModuleEngagementRosterTableTask(BareHiveTableTask):
@@ -1078,7 +1089,17 @@ class ModuleEngagementRosterPartitionTask(WeekIntervalMixin, ModuleEngagementDow
                 eng.problem_attempts_per_completed IS NULL,
                 -COALESCE(eng.problem_attempts, 0),
                 COALESCE(eng.problem_attempts, 0)
-            )
+            ),
+            aup.user_id,
+            aup.language,
+            aup.location,
+            aup.year_of_birth,
+            aup.level_of_education,
+            aup.gender,
+            aup.mailing_address,
+            aup.city,
+            aup.country,
+            aup.goals
         FROM course_enrollment ce
         INNER JOIN auth_user au
             ON (ce.user_id = au.id)

--- a/edx/analytics/tasks/tests/acceptance/fixtures/input/load_auth_userprofile.sql
+++ b/edx/analytics/tasks/tests/acceptance/fixtures/input/load_auth_userprofile.sql
@@ -1,6 +1,6 @@
 CREATE TABLE `auth_userprofile` ( `id` int(11) NOT NULL, `user_id` int(11) NOT NULL, `name` varchar(255) NOT NULL, `language` varchar(255) NOT NULL, `location` varchar(255) NOT NULL, `meta` longtext NOT NULL, `courseware` varchar(255) NOT NULL, `gender` varchar(6), `mailing_address` longtext, `year_of_birth` int(11), `level_of_education` varchar(6), `goals` longtext, `allow_certificate` tinyint(1) NOT NULL, `country` varchar(2), `city` longtext, PRIMARY KEY (`id`), UNIQUE KEY `user_id` (`user_id`) );
 
-INSERT INTO `auth_userprofile` VALUES (1,1,'honor','','','','course.xml','m',NULL,1984,'a',NULL,1,'',NULL);
+INSERT INTO `auth_userprofile` (`id`,`user_id`,`name`,`language`,`location`,`meta`,`courseware`,`gender`,`mailing_address`,`year_of_birth`,`level_of_education`,`goals`,`allow_certificate`,`country`,`city`) VALUES (1,1,'honor','es-ES','Europe','','course.xml','m','Luna, 10 - 3, 28300 ARANJUEZ',1984,'a','Me encanta aprender.',1,'ES', 'Madrid');
 INSERT INTO `auth_userprofile` VALUES (2,2,'audit','','','','course.xml','m',NULL,1975,'b',NULL,1,'',NULL);
 INSERT INTO `auth_userprofile` VALUES (3,3,'verified','','','','course.xml','',NULL,2000,'b',NULL,1,'',NULL);
 INSERT INTO `auth_userprofile` VALUES (4,4,'staff','','','','course.xml',NULL,NULL,2000,'',NULL,1,'',NULL);

--- a/edx/analytics/tasks/tests/acceptance/test_module_engagement.py
+++ b/edx/analytics/tasks/tests/acceptance/test_module_engagement.py
@@ -77,6 +77,12 @@ class ModuleEngagementAcceptanceTest(AcceptanceTestCase):
                 'segments': [''],
                 'start_date': '2015-04-10',
                 'username': 'staff',
+                'user_id': 4,
+                'location': '',
+                'language': '',
+                'year_of_birth': 2000,
+                'country': '',
+                'level_of_education': '',
                 'videos_viewed': 1
             },
             {
@@ -96,6 +102,16 @@ class ModuleEngagementAcceptanceTest(AcceptanceTestCase):
                 'segments': [''],
                 'start_date': u'2015-04-10',
                 'username': u'honor',
+                'user_id': 1,
+                'location': 'Europe',
+                'language': 'es-ES',
+                'year_of_birth': 1984,
+                'gender': 'm',
+                'goals': 'Me encanta aprender.',
+                'level_of_education': 'a',
+                'mailing_address': 'Luna, 10 - 3, 28300 ARANJUEZ',
+                'city': 'Madrid',
+                'country': 'ES',
                 'videos_viewed': 2
             },
             {
@@ -114,6 +130,16 @@ class ModuleEngagementAcceptanceTest(AcceptanceTestCase):
                 'segments': [u'highly_engaged'],
                 'start_date': u'2015-04-10',
                 'username': u'honor',
+                'user_id': 1,
+                'location': 'Europe',
+                'language': 'es-ES',
+                'year_of_birth': 1984,
+                'gender': 'm',
+                'goals': 'Me encanta aprender.',
+                'level_of_education': 'a',
+                'mailing_address': 'Luna, 10 - 3, 28300 ARANJUEZ',
+                'city': 'Madrid',
+                'country': 'ES',
                 'videos_viewed': 1
             },
             {
@@ -132,6 +158,16 @@ class ModuleEngagementAcceptanceTest(AcceptanceTestCase):
                 'segments': [''],
                 'start_date': u'2015-04-10',
                 'username': u'honor',
+                'user_id': 1,
+                'location': 'Europe',
+                'language': 'es-ES',
+                'year_of_birth': 1984,
+                'gender': 'm',
+                'goals': 'Me encanta aprender.',
+                'level_of_education': 'a',
+                'mailing_address': 'Luna, 10 - 3, 28300 ARANJUEZ',
+                'city': 'Madrid',
+                'country': 'ES',
                 'videos_viewed': 1
             },
         ]

--- a/edx/analytics/tasks/tests/test_module_engagement.py
+++ b/edx/analytics/tasks/tests/test_module_engagement.py
@@ -916,7 +916,17 @@ class ModuleEngagementRosterIndexTaskTest(ReducerTestMixin, unittest.TestCase):
                     'attempt_ratio_order': -1,
                     'problem_attempts_per_completed': 4.0,
                     'course_id': 'foo/bar/baz',
-                    'start_date': datetime.date(2014, 3, 25)
+                    'start_date': datetime.date(2014, 3, 25),
+                    'user_id': 10,
+                    'language': 'en',
+                    'location': 'Asia Pacific',
+                    'year_of_birth': 1970,
+                    'level_of_education': 'none',
+                    'gender': 'o',
+                    'mailing_address': '123 Sesame St',
+                    'city': 'Springfield',
+                    'country': 'USA',
+                    'goals': 'Aim high',
                 }
             }
         )
@@ -941,6 +951,16 @@ class ModuleEngagementRosterIndexTaskTest(ReducerTestMixin, unittest.TestCase):
             'course_id': self.COURSE_ID,
             'start_date': datetime.date(2014, 3, 25),
             'cohort': None,
+            'user_id': 10,
+            'language': 'en',
+            'location': 'Asia Pacific',
+            'year_of_birth': 1970,
+            'level_of_education': 'none',
+            'gender': 'o',
+            'mailing_address': '123 Sesame St',
+            'city': 'Springfield',
+            'country': 'USA',
+            'goals': 'Aim high',
         }
         field_values.update(kwargs)
         return ModuleEngagementRosterRecord(**field_values)


### PR DESCRIPTION
Adds the following fields from the `auth_userprofile` table to the `ModuleEngagementRosterRecord`:
- user_id
- language
- location
- year_of_birth
- level_of_education
- gender
- mailing_address
- city
- country
- goals

Appends the new fields to the end of the hive table to facilitate migrations for persistent clusters.

**Discussions**: This change is related to [edx-analytics-data-api PR #128](https://github.com/edx/edx-analytics-data-api/pull/128), which has been discussed extensively with the Analytics team.

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Partner information**: 3rd party-hosted open edX instance

**Testing instructions**:
1. See [edx-analytics-data-api PR #128](https://github.com/edx/edx-analytics-data-api/pull/128) for testing setup instructions.  
2. If you want to see the data flow through to the Analytics API, install the branch from [edx-analytics-data-api PR #129 ](https://github.com/edx/edx-analytics-data-api/pull/129) and restart the analytics API.
3. Reinstall the analytics pipeline from this PR branch on vagrant instance under the previously-installed location:
   
   ```
   ssh vagrant
   cd /var/lib/analytics-tasks/analyticstack/repo
   source /var/lib/analytics-tasks/analyticstack/venv/bin/activate
   git remote add pr https://github.com/open-craft/edx-analytics-pipeline.git
   git fetch pr
   git checkout jill/module-engagement-add-fields
   make bootstrap
   ```
4. To preserve your existing hdfs data, run these hive SQL queries.
   
   _NB_ This step is only required for persistent clusters, like the analyticstack.  Most production analytics clusters are run using transient clusters.  To simulate the transient cluster effect, DROP the following tables instead of ALTERing them.
   
   ```
   sudo su hadoop
   hive    
   hive> ALTER TABLE module_engagement_roster
   ADD COLUMNS (
   user_id int,
   language string,
   location string,
   year_of_birth int,
   level_of_education string,
   gender string,
   mailing_address string,
   city string,
   country string,
   goals string
   );
   
   hive> ALTER TABLE auth_userprofile
   ADD COLUMNS (
   language string,
   location string,
   mailing_address string,
   city string,
   country string,
   goals string
   );
   ```
5. Re-run the pipeline tasks, using the `--overwrite` flag to overwrite existing data.
   
   _NB_ @haikuginger ~~I made a mistake with the initial PR description, and used `ModuleEngagementWorkflowTask --date $TOMORROW`.  This doesn't work, as the query that constructs this table relies on today's data from the `auth_userprofile` table.~~
   
   ```
   sudo su hadoop
   source /var/lib/analytics-tasks/analyticstack/venv/bin/activate
   TODAY=`date +%Y-%m-%d`
   TOMORROW=`date --date="tomorrow" +%Y-%m-%d`
   
   launch-task ImportEnrollmentsIntoMysql \
   --interval 2016-07-01-$TOMORROW \
   --local-scheduler --n-reduce-tasks 2 \
   --remote-log-level DEBUG
   
   launch-task ModuleEngagementWorkflowTask \
    --local-scheduler --n-reduce-tasks 2 \
    --remote-log-level DEBUG \
    --date $TOMORROW --overwrite  # NOTE
   ```
6. Check the ElasticSearch index to ensure the new fields are populated:
   
   ```
   http://localhost:9223/roster/_search/?course_id=<your URL-encoded course ID>
   ```
7. Save changes to your test user profiles from the `Accounts` page.
8. Wait 1 min for tracking logs to be copied to hdfs (cron'd).
9. Re-run analytics pipeline tasks above ensure the updated data is visible in the hive table.
10. Run unit tests (also installs test dependencies):
    
    ```
    vagrant ssh
    cd /var/lib/analytics-tasks/analyticstack/repo
    source ../venv/bin/activate
    export WHEEL_URL=http://edx-wheelhouse.s3-website-us-east-1.amazonaws.com/Ubuntu/precise
    export WHEEL_PYVER=python2.7
    make coverage
    ```
11. Run acceptance tests:
    
    ```
    vagrant ssh
    sudo su hadoop
    cd /var/lib/analytics-tasks/analyticstack/repo
    source ../venv/bin/activate
    make test-acceptance-local
    ```

**Author Notes and Concerns**:
1. The `auth_userprofile.language` field doesn't seem to be populated by the Accounts page anymore; instead it feeds a one-to-many relationship with `student_languageproficiency`.  Will need to discuss with the client whether this field is required, and if so, import the `student_languageproficiency` into hive and add a `JOIN` to the roster query.
2. The `auth_userprofile.location` field doesn't seem to be populated by the Accounts page anymore either.  It may be deprecated; will discuss with client.
3. Need to find out how to trigger jenkins tests from github.

**Reviewers**
- [x] @haikuginger
- [ ] @mulby 
- [ ] edX reviewer[s] TBD
