### PR TITLE
Add columns to certificate table export.

### DIFF
--- a/edx/analytics/tasks/database_imports.py
+++ b/edx/analytics/tasks/database_imports.py
@@ -852,6 +852,8 @@ class ImportGeneratedCertificatesTask(ImportMysqlToHiveTableTask):
             ('grade', 'STRING'),
             ('status', 'STRING'),
             ('mode', 'STRING'),
+            ('created_date', 'TIMESTAMP'),
+            ('modified_date', 'TIMESTAMP'),
         ]
 
 

--- a/edx/analytics/tasks/load_internal_reporting_certificates.py
+++ b/edx/analytics/tasks/load_internal_reporting_certificates.py
@@ -30,8 +30,11 @@ class LoadInternalReportingCertificatesTableHive(HiveTableFromQueryTask):
             ('user_id', 'INT'),
             ('course_id', 'STRING'),
             ('is_certified', 'INT'),
-            ('enrollment_mode', 'STRING'),
+            ('certificate_mode', 'STRING'),
             ('final_grade', 'STRING'),
+            ('has_passed', 'INT'),
+            ('created_date', 'TIMESTAMP'),
+            ('modified_date', 'TIMESTAMP'),
         ]
 
     @property
@@ -45,8 +48,11 @@ class LoadInternalReportingCertificatesTableHive(HiveTableFromQueryTask):
               user_id
             , course_id
             , if(status='downloadable', 1, 0) as is_certified
-            , mode as enrollment_mode
+            , mode as certificate_mode
             , grade as final_grade
+            , if(status='downloadable' OR status='audit_passing', 1, 0) as has_passed
+            , created_date
+            , modified_date
             FROM certificates_generatedcertificate
             """
 
@@ -78,8 +84,11 @@ class LoadInternalReportingCertificatesToWarehouse(WarehouseMixin, VerticaCopyTa
             ('user_id', 'INTEGER NOT NULL'),
             ('course_id', 'VARCHAR(255) NOT NULL'),
             ('is_certified', 'INTEGER'),
-            ('enrollment_mode', 'VARCHAR(200)'),
-            ('final_grade', 'VARCHAR(5)')
+            ('certificate_mode', 'VARCHAR(200)'),
+            ('final_grade', 'VARCHAR(5)'),
+            ('has_passed', 'INTEGER'),
+            ('created_date', 'TIMESTAMP'),
+            ('modified_date', 'TIMESTAMP'),
         ]
 
     @property

--- a/edx/analytics/tasks/tests/acceptance/fixtures/output/acceptance_expected_d_user_course_certificate.csv
+++ b/edx/analytics/tasks/tests/acceptance/fixtures/output/acceptance_expected_d_user_course_certificate.csv
@@ -1,5 +1,5 @@
-user_id,course_id,is_certified,enrollment_mode,final_grade
-1,course-v1:edX+DemoX+Demo_Course,1,honor,0.27
-2,course-v1:edX+DemoX+Demo_Course,1,honor,0.58
-3,course-v1:edX+DemoX+Demo_Course,0,honor,0.0
-4,course-v1:edX+DemoX+Demo_Course,0,honor,0.0
+user_id,course_id,is_certified,certificate_mode,final_grade,has_passed,created_date,modified_date
+1,course-v1:edX+DemoX+Demo_Course,1,honor,0.27,1,2012-11-09 23:13:21,2012-11-10 00:10:14
+2,course-v1:edX+DemoX+Demo_Course,1,honor,0.58,1,2012-11-09 23:31:34,2012-11-10 00:05:46
+3,course-v1:edX+DemoX+Demo_Course,0,honor,0.0,0,2012-11-10 00:12:10,2012-11-26 19:03:01
+4,course-v1:edX+DemoX+Demo_Course,0,honor,0.0,0,2012-11-10 00:12:10,2012-11-26 19:00:59

--- a/edx/analytics/tasks/tests/acceptance/test_internal_reporting_certificate.py
+++ b/edx/analytics/tasks/tests/acceptance/test_internal_reporting_certificate.py
@@ -43,7 +43,10 @@ class InternalReportingCertificateLoadAcceptanceTest(AcceptanceTestCase):
 
             cursor.execute("SELECT * FROM {schema}.d_user_course_certificate".format(schema=self.vertica.schema_name))
             response = cursor.fetchall()
-            d_user_course_certificate = pandas.DataFrame(response, columns=['user_id', 'course_id', 'is_certified', 'enrollment_mode', 'final_grade'])
+            d_user_course_certificate = pandas.DataFrame(response, columns=[
+                'user_id', 'course_id', 'is_certified', 'certificate_mode',
+                'final_grade', 'has_passed', 'created_date', 'modified_date',
+            ])
 
             try:  # A ValueError will be thrown if the column names don't match or the two data frames are not square.
                 self.assertTrue(all(d_user_course_certificate == expected))


### PR DESCRIPTION
This PR: 
- Adds created_date and modified_date to the data pulled from certificates_generatedcertificates.  
- Renames enrollment_mode to certificate_mode
- Calculates a new 'has_passed' column based on status (either 'downloadable' or 'audit_passing').

Addresses AN-7615. 
