### PR TITLE
Include the ccx_keys package when launching tasks

### DIFF
--- a/config/devstack.cfg
+++ b/config/devstack.cfg
@@ -84,3 +84,6 @@ host = http://172.17.0.1:9201/
 [module-engagement]
 alias = roster
 number_of_shards = 5
+
+[ccx]
+enabled = false

--- a/config/test.cfg
+++ b/config/test.cfg
@@ -126,3 +126,6 @@ number_of_shards = 5
 [course-catalog-api]
 partner_short_codes = openedx
 api_root_url = http://example.com/api/v1/
+
+[ccx]
+enabled = false

--- a/edx/analytics/tasks/launchers/local.py
+++ b/edx/analytics/tasks/launchers/local.py
@@ -56,8 +56,13 @@ def main():
     # - cjson is used for all parsing event logs.
     # - filechunkio is used for multipart uploads of large files to s3.
     # - opaque_keys is used to interpret serialized course_ids
+    #   - opaque_keys extensions:  ccx_keys
     #   - dependencies of opaque_keys:  bson, stevedore
     luigi.hadoop.attach(boto, cjson, filechunkio, opaque_keys, bson, stevedore, ciso8601, requests)
+
+    if configuration.getboolean('ccx', 'enabled', default=False):
+        import ccx_keys
+        luigi.hadoop.attach(ccx_keys)
 
     # TODO: setup logging for tasks or configured logging mechanism
 


### PR DESCRIPTION
Closes https://openedx.atlassian.net/browse/AN-5666.

This adds ccx_keys to the list of modules that are included in tarballs whenever the HadoopTaskRunner-based mapreduce engine is used. This is necessary for any CCX course event logs to be processed by any mapreduce tasks.
### Testing instructions:
1. Setup an analytics devstack: https://github.com/edx/edx-documentation/blob/813c5cd23034ac0fc171f7f9b6ab70051b0b5eac/en_us/install_operations/source/installation/analytics/install_analytics.rst#installing-analytics-devstack
2. Checkout this branch: `git checkout bdero/ccx-keys`
3. Create a CCX and add enroll a user in it from within edX: http://edx.readthedocs.io/projects/open-edx-ca/en/latest/set_up_course/custom_courses.html
4. Run the ImportEnrollmentsIntoMysql:
   
   ``` bash
   remote-task --host localhost --user hadoop --remote-name analyticstack --skip-setup --wait ImportEnrollmentsIntoMysql --interval 2016 --local-scheduler
   ```
5. Check the course_enrollment_daily report table to observe that enrollment information for the CCX is in the table (the password for user `read_only` is `password`): 
   
   ``` bash
   echo "select id, course_id, created from reports.course_enrollment_daily group by course_id;" | mysql -u read_only -p
   ```
