### PR TITLE
Revert "PR review: updates module engagement acceptance tests to add new fields"

### DIFF
--- a/edx/analytics/tasks/tests/acceptance/fixtures/input/load_auth_userprofile.sql
+++ b/edx/analytics/tasks/tests/acceptance/fixtures/input/load_auth_userprofile.sql
@@ -1,6 +1,6 @@
 CREATE TABLE `auth_userprofile` ( `id` int(11) NOT NULL, `user_id` int(11) NOT NULL, `name` varchar(255) NOT NULL, `language` varchar(255) NOT NULL, `location` varchar(255) NOT NULL, `meta` longtext NOT NULL, `courseware` varchar(255) NOT NULL, `gender` varchar(6), `mailing_address` longtext, `year_of_birth` int(11), `level_of_education` varchar(6), `goals` longtext, `allow_certificate` tinyint(1) NOT NULL, `country` varchar(2), `city` longtext, PRIMARY KEY (`id`), UNIQUE KEY `user_id` (`user_id`) );
 
-INSERT INTO `auth_userprofile` (`id`,`user_id`,`name`,`language`,`location`,`meta`,`courseware`,`gender`,`mailing_address`,`year_of_birth`,`level_of_education`,`goals`,`allow_certificate`,`country`,`city`) VALUES (1,1,'honor','es-ES','Europe','','course.xml','m','Luna, 10 - 3, 28300 ARANJUEZ',1984,'a','Me encanta aprender.',1,'ES', 'Madrid');
+INSERT INTO `auth_userprofile` VALUES (1,1,'honor','','','','course.xml','m',NULL,1984,'a',NULL,1,'',NULL);
 INSERT INTO `auth_userprofile` VALUES (2,2,'audit','','','','course.xml','m',NULL,1975,'b',NULL,1,'',NULL);
 INSERT INTO `auth_userprofile` VALUES (3,3,'verified','','','','course.xml','',NULL,2000,'b',NULL,1,'',NULL);
 INSERT INTO `auth_userprofile` VALUES (4,4,'staff','','','','course.xml',NULL,NULL,2000,'',NULL,1,'',NULL);

--- a/edx/analytics/tasks/tests/acceptance/test_module_engagement.py
+++ b/edx/analytics/tasks/tests/acceptance/test_module_engagement.py
@@ -77,12 +77,6 @@ class ModuleEngagementAcceptanceTest(AcceptanceTestCase):
                 'segments': [''],
                 'start_date': '2015-04-10',
                 'username': 'staff',
-                'user_id': 4,
-                'location': '',
-                'language': '',
-                'year_of_birth': 2000,
-                'country': '',
-                'level_of_education': '',
                 'videos_viewed': 1
             },
             {
@@ -102,16 +96,6 @@ class ModuleEngagementAcceptanceTest(AcceptanceTestCase):
                 'segments': [''],
                 'start_date': u'2015-04-10',
                 'username': u'honor',
-                'user_id': 1,
-                'location': 'Europe',
-                'language': 'es-ES',
-                'year_of_birth': 1984,
-                'gender': 'm',
-                'goals': 'Me encanta aprender.',
-                'level_of_education': 'a',
-                'mailing_address': 'Luna, 10 - 3, 28300 ARANJUEZ',
-                'city': 'Madrid',
-                'country': 'ES',
                 'videos_viewed': 2
             },
             {
@@ -130,16 +114,6 @@ class ModuleEngagementAcceptanceTest(AcceptanceTestCase):
                 'segments': [u'highly_engaged'],
                 'start_date': u'2015-04-10',
                 'username': u'honor',
-                'user_id': 1,
-                'location': 'Europe',
-                'language': 'es-ES',
-                'year_of_birth': 1984,
-                'gender': 'm',
-                'goals': 'Me encanta aprender.',
-                'level_of_education': 'a',
-                'mailing_address': 'Luna, 10 - 3, 28300 ARANJUEZ',
-                'city': 'Madrid',
-                'country': 'ES',
                 'videos_viewed': 1
             },
             {
@@ -158,16 +132,6 @@ class ModuleEngagementAcceptanceTest(AcceptanceTestCase):
                 'segments': [''],
                 'start_date': u'2015-04-10',
                 'username': u'honor',
-                'user_id': 1,
-                'location': 'Europe',
-                'language': 'es-ES',
-                'year_of_birth': 1984,
-                'gender': 'm',
-                'goals': 'Me encanta aprender.',
-                'level_of_education': 'a',
-                'mailing_address': 'Luna, 10 - 3, 28300 ARANJUEZ',
-                'city': 'Madrid',
-                'country': 'ES',
                 'videos_viewed': 1
             },
         ]


### PR DESCRIPTION
This reverts commit bf5743df468109c9d3a31eaedeb4c05ea370711f.

@pomegranited - I discovered in our production data that some of these fields contain separator characters ("\t" or "\n"). I've been thinking a bit about what to do in such scenarios, considering the following options:
1. We use different separator characters and tell Hive about it (Hive uses 0x01 as the field separator by default... we could do the same and we do for our sqoop exports).
2. We make record "smarter", having it escape separator characters it finds in the data that is being stored in fields (and subsequently unescapes it when it reads it back). The downside of this approach is that Hive processing will see escaped data.

In theory we could use both approaches. I'm also open to other ideas. @brianhw - do you have an opinion about this?

Short term, I'm going to revert this so that it doesn't block the release and we should open a new PR to merge this in once this issue is fixed.
