### PR TITLE
[WIP] Use edx-opaque-keys v0.3.3 get_filename_safe_course_id

### DIFF
--- a/edx/analytics/tasks/answer_dist.py
+++ b/edx/analytics/tasks/answer_dist.py
@@ -21,7 +21,8 @@ from edx.analytics.tasks.url import get_target_from_url, url_path_join
 from edx.analytics.tasks.mysql_load import MysqlInsertTask, MysqlInsertTaskMixin
 from edx.analytics.tasks.decorators import workflow_entry_point
 import edx.analytics.tasks.util.eventlog as eventlog
-import edx.analytics.tasks.util.opaque_key_util as opaque_key_util
+from edx.analytics.tasks.util import opaque_key_util
+from edx.opaque_keys.util import get_filename_safe_course_id
 
 import logging
 log = logging.getLogger(__name__)
@@ -743,7 +744,7 @@ class AnswerDistributionOneFilePerCourseTask(AnswerDistributionDownstreamMixin, 
         directory will be displayed on the instructor dashboard for that course.
         """
         hashed_course_id = hashlib.sha1(course_id).hexdigest()
-        filename_safe_course_id = opaque_key_util.get_filename_safe_course_id(course_id, '_')
+        filename_safe_course_id = get_filename_safe_course_id(course_id, '_')
         filename = u'{course_id}_answer_distribution.csv'.format(course_id=filename_safe_course_id)
         return url_path_join(self.output_root, hashed_course_id, filename)
 

--- a/edx/analytics/tasks/data_obfuscation.py
+++ b/edx/analytics/tasks/data_obfuscation.py
@@ -19,7 +19,7 @@ from edx.analytics.tasks.util.obfuscate_util import (
 )
 from edx.analytics.tasks.util.file_util import read_config_file, copy_file_to_file
 from edx.analytics.tasks.util.tempdir import make_temp_directory
-import edx.analytics.tasks.util.opaque_key_util as opaque_key_util
+from edx.opaque_keys.util import get_filename_safe_course_id
 
 
 log = logging.getLogger(__name__)
@@ -627,7 +627,7 @@ class ObfuscatedCourseDumpTask(ObfuscatorDownstreamMixin, luigi.WrapperTask):
     def __init__(self, *args, **kwargs):
         super(ObfuscatedCourseDumpTask, self).__init__(*args, **kwargs)
 
-        filename_safe_course_id = opaque_key_util.get_filename_safe_course_id(self.course)
+        filename_safe_course_id = get_filename_safe_course_id(self.course)
         dump_path = url_path_join(self.dump_root, filename_safe_course_id, 'state')
         auth_userprofile_targets = PathSetTask([dump_path], ['*auth_userprofile*']).output()
         # TODO: Refactor out this logic of getting latest file. Right now we expect a date, so we use that

--- a/edx/analytics/tasks/database_exports.py
+++ b/edx/analytics/tasks/database_exports.py
@@ -14,7 +14,7 @@ from edx.analytics.tasks.pathutil import PathSetTask
 from edx.analytics.tasks.sqoop import SqoopImportFromMysql
 from edx.analytics.tasks.util import csv_util
 from edx.analytics.tasks.url import url_path_join, get_target_from_url
-import edx.analytics.tasks.util.opaque_key_util as opaque_key_util
+from edx.opaque_keys.util import get_filename_safe_course_id
 
 
 log = logging.getLogger(__name__)
@@ -104,7 +104,7 @@ class StudentModulePerCourseTask(MultiOutputMapReduceJobTask):
         template = "{course_id}-courseware_studentmodule-{suffix}analytics.sql"
 
         filename = template.format(
-            course_id=opaque_key_util.get_filename_safe_course_id(course_id, '-'),
+            course_id=get_filename_safe_course_id(course_id, '-'),
             suffix=(self.output_suffix + '-') if self.output_suffix else ''
         )
 

--- a/edx/analytics/tasks/enrollment_validation.py
+++ b/edx/analytics/tasks/enrollment_validation.py
@@ -17,6 +17,7 @@ from edx.analytics.tasks.util import eventlog, opaque_key_util
 from edx.analytics.tasks.util.datetime_util import add_microseconds, mysql_datetime_to_isoformat, ensure_microseconds
 from edx.analytics.tasks.util.event_factory import SyntheticEventFactory
 from edx.analytics.tasks.util.hive import WarehouseMixin
+from edx.opaque_keys.util import get_filename_safe_course_id
 
 
 log = logging.getLogger(__name__)
@@ -785,7 +786,7 @@ class CreateEnrollmentValidationEventsTask(MultiOutputMapReduceJobTask):
                 outfile.write('\n')
 
     def output_path_for_key(self, course_id):
-        filename_safe_course_id = opaque_key_util.get_filename_safe_course_id(course_id, '_')
+        filename_safe_course_id = get_filename_safe_course_id(course_id, '_')
         filename = u'{course_id}_enroll_validated_{dumpdate}.log.gz'.format(
             course_id=filename_safe_course_id,
             dumpdate=self.dump_date,

--- a/edx/analytics/tasks/event_exports_by_course.py
+++ b/edx/analytics/tasks/event_exports_by_course.py
@@ -9,8 +9,8 @@ import luigi.date_interval
 from edx.analytics.tasks.mapreduce import MultiOutputMapReduceJobTask
 from edx.analytics.tasks.pathutil import EventLogSelectionMixin
 from edx.analytics.tasks.url import url_path_join
-import edx.analytics.tasks.util.opaque_key_util as opaque_key_util
 from edx.analytics.tasks.util import eventlog
+from edx.opaque_keys.util import get_filename_safe_course_id
 
 log = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ class EventExportByCourseTask(EventLogSelectionMixin, MultiOutputMapReduceJobTas
 
     def output_path_for_key(self, key):
         date, course_id = key
-        filename_safe_course_id = opaque_key_util.get_filename_safe_course_id(course_id)
+        filename_safe_course_id = get_filename_safe_course_id(course_id)
 
         return url_path_join(
             self.output_root,

--- a/edx/analytics/tasks/events_obfuscation.py
+++ b/edx/analytics/tasks/events_obfuscation.py
@@ -18,8 +18,8 @@ from edx.analytics.tasks.url import ExternalURL, url_path_join
 from edx.analytics.tasks.util.obfuscate_util import (
     ObfuscatorMixin, ObfuscatorDownstreamMixin, IMPLICIT_EVENT_TYPE_PATTERNS
 )
-import edx.analytics.tasks.util.opaque_key_util as opaque_key_util
-from edx.analytics.tasks.util import eventlog
+from edx.opaque_keys.util import get_filename_safe_course_id
+from edx.analytics.tasks.util import eventlog, opaque_key_util
 from edx.analytics.tasks.util.file_util import read_config_file
 
 log = logging.getLogger(__name__)
@@ -43,7 +43,7 @@ class ObfuscateCourseEventsTask(ObfuscatorMixin, GeolocationMixin, GeolocationTa
     dump_root = luigi.Parameter(default=None)
 
     def requires(self):
-        filename_safe_course_id = opaque_key_util.get_filename_safe_course_id(self.course)
+        filename_safe_course_id = get_filename_safe_course_id(self.course)
         event_files_url = url_path_join(self.dump_root, filename_safe_course_id, 'events')
         return PathSetTask([event_files_url], ['*'])
 
@@ -101,7 +101,7 @@ class ObfuscateCourseEventsTask(ObfuscatorMixin, GeolocationMixin, GeolocationTa
                 outfile.close()
 
     def output_path_for_key(self, key):
-        filename_safe_course_id = opaque_key_util.get_filename_safe_course_id(self.course)
+        filename_safe_course_id = get_filename_safe_course_id(self.course)
 
         return url_path_join(
             self.output_root,

--- a/edx/analytics/tasks/obfuscation.py
+++ b/edx/analytics/tasks/obfuscation.py
@@ -19,8 +19,8 @@ from edx.analytics.tasks.events_obfuscation import ObfuscateCourseEventsTask
 from edx.analytics.tasks.pathutil import PathSetTask
 from edx.analytics.tasks.url import url_path_join, get_target_from_url
 from edx.analytics.tasks.url import ExternalURL
-from edx.analytics.tasks.util import opaque_key_util
 from edx.analytics.tasks.util.tempdir import make_temp_directory
+from edx.opaque_keys.util import get_filename_safe_course_id
 
 
 log = logging.getLogger(__name__)
@@ -93,7 +93,7 @@ class ObfuscatedCourseTask(ObfuscatedCourseTaskMixin, luigi.Task):
             }, metadata_file)
 
     def output(self):
-        filename_safe_course_id = opaque_key_util.get_filename_safe_course_id(self.course)
+        filename_safe_course_id = get_filename_safe_course_id(self.course)
         return get_target_from_url(url_path_join(
             self.obfuscated_output_root, self.format_version, filename_safe_course_id, 'metadata_file.json'
         ))
@@ -110,7 +110,7 @@ class ObfuscatedPackageTask(ObfuscatedPackageTaskMixin, luigi.Task):
 
     def __init__(self, *args, **kwargs):
         super(ObfuscatedPackageTask, self).__init__(*args, **kwargs)
-        self.filename_safe_course_id = opaque_key_util.get_filename_safe_course_id(self.course)
+        self.filename_safe_course_id = get_filename_safe_course_id(self.course)
         self.course_files_url = url_path_join(
             self.obfuscated_output_root, self.format_version, self.filename_safe_course_id
         )

--- a/edx/analytics/tasks/tests/acceptance/test_database_export.py
+++ b/edx/analytics/tasks/tests/acceptance/test_database_export.py
@@ -19,7 +19,8 @@ from edx.analytics.tasks.url import url_path_join
 from edx.analytics.tasks.tests import unittest
 from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase, when_s3_available, when_exporter_available
 from edx.analytics.tasks.tests.acceptance.services import shell
-from edx.analytics.tasks.util.opaque_key_util import get_filename_safe_course_id, get_org_id_for_course
+from edx.analytics.tasks.util.opaque_key_util import get_org_id_for_course
+from edx.opaque_keys.util import get_filename_safe_course_id
 
 
 log = logging.getLogger(__name__)

--- a/edx/analytics/tasks/tests/acceptance/test_obfuscation.py
+++ b/edx/analytics/tasks/tests/acceptance/test_obfuscation.py
@@ -13,8 +13,8 @@ from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase
 from edx.analytics.tasks.pathutil import PathSetTask
 from edx.analytics.tasks.url import url_path_join, get_target_from_url
 from edx.analytics.tasks.tests.acceptance.services import fs, shell
-from edx.analytics.tasks.util.opaque_key_util import get_filename_safe_course_id
 from edx.analytics.tasks.util.file_util import copy_file_to_file
+from edx.opaque_keys.util import get_filename_safe_course_id
 
 log = logging.getLogger(__name__)
 

--- a/edx/analytics/tasks/tests/test_data_obfuscation.py
+++ b/edx/analytics/tasks/tests/test_data_obfuscation.py
@@ -19,8 +19,8 @@ from edx.analytics.tasks.tests.target import FakeTarget
 import edx.analytics.tasks.data_obfuscation as obfuscate
 from edx.analytics.tasks.url import url_path_join
 from edx.analytics.tasks.util.obfuscate_util import reset_user_info_for_testing
-from edx.analytics.tasks.util.opaque_key_util import get_filename_safe_course_id
 from edx.analytics.tasks.util.tests.test_obfuscate_util import get_mock_user_info_requirements
+from edx.opaque_keys.util import get_filename_safe_course_id
 
 
 LOG = logging.getLogger(__name__)

--- a/edx/analytics/tasks/util/opaque_key_util.py
+++ b/edx/analytics/tasks/util/opaque_key_util.py
@@ -58,23 +58,6 @@ def get_org_id_for_course(course_id):
         return None
 
 
-def get_filename_safe_course_id(course_id, replacement_char='_'):
-    """
-    Create a representation of a course_id that can be used safely in a filepath.
-    """
-    try:
-        course_key = CourseKey.from_string(course_id)
-        filename = unicode(replacement_char).join([course_key.org, course_key.course, course_key.run])
-    except InvalidKeyError:
-        # If the course_id doesn't parse, we will still return a value here.
-        filename = course_id
-
-    # The safest characters are A-Z, a-z, 0-9, <underscore>, <period> and <hyphen>.
-    # We represent the first four with \w.
-    # TODO: Once we support courses with unicode characters, we will need to revisit this.
-    return re.sub(r'[^\w\.\-]', unicode(replacement_char), filename)
-
-
 def get_course_key_from_url(url):
     """
     Extracts the course from the given `url`, if possible.

--- a/edx/analytics/tasks/util/tests/test_opaque_key_util.py
+++ b/edx/analytics/tasks/util/tests/test_opaque_key_util.py
@@ -4,7 +4,7 @@ Tests for utilities that parse event logs.
 
 from opaque_keys.edx.locator import CourseLocator
 
-import edx.analytics.tasks.util.opaque_key_util as opaque_key_util
+from edx.analytics.tasks.util import opaque_key_util
 from edx.analytics.tasks.tests import unittest
 
 
@@ -57,53 +57,6 @@ class CourseIdTest(unittest.TestCase):
     def test_get_invalid_legacy_org_id(self):
         self.assertIsNone(opaque_key_util.get_org_id_for_course(INVALID_LEGACY_COURSE_ID))
         self.assertIsNone(opaque_key_util.get_org_id_for_course(INVALID_NONASCII_LEGACY_COURSE_ID))
-
-    def test_get_filename(self):
-        self.assertEquals(opaque_key_util.get_filename_safe_course_id(VALID_COURSE_ID), "org_course_id_course_run")
-        self.assertEquals(opaque_key_util.get_filename_safe_course_id(VALID_COURSE_ID, '-'), "org-course_id-course_run")
-
-    def test_get_filename_with_colon(self):
-        course_id = unicode(CourseLocator(org='org', course='course:id', run='course:run'))
-        self.assertEquals(opaque_key_util.get_filename_safe_course_id(VALID_COURSE_ID), "org_course_id_course_run")
-        self.assertEquals(opaque_key_util.get_filename_safe_course_id(course_id, '-'), "org-course-id-course-run")
-
-    def test_get_filename_for_legacy_id(self):
-        self.assertEquals(
-            opaque_key_util.get_filename_safe_course_id(VALID_LEGACY_COURSE_ID),
-            "org_course_id_course_run"
-        )
-        self.assertEquals(
-            opaque_key_util.get_filename_safe_course_id(VALID_LEGACY_COURSE_ID, '-'),
-            "org-course_id-course_run"
-        )
-
-    def test_get_filename_for_invalid_id(self):
-        self.assertEquals(
-            opaque_key_util.get_filename_safe_course_id(INVALID_LEGACY_COURSE_ID),
-            "org_course_id_course_run"
-        )
-        self.assertEquals(
-            opaque_key_util.get_filename_safe_course_id(INVALID_LEGACY_COURSE_ID, '-'),
-            "org-course_id-course_run"
-        )
-
-    def test_get_filename_for_nonascii_id(self):
-        self.assertEquals(
-            opaque_key_util.get_filename_safe_course_id(VALID_NONASCII_LEGACY_COURSE_ID),
-            u"org_cours__id_course_run"
-        )
-        self.assertEquals(
-            opaque_key_util.get_filename_safe_course_id(VALID_NONASCII_LEGACY_COURSE_ID, '-'),
-            u"org-cours-_id-course_run"
-        )
-        self.assertEquals(
-            opaque_key_util.get_filename_safe_course_id(INVALID_NONASCII_LEGACY_COURSE_ID),
-            u"org_course__id_course_run"
-        )
-        self.assertEquals(
-            opaque_key_util.get_filename_safe_course_id(INVALID_NONASCII_LEGACY_COURSE_ID, '-'),
-            u"org-course-_id-course_run"
-        )
 
     def test_get_course_key_from_url(self):
         url = "https://courses.edx.org/courses/{course_id}/stuff".format(course_id=VALID_COURSE_ID)

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -3,7 +3,9 @@ argparse==1.2.1 	# Python Software Foundation License
 cffi==1.1.0             # MIT
 ciso8601==1.0.1         # MIT
 cryptography==0.9       # BSD or Apache 2.0
-edx-opaque-keys==0.2.1  # AGPL
+#FIXME: change to edx-opaque-keys==0.3.3  # AGPL
+-e git+https://github.com/open-craft/opaque_keys.git@66c794ece40cd762b9764916904fa0e493ef1b9f#egg=edx-opaque-keys       # AGPL
+# END FIXME
 edx-ccx-keys==0.1.2     # AGPL
 elasticsearch==1.7.0    # Apache
 enum34==1.0.4           # BSD


### PR DESCRIPTION
Lets `edx-opaque-keys v0.3.3` provide `get_filename_safe_course_id()` instead of providing it in `util.opaque_key_util`.

**Discussion**: See [edx-opaque-keys PR #74](https://github.com/edx/opaque-keys/pull/74).

**Dependencies**: [edx-opaque-keys PR #74](https://github.com/edx/opaque-keys/pull/74)

**Testing instructions**:

Covered by unit tests.

**Reviewers**
- [ ] OpenCraft reviewer TBD
- [ ] edX reviewer[s] TBD
