### PR TITLE
AN-7880 UserActivityTask: process new forum event_types

### DIFF
--- a/edx/analytics/tasks/tests/test_user_activity.py
+++ b/edx/analytics/tasks/tests/test_user_activity.py
@@ -119,6 +119,27 @@ class UserActivityTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMixin, unitte
                     ((self.course_id, self.username, self.expected_date_string, POST_FORUM_LABEL), 1))
         self.assertEquals(event, expected)
 
+    def test_forum_response_event(self):
+        line = self.create_event_log_line(event_source='server', event_type='edx.forum.response.created')
+        event = tuple(self.task.mapper(line))
+        expected = (((self.course_id, self.username, self.expected_date_string, ACTIVE_LABEL), 1),
+                    ((self.course_id, self.username, self.expected_date_string, POST_FORUM_LABEL), 1))
+        self.assertEquals(event, expected)
+
+    def test_forum_comment_event(self):
+        line = self.create_event_log_line(event_source='server', event_type='edx.forum.comment.created')
+        event = tuple(self.task.mapper(line))
+        expected = (((self.course_id, self.username, self.expected_date_string, ACTIVE_LABEL), 1),
+                    ((self.course_id, self.username, self.expected_date_string, POST_FORUM_LABEL), 1))
+        self.assertEquals(event, expected)
+
+    def test_forum_vote_event(self):
+	# The voted event is not a "discussion activity" and thus does not get the POST_FORUM_LABEL
+        line = self.create_event_log_line(event_source='server', event_type='edx.forum.thread.voted')
+        event = tuple(self.task.mapper(line))
+        expected = (((self.course_id, self.username, self.expected_date_string, ACTIVE_LABEL), 1),)
+        self.assertEquals(event, expected)
+
     def test_exclusion_of_events_by_source(self):
         line = self.create_event_log_line(event_source='task')
         self.assert_no_map_output_for(line)

--- a/edx/analytics/tasks/tests/test_user_activity.py
+++ b/edx/analytics/tasks/tests/test_user_activity.py
@@ -113,7 +113,7 @@ class UserActivityTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMixin, unitte
         self.assertEquals(event, expected)
 
     def test_post_forum_event(self):
-        line = self.create_event_log_line(event_source='server', event_type='blah/blah/threads/create')
+        line = self.create_event_log_line(event_source='server', event_type='edx.forum.thread.created')
         event = tuple(self.task.mapper(line))
         expected = (((self.course_id, self.username, self.expected_date_string, ACTIVE_LABEL), 1),
                     ((self.course_id, self.username, self.expected_date_string, POST_FORUM_LABEL), 1))

--- a/edx/analytics/tasks/user_activity.py
+++ b/edx/analytics/tasks/user_activity.py
@@ -22,9 +22,6 @@ PROBLEM_LABEL = "ATTEMPTED_PROBLEM"
 PLAY_VIDEO_LABEL = "PLAYED_VIDEO"
 POST_FORUM_LABEL = "POSTED_FORUM"
 
-DISCUSSION_ACTIVITIES = ['edx.forum.thread.created', 'edx.forum.thread.voted', 'edx.forum.response.created',
-                         'edx.forum.comment.created']
-
 
 class UserActivityTask(EventLogSelectionMixin, MapReduceJobTask):
     """
@@ -81,7 +78,7 @@ class UserActivityTask(EventLogSelectionMixin, MapReduceJobTask):
             if event_type == 'problem_check':
                 labels.append(PROBLEM_LABEL)
 
-            if event_type in DISCUSSION_ACTIVITIES:
+            if event_type.startswith('edx.forum.') and event_type.endswith('.created'):
                 labels.append(POST_FORUM_LABEL)
 
         if event_source in ('browser', 'mobile'):

--- a/edx/analytics/tasks/user_activity.py
+++ b/edx/analytics/tasks/user_activity.py
@@ -22,6 +22,9 @@ PROBLEM_LABEL = "ATTEMPTED_PROBLEM"
 PLAY_VIDEO_LABEL = "PLAYED_VIDEO"
 POST_FORUM_LABEL = "POSTED_FORUM"
 
+DISCUSSION_ACTIVITIES = ['edx.forum.thread.created', 'edx.forum.thread.voted', 'edx.forum.response.created',
+                         'edx.forum.comment.created']
+
 
 class UserActivityTask(EventLogSelectionMixin, MapReduceJobTask):
     """
@@ -78,7 +81,7 @@ class UserActivityTask(EventLogSelectionMixin, MapReduceJobTask):
             if event_type == 'problem_check':
                 labels.append(PROBLEM_LABEL)
 
-            if event_type.endswith("threads/create"):
+            if event_type in DISCUSSION_ACTIVITIES:
                 labels.append(POST_FORUM_LABEL)
 
         if event_source in ('browser', 'mobile'):


### PR DESCRIPTION
This will enable processing forum events in the weekly course activity task. I tested this locally with some (slightly modified) [example forum events from student_forum_activity.log](https://github.com/edx/edx-analytics-pipeline/blob/master/edx/analytics/tasks/tests/acceptance/fixtures/input/student_forum_activity.log) in my tracking.log.

Some things I wasn't able to confirm:
- If these event_types are really what the forums emits now (I can't get forums working on my devstack)
- ~~If I'm missing or including and event I shouldn't in DISCUSSION_ACTIVITIES. It depends on how we want to define what a "discussion activity" is.~~ Nevermind, I talked to Katy and now I'm copying what the learner roster considers "discussion activity"
