### PR TITLE
Adds new Field classes to edx.analytics.pipeline.util.records

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ Dylan Rhodes <dylanr@stanford.edu>
 James Rowan <jrowan@mit.edu>
 Dmitry Viskov <dmitry.viskov@webenterprise.ru>
 Sanford Student <sstudent@edx.org>
+Jillian Vogel <jill@opencraft.com>


### PR DESCRIPTION
Adds:
- `DelimitedStringField`: stores a list of strings
- `BooleanField`: nullable field to store True and False
- `DateTimeField`: contains a UTC date and time.
- Also extends the base `Field` class to support an `elasticsearch_format` property.

Partner information: 3rd party-hosted open edX instance

**Discussions**: See PR #274 for the code review and discussion of these changes.  I've pulled them into a separate PR at [Gabe's request to allow them to be merged immediately](https://github.com/edx/edx-analytics-pipeline/pull/274#issuecomment-250594161).

**Reviewers**
- [x] @haikuginger - reviewed this code in PR #274
- [x] @mulby 
