### PR TITLE
Remove "NOT NULL" constraint on country_code.

### DIFF
--- a/edx/analytics/tasks/location_per_course.py
+++ b/edx/analytics/tasks/location_per_course.py
@@ -347,7 +347,7 @@ class InsertToMysqlCourseEnrollByCountryTaskBase(MysqlInsertTask):  # pylint: di
         return [
             ('date', 'DATE NOT NULL'),
             ('course_id', 'VARCHAR(255) NOT NULL'),
-            ('country_code', 'VARCHAR(10) NOT NULL'),
+            ('country_code', 'VARCHAR(10)'),
             ('count', 'INT(11) NOT NULL'),
             ('cumulative_count', 'INT(11) NOT NULL'),
         ]

--- a/edx/analytics/tasks/tests/acceptance/test_location_per_course.py
+++ b/edx/analytics/tasks/tests/acceptance/test_location_per_course.py
@@ -48,7 +48,7 @@ class LocationByCourseAcceptanceTest(AcceptanceTestCase):
         self.assertItemsEqual([
             row[1:6] for row in results
         ], [
-            (today, self.COURSE_ID, '', 1, 1),
+            (today, self.COURSE_ID, None, 1, 1),
             (today, self.COURSE_ID, 'UNKNOWN', 0, 1),
             (today, self.COURSE_ID, 'IE', 1, 1),
             (today, self.COURSE_ID2, 'TH', 1, 1),


### PR DESCRIPTION
We were seeing that '\N' values in a Hive table was being written incorrectly as zero-length strings in Mysql when run in production and on our acceptance test server, but being written as NULL and failing the constraint when run in acceptance tests on analyticstack.  Removing the constraint apparently results in NULLs being written instead of zero-length strings on both production and analyticstack.  

@mulby @HassanJaveed84 