### PR TITLE
Create a summarized enrollment table

### DIFF
--- a/edx/analytics/tasks/load_warehouse.py
+++ b/edx/analytics/tasks/load_warehouse.py
@@ -9,7 +9,7 @@ from edx.analytics.tasks.load_internal_reporting_country import LoadInternalRepo
 from edx.analytics.tasks.load_internal_reporting_course import LoadInternalReportingCourseToWarehouse
 from edx.analytics.tasks.load_internal_reporting_course_catalog import LoadInternalReportingProgramCourseToWarehouse
 from edx.analytics.tasks.load_internal_reporting_user_activity import LoadInternalReportingUserActivityToWarehouse
-from edx.analytics.tasks.load_internal_reporting_user_course import BuildUserCourseView
+from edx.analytics.tasks.load_internal_reporting_user_course import BuildUserCourseView, LoadUserCourseSummary
 from edx.analytics.tasks.load_internal_reporting_user import LoadInternalReportingUserToWarehouse
 from edx.analytics.tasks.course_catalog import DailyLoadSubjectsToVerticaTask
 from edx.analytics.tasks.vertica_load import VerticaCopyTaskMixin, CredentialFileVerticaTarget
@@ -203,7 +203,11 @@ class LoadWarehouseTask(WarehouseWorkflowMixin, luigi.WrapperTask):
                 **kwargs
             ),
             BuildUserCourseView(
-                 **kwargs
+                **kwargs
+            ),
+            LoadUserCourseSummary(
+                date=self.date,
+                **kwargs
             ),
             LoadInternalReportingUserActivityToWarehouse(
                 date=self.date,

--- a/edx/analytics/tasks/tests/acceptance/fixtures/output/acceptance_expected_d_user_course.csv
+++ b/edx/analytics/tasks/tests/acceptance/fixtures/output/acceptance_expected_d_user_course.csv
@@ -1,0 +1,7 @@
+course_id,user_id,current_enrollment_mode,current_enrollment_is_active,first_enrollment_mode,first_enrollment_time,last_unenrollment_time,first_verified_enrollment_time,first_credit_enrollment_time,end_time
+edX/Open_DemoX/edx_demo_course,1,honor,0,honor,2014-08-01 17:09:59.941616,2014-08-01 18:34:05.474003,,,2014-08-06 00:00:00.000000
+course-v1:edX+Open_DemoX+edx_demo_course2,1,honor,1,honor,2014-08-05 18:34:05.474003,,,,2014-08-06 00:00:00.000000
+edX/Open_DemoX/edx_demo_course,2,audit,0,audit,2014-08-01 17:10:04.587707,2014-08-04 18:34:05.474003,,,2014-08-06 00:00:00.000000
+course-v1:edX+Open_DemoX+edx_demo_course2,2,verified,1,verified,2014-08-03 18:34:05.474003,,2014-08-03 18:34:05.474003,,2014-08-06 00:00:00.000000
+edX/Open_DemoX/edx_demo_course,3,verified,0,verified,2014-08-01 17:10:07.989504,2014-08-05 18:34:05.474003,2014-08-01 17:10:07.989504,,2014-08-06 00:00:00.000000
+edX/Open_DemoX/edx_demo_course,4,honor,1,honor,2014-08-01 17:10:11.440312,,,,2014-08-06 00:00:00.000000


### PR DESCRIPTION
Generate a smaller version of the `course_enrollment` model that just includes summary information for each user in each course.

Todo:
- [x] Acceptance Test
- [x] Pep8/Pylint
- [x] Docstrings

Reviewers: @HassanJaveed84 @brianhw 
