### PR TITLE
Make warehouse loading task in sync with pentaho.

### DIFF
--- a/edx/analytics/tasks/tests/test_vertica_load.py
+++ b/edx/analytics/tasks/tests/test_vertica_load.py
@@ -120,6 +120,7 @@ class VerticaCopyTaskTest(unittest.TestCase):
         }
 
         fake_output = MagicMock(return_value=self.mock_vertica_connector)
+        self.mock_vertica_connector.marker_schema = "name_of_marker_schema"
         self.mock_vertica_connector.marker_table = "name_of_marker_table"
 
         task.input = MagicMock(return_value=fake_input)
@@ -320,7 +321,7 @@ class VerticaCopyTaskTest(unittest.TestCase):
             call('DROP PROJECTION IF EXISTS foobar.dummy_table_projection_2;'),
             call('DELETE FROM foobar.dummy_table'),
             call("SET TIMEZONE TO 'GMT';"),
-            call("DELETE FROM foobar.name_of_marker_table where target_table='foobar.dummy_table';"),
+            call("DELETE FROM name_of_marker_schema.name_of_marker_table where target_table='foobar.dummy_table';"),
             call("SELECT PURGE_TABLE('foobar.dummy_table')"),
             call('CREATE PROJECTION IF NOT EXISTS foobar.dummy_table_projection_2 DEFINITION_2 on foobar.dummy_table;'),
             call('SELECT start_refresh();'),

--- a/edx/analytics/tasks/vertica_load.py
+++ b/edx/analytics/tasks/vertica_load.py
@@ -52,6 +52,10 @@ class VerticaCopyTaskMixin(OverwriteOutputMixin):
         'default to the schema value if the value here is None.'
     )
 
+    persistent_schema = luigi.Parameter(
+        default='experimental',
+        config_path={'section': 'vertica-export', 'name': 'persistent_schema'}
+    )
 
 class VerticaCopyTask(VerticaCopyTaskMixin, luigi.Task):
     """
@@ -348,9 +352,11 @@ class VerticaCopyTask(VerticaCopyTaskMixin, luigi.Task):
         if self.overwrite:
             # Clear the appropriate rows from the luigi Vertica marker table
             marker_table = self.output().marker_table  # side-effect: sets self.output_target if it's None
+            marker_schema = self.output().marker_schema
             try:
-                query = "DELETE FROM {schema}.{marker_table} where target_table='{schema}.{target_table}';".format(
+                query = "DELETE FROM {marker_schema}.{marker_table} where target_table='{schema}.{target_table}';".format(
                     schema=self.schema,
+                    marker_schema=marker_schema,
                     marker_table=marker_table,
                     target_table=self.table,
                 )


### PR DESCRIPTION
@mulby @brianhw this is ready for review. 

Note that I implemented some custom logic to get the latest partition from internal_reporting_user_activity table. It is similar to what we do in DataObfuscationTask currently.
I'm not sure how to DRY this, I still don't have access to edx-analytics-etl-pentaho repo(Brian mentioned that I could follow the approach for looking up most recent copy of the table from /util/Load_Vertica_From_S3.kjb)
