### PR TITLE
Hotfix enrollment and malformed course_ids

### DIFF
--- a/edx/analytics/tasks/enrollments.py
+++ b/edx/analytics/tasks/enrollments.py
@@ -529,7 +529,6 @@ class EnrollmentByModeTask(EnrollmentTask):
                 SUM(ce.at_end),
                 COUNT(ce.user_id)
             FROM course_enrollment ce
-            WHERE ce.date = '{date}'
             GROUP BY
                 ce.date,
                 ce.course_id,
@@ -564,7 +563,6 @@ class EnrollmentDailyTask(EnrollmentTask):
                 SUM(ce.at_end),
                 COUNT(ce.user_id)
             FROM course_enrollment ce
-            WHERE ce.date = '{date}'
             GROUP BY
                 ce.course_id,
                 ce.date

--- a/edx/analytics/tasks/tests/acceptance/test_enrollments.py
+++ b/edx/analytics/tasks/tests/acceptance/test_enrollments.py
@@ -106,6 +106,19 @@ class EnrollmentAcceptanceTest(AcceptanceTestCase):
             results = cursor.fetchall()
 
         expected = [
+            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 'audit', 1, 1),
+            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 'honor', 1, 2),
+            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 'verified', 1, 1),
+            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', 'audit', 0, 1),
+            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', 'honor', 1, 2),
+            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', 'verified', 1, 1),
+            (datetime.date(2014, 8, 3), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'verified', 1, 1),
+            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 'audit', 1, 1),
+            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 'honor', 1, 2),
+            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 'verified', 1, 1),
+            (datetime.date(2014, 8, 4), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'verified', 1, 1),
+            (datetime.date(2014, 8, 4), 'edX/Open_DemoX/edx_demo_course', 'honor', 1, 3),
+            (datetime.date(2014, 8, 4), 'edX/Open_DemoX/edx_demo_course', 'verified', 1, 1),
             (datetime.date(2014, 8, 5), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'honor', 1, 1),
             (datetime.date(2014, 8, 5), 'course-v1:edX+Open_DemoX+edx_demo_course2', 'verified', 1, 1),
             (datetime.date(2014, 8, 5), 'edX/Open_DemoX/edx_demo_course', 'honor', 1, 3),
@@ -119,6 +132,12 @@ class EnrollmentAcceptanceTest(AcceptanceTestCase):
             results = cursor.fetchall()
 
         self.assertItemsEqual(results, [
+            (datetime.date(2014, 8, 1), 'edX/Open_DemoX/edx_demo_course', 3, 4),
+            (datetime.date(2014, 8, 2), 'edX/Open_DemoX/edx_demo_course', 2, 4),
+            (datetime.date(2014, 8, 3), 'course-v1:edX+Open_DemoX+edx_demo_course2', 1, 1),
+            (datetime.date(2014, 8, 3), 'edX/Open_DemoX/edx_demo_course', 3, 4),
+            (datetime.date(2014, 8, 4), 'course-v1:edX+Open_DemoX+edx_demo_course2', 1, 1),
+            (datetime.date(2014, 8, 4), 'edX/Open_DemoX/edx_demo_course', 2, 4),
             (datetime.date(2014, 8, 5), 'course-v1:edX+Open_DemoX+edx_demo_course2', 2, 2),
             (datetime.date(2014, 8, 5), 'edX/Open_DemoX/edx_demo_course', 1, 4),
         ])

--- a/edx/analytics/tasks/util/opaque_key_util.py
+++ b/edx/analytics/tasks/util/opaque_key_util.py
@@ -22,6 +22,10 @@ def is_valid_course_id(course_id):
     """
     Determines if a course_id from an event log is possibly legitimate.
     """
+    if course_id and course_id[-1] == '\n':
+        log.error("Found course_id that ends with a newline character '%s'", course_id)
+        return False
+
     try:
         _course_key = CourseKey.from_string(course_id)
         return True

--- a/edx/analytics/tasks/util/tests/test_opaque_key_util.py
+++ b/edx/analytics/tasks/util/tests/test_opaque_key_util.py
@@ -128,3 +128,12 @@ class CourseIdTest(unittest.TestCase):
         url = u"https://courses.edx.org/courses/{course_id}/stuff".format(course_id=INVALID_NONASCII_LEGACY_COURSE_ID)
         course_key = opaque_key_util.get_course_key_from_url(url)
         self.assertIsNone(course_key)
+
+    def test_newline_terminated_course_id(self):
+        self.assertFalse(opaque_key_util.is_valid_course_id(VALID_COURSE_ID + '\n'))
+
+    def test_empty_course_id(self):
+        self.assertFalse(opaque_key_util.is_valid_course_id(''))
+
+    def test_just_newline_course_id(self):
+        self.assertFalse(opaque_key_util.is_valid_course_id('\n'))


### PR DESCRIPTION
The primary fix here is to reject events that contain these malformed course_ids that end with "\n" characters. Longer term we should probably clean these course_ids, but this felt like the smallest scope patch that would keep our jobs running. This will introduce a new source of error into our metrics, however, given the small number of enrollments (~200) that are affected by this issue, I think that's acceptable.

Note that enrollment on master is broken, so this patch also includes a fix for that issue.

Reviewer: @HassanJaveed84 
FYI: @adampalay @dsjen @stroilova @katymyw @brianhw 
