### PR TITLE
handle course_ids with newline characters in them

### DIFF
--- a/edx/analytics/tasks/answer_dist.py
+++ b/edx/analytics/tasks/answer_dist.py
@@ -133,7 +133,7 @@ class ProblemCheckEventMixin(object):
         event = json.loads(event_string)
 
         # Get context information:
-        course_id = event.get('context').get('course_id')
+        course_id = eventlog.get_course_id(event)
         timestamp = event.get('timestamp')
         problem_id = event.get('problem_id')
         problem_display_name = event.get('context').get('module', {}).get('display_name', None)
@@ -979,7 +979,7 @@ def get_problem_check_event(line):
     # contain the org and course name, but not the run.)  Course_id
     # information could be found from other events, but it would
     # require expanding the events being selected.
-    course_id = problem_data.get('context').get('course_id')
+    course_id = eventlog.get_course_id(event)
     if course_id is None:
         log.error("encountered explicit problem_check event with missing course_id: %s", event)
         return None

--- a/edx/analytics/tasks/course_enroll.py
+++ b/edx/analytics/tasks/course_enroll.py
@@ -331,7 +331,7 @@ def get_explicit_enrollment_output(line):
         return None
 
     # Get the course_id from the data, and validate.
-    course_id = event_data['course_id']
+    course_id = opaque_key_util.normalize_course_id(event_data['course_id'])
     if not opaque_key_util.is_valid_course_id(course_id):
         log.error("encountered explicit enrollment event with bogus course_id: %s", event)
         return None

--- a/edx/analytics/tasks/enrollment_validation.py
+++ b/edx/analytics/tasks/enrollment_validation.py
@@ -119,7 +119,7 @@ class CourseEnrollmentValidationTask(
         if event_data is None:
             return
 
-        course_id = event_data.get('course_id')
+        course_id = opaque_key_util.normalize_course_id(event_data.get('course_id'))
         if course_id is None or not opaque_key_util.is_valid_course_id(course_id):
             log.error("encountered explicit enrollment event with invalid course_id: %s", event)
             return

--- a/edx/analytics/tasks/enrollments.py
+++ b/edx/analytics/tasks/enrollments.py
@@ -51,7 +51,7 @@ class CourseEnrollmentTask(EventLogSelectionMixin, MapReduceJobTask):
         if event_data is None:
             return
 
-        course_id = event_data.get('course_id')
+        course_id = opaque_key_util.normalize_course_id(event_data.get('course_id'))
         if course_id is None or not opaque_key_util.is_valid_course_id(course_id):
             log.error("encountered explicit enrollment event with invalid course_id: %s", event)
             return

--- a/edx/analytics/tasks/lms_courseware_link_clicked.py
+++ b/edx/analytics/tasks/lms_courseware_link_clicked.py
@@ -53,13 +53,8 @@ class LMSCoursewareLinkClickedTask(EventLogSelectionMixin, MapReduceJobTask):
             log.error("encountered explicit link_clicked event with no event data: %s", event)
             return
 
-        context = event.get('context')
-        if not context:
-            log.error("encountered explicit link_clicked event with no context: %s", event)
-            return
-
-        course_id = context.get('course_id')
-        if course_id is None or not opaque_key_util.is_valid_course_id(course_id):
+        course_id = eventlog.get_course_id(event)
+        if course_id is None:
             log.error("encountered explicit link_clicked event with invalid course_id: %s", event)
             return
 

--- a/edx/analytics/tasks/load_internal_reporting_course.py
+++ b/edx/analytics/tasks/load_internal_reporting_course.py
@@ -12,7 +12,7 @@ import ciso8601
 
 from opaque_keys.edx.keys import CourseKey
 
-from edx.analytics.tasks.util.opaque_key_util import is_valid_course_id
+from edx.analytics.tasks.util.opaque_key_util import is_valid_course_id, normalize_course_id
 from edx.analytics.tasks.url import get_target_from_url
 from edx.analytics.tasks.url import url_path_join
 from edx.analytics.tasks.util.overwrite import OverwriteOutputMixin
@@ -99,7 +99,7 @@ class ProcessCourseStructureAPIData(LoadInternalReportingCourseMixin, luigi.Task
                         else:
                             cleaned_end_string = ciso8601.parse_datetime(end_string)
 
-                        course_id = course.get('id', '\N')
+                        course_id = normalize_course_id(course.get('id', '\N'))
                         if is_valid_course_id(course_id):
                             course_key = CourseKey.from_string(course_id)
                             course_run = course_key.run

--- a/edx/analytics/tasks/tests/test_lms_courseware_link_clicked.py
+++ b/edx/analytics/tasks/tests/test_lms_courseware_link_clicked.py
@@ -62,7 +62,7 @@ class LMSCoursewareLinkClickedTaskMapTest(MapperTestMixin, InitializeOpaqueKeysM
         line = self.create_event_log_line(event="")
         self.assert_no_map_output_for(line)
 
-        line = self.create_event_log_line(context="")
+        line = self.create_event_log_line(context={})
         self.assert_no_map_output_for(line)
 
         line = self.create_event_log_line(context={"course_id": ""})

--- a/edx/analytics/tasks/util/eventlog.py
+++ b/edx/analytics/tasks/util/eventlog.py
@@ -266,7 +266,7 @@ def get_course_id(event, from_url=False):
         return None
 
     # Get the course_id from the data, and validate.
-    course_id = event_context.get('course_id', '')
+    course_id = opaque_key_util.normalize_course_id(event_context.get('course_id', ''))
     if course_id:
         if opaque_key_util.is_valid_course_id(course_id):
             return course_id

--- a/edx/analytics/tasks/util/opaque_key_util.py
+++ b/edx/analytics/tasks/util/opaque_key_util.py
@@ -18,6 +18,14 @@ COURSE_ID_PATTERN = COURSE_KEY_PATTERN.replace('course_key_string', 'course_id')
 COURSE_REGEX = re.compile(r'^.*?/courses/{}'.format(COURSE_ID_PATTERN))
 
 
+def normalize_course_id(course_id):
+    """Make a best effort to rescue malformed course_ids"""
+    if course_id:
+        return course_id.strip()
+    else:
+        return course_id
+
+
 def is_valid_course_id(course_id):
     """
     Determines if a course_id from an event log is possibly legitimate.


### PR DESCRIPTION
This is one of those moments when I wish I had a canonicalization stage implemented :frowning: 

I searched for places in the code where we were calling `opaque_key_util.is_valid_course_id()` and introduced this normalization before it. I'm not 100% confident this will cover all cases where we parse course_ids from events, but it will certainly cover most of them. Let me know if you think of any others or another approach we could use to find others.

My plan is to:
1. Baseline the number of occurrences of this error message: https://github.com/edx/edx-analytics-pipeline/blob/master/edx/analytics/tasks/util/opaque_key_util.py#L26 when running the enrollment workflow.
2. Apply this patch and run it in stage.
3. Check the occurrences of that message on the fixed run - it should drop to zero.
4. Deploy the fix to prod.
5. Download logs for each production job after the fix and see they contain that error message.

Reviewer: @HassanJaveed84 @adampalay 
FYI: @adampalay @dsjen @stroilova @katymyw @brianhw
