### PR TITLE
Ability to handle multiple tag values

### DIFF
--- a/edx/analytics/tasks/insights/tags_dist.py
+++ b/edx/analytics/tasks/insights/tags_dist.py
@@ -110,14 +110,16 @@ class TagsDistributionPerCourse(
             return
         else:
             for tag_key, tag_val in latest_tags.iteritems():
-                yield TagsDistributionRecord(
-                    course_id=course_id,
-                    org_id=org_id,
-                    module_id=problem_id,
-                    tag_name=tag_key,
-                    tag_value=tag_val,
-                    total_submissions=num_total,
-                    correct_submissions=num_correct).to_string_tuple()
+                tag_val_lst = [tag_val] if isinstance(tag_val, basestring) else tag_val
+                for val in tag_val_lst:
+                    yield TagsDistributionRecord(
+                        course_id=course_id,
+                        org_id=org_id,
+                        module_id=problem_id,
+                        tag_name=tag_key,
+                        tag_value=val,
+                        total_submissions=num_total,
+                        correct_submissions=num_correct).to_string_tuple()
 
 
 class TagsDistributionRecord(Record):

--- a/edx/analytics/tasks/insights/tests/test_tags_dist.py
+++ b/edx/analytics/tasks/insights/tests/test_tags_dist.py
@@ -211,3 +211,20 @@ class TagsDistributionPerCourseReducerTest(ReducerTestMixin, TestCase):
                   ('2013-01-01T00:00:02', {'difficulty': 'Hard',
                                            'learning_outcome': 'Learned nothing'}, 1), ]
         self._check_output_complete_tuple(inputs, ())
+
+    def test_multiple_tag_values(self):
+        multiple_tag_values = {
+            'learning_outcome_1': ['Research as Inquiry', 'Authority is Constructed and Contextual'],
+            'learning_outcome_2': ['Research as Inquiry', 'Scholarship as Conversation'],
+        }
+        inputs = [('2013-01-01T00:00:0{sec}'.format(sec=k), multiple_tag_values,
+                   1 if k != 1 else 0) for k in xrange(4)]
+        expected = ((self.course_id, self.org_id, self.problem_id, 'learning_outcome_1',
+                     'Research as Inquiry', '4', '3'),
+                    (self.course_id, self.org_id, self.problem_id, 'learning_outcome_1',
+                     'Authority is Constructed and Contextual', '4', '3'),
+                    (self.course_id, self.org_id, self.problem_id, 'learning_outcome_2',
+                     'Research as Inquiry', '4', '3'),
+                    (self.course_id, self.org_id, self.problem_id, 'learning_outcome_2',
+                     'Scholarship as Conversation', '4', '3'))
+        self._check_output_complete_tuple(inputs, expected)


### PR DESCRIPTION
It is a little fix that allow to handle multiple tag values for each tag.
This task related to https://github.com/edx/edx-platform/pull/13899 but in analytics-pipeline could be implemented separately.

@mulby please take a look