### PR TITLE
Incremental calculation of user's location

### DIFF
--- a/config/test.cfg
+++ b/config/test.cfg
@@ -58,6 +58,10 @@ output_root = s3://fake/activity/
 interval_start = 2013-11-01
 overwrite_n_days = 14
 
+[location-per-course]
+interval_start = 2013-11-01
+overwrite_n_days = 14
+
 [enrollment-reports]
 src = s3://fake/input/
 destination = s3://fake/enrollment_reports/output/

--- a/edx/analytics/tasks/events_obfuscation.py
+++ b/edx/analytics/tasks/events_obfuscation.py
@@ -337,9 +337,7 @@ class ObfuscateCourseEventsTask(ObfuscatorMixin, GeolocationMixin, MultiOutputMa
         ip_address = event.get('ip')
         # Skip over IPv6-format ip_address values for now.
         if ip_address and ':' not in ip_address:
-            country_code = self.geoip.country_code_by_addr(ip_address)
-            if country_code is None or len(country_code.strip()) <= 0:
-                country_code = "UNKNOWN"
+            country_code = self.get_country_code(ip_address)
             event.update({'augmented': {'country_code': country_code}})
 
         # Delete base properties other than username.

--- a/edx/analytics/tasks/load_internal_reporting_country.py
+++ b/edx/analytics/tasks/load_internal_reporting_country.py
@@ -9,7 +9,7 @@ from edx.analytics.tasks.vertica_load import VerticaCopyTask
 from edx.analytics.tasks.util.hive import HiveTableFromQueryTask, WarehouseMixin, HivePartition
 from edx.analytics.tasks.url import url_path_join, ExternalURL
 from edx.analytics.tasks.location_per_course import (
-    LastCountryOfUserMixin,
+    LastCountryOfUserDownstreamMixin,
     QueryLastCountryPerCourseMixin,
     ImportLastCountryOfUserToHiveTask,
     InsertToMysqlCourseEnrollByCountryWorkflow,
@@ -18,7 +18,7 @@ from edx.analytics.tasks.location_per_course import (
 log = logging.getLogger(__name__)
 
 
-class LoadInternalReportingCountryTableHive(LastCountryOfUserMixin, HiveTableFromQueryTask):
+class LoadInternalReportingCountryTableHive(LastCountryOfUserDownstreamMixin, HiveTableFromQueryTask):
     """Loads internal_reporting_d_country Hive table from last_country_of_user Hive table."""
 
     def requires(self):
@@ -26,8 +26,11 @@ class LoadInternalReportingCountryTableHive(LastCountryOfUserMixin, HiveTableFro
             mapreduce_engine=self.mapreduce_engine,
             n_reduce_tasks=self.n_reduce_tasks,
             source=self.source,
-            interval=self.interval,
             pattern=self.pattern,
+            interval=self.interval,
+            interval_start=self.interval_start,
+            interval_end=self.interval_end,
+            overwrite_n_days=self.overwrite_n_days,
             geolocation_data=self.geolocation_data,
             overwrite=self.overwrite,
         )
@@ -58,7 +61,7 @@ class LoadInternalReportingCountryTableHive(LastCountryOfUserMixin, HiveTableFro
             """
 
 
-class ImportCountryWorkflow(QueryLastCountryPerCourseMixin, LastCountryOfUserMixin, luigi.WrapperTask):
+class ImportCountryWorkflow(QueryLastCountryPerCourseMixin, LastCountryOfUserDownstreamMixin, luigi.WrapperTask):
 
     def requires(self):
         yield (
@@ -66,8 +69,11 @@ class ImportCountryWorkflow(QueryLastCountryPerCourseMixin, LastCountryOfUserMix
                 mapreduce_engine=self.mapreduce_engine,
                 n_reduce_tasks=self.n_reduce_tasks,
                 source=self.source,
-                interval=self.interval,
                 pattern=self.pattern,
+                interval=self.interval,
+                interval_start=self.interval_start,
+                interval_end=self.interval_end,
+                overwrite_n_days=self.overwrite_n_days,
                 geolocation_data=self.geolocation_data,
                 overwrite=self.overwrite,
             ),
@@ -75,8 +81,11 @@ class ImportCountryWorkflow(QueryLastCountryPerCourseMixin, LastCountryOfUserMix
                 mapreduce_engine=self.mapreduce_engine,
                 n_reduce_tasks=self.n_reduce_tasks,
                 source=self.source,
-                interval=self.interval,
                 pattern=self.pattern,
+                interval=self.interval,
+                interval_start=self.interval_start,
+                interval_end=self.interval_end,
+                overwrite_n_days=self.overwrite_n_days,
                 geolocation_data=self.geolocation_data,
                 overwrite=self.overwrite,
                 course_country_output=self.course_country_output,

--- a/edx/analytics/tasks/util/tests/test_geolocation.py
+++ b/edx/analytics/tasks/util/tests/test_geolocation.py
@@ -1,6 +1,15 @@
 """
-Test object for geolocation tests.
+Tests and test object for geolocation tests.
 """
+
+from mock import Mock
+
+from edx.analytics.tasks.tests import unittest
+from edx.analytics.tasks.util.geolocation import (
+    UNKNOWN_COUNTRY,
+    UNKNOWN_CODE,
+    GeolocationMixin,
+)
 
 
 class FakeGeoLocation(object):
@@ -28,3 +37,49 @@ class FakeGeoLocation(object):
             self.ip_address_2: self.country_code_2,
         }
         return country_code_map.get(ip_address)
+
+
+class TestGeolocationTaskTestCase(unittest.TestCase):
+    """Test GeolocationMixin.get_country_xxx() methods."""
+
+    def setUp(self):
+        self.task = GeolocationMixin()
+        self.task.geoip = FakeGeoLocation()
+
+    def test_country_name(self):
+        name = self.task.get_country_name(FakeGeoLocation.ip_address_1)
+        self.assertEquals(name, FakeGeoLocation.country_name_1)
+
+    def test_country_code(self):
+        code = self.task.get_country_code(FakeGeoLocation.ip_address_1)
+        self.assertEquals(code, FakeGeoLocation.country_code_1)
+
+    def test_country_name_exception(self):
+        self.task.geoip.country_name_by_addr = Mock(side_effect=Exception)
+        name = self.task.get_country_name(FakeGeoLocation.ip_address_1)
+        self.assertEquals(name, UNKNOWN_COUNTRY)
+
+    def test_country_code_exception(self):
+        self.task.geoip.country_code_by_addr = Mock(side_effect=Exception)
+        code = self.task.get_country_code(FakeGeoLocation.ip_address_1)
+        self.assertEquals(code, UNKNOWN_CODE)
+
+    def test_missing_country_name(self):
+        self.task.geoip.country_name_by_addr = Mock(return_value=None)
+        name = self.task.get_country_name(FakeGeoLocation.ip_address_1)
+        self.assertEquals(name, UNKNOWN_COUNTRY)
+
+    def test_missing_country_code(self):
+        self.task.geoip.country_code_by_addr = Mock(return_value=None)
+        code = self.task.get_country_code(FakeGeoLocation.ip_address_1)
+        self.assertEquals(code, UNKNOWN_CODE)
+
+    def test_empty_country_name(self):
+        self.task.geoip.country_name_by_addr = Mock(return_value="  ")
+        name = self.task.get_country_name(FakeGeoLocation.ip_address_1)
+        self.assertEquals(name, UNKNOWN_COUNTRY)
+
+    def test_empty_country_code(self):
+        self.task.geoip.country_code_by_addr = Mock(return_value="  ")
+        code = self.task.get_country_code(FakeGeoLocation.ip_address_1)
+        self.assertEquals(code, UNKNOWN_CODE)


### PR DESCRIPTION
This moves calculation of user location into an incremental framework.  

The first part is to first calculate historical data that stores each user's IP address on the last interaction with a course on a particular day. 

LastDailyIpAddressOfUserTask --local-scheduler \
  --interval $(date +%Y-%m-%d -d "$FROM_DATE")-$(date +%Y-%m-%d -d "$TO_DATE") \
  --n-reduce-tasks $NUM_REDUCE_TASKS \
  --warehouse-path s3://edx-analytics-scratch/brian/test-incremental-location

Calculations of location per user and location counts per course are calculated with the same entry points as before (e.g. InsertToMysqlCourseEnrollByCountryWorkflow), with the addition of an --overwrite-n-days parameter that specifies the number of days for which to recalculate LastDailyIpAddressOfUserTask before doing the rest of the aggregations.

Changes mainly involve the splitting out the LastDailyIpAddressOfUserTask functionality from  LastCountryOfUser so that it can be calculated incrementally.  LastCountryOfUser continues to find the last IP address for each user independent of the course, but the course_id is in the historical data for when we want to change this.

Additional work was done to encapsulate geolocation functionality more completely into GeolocationMixin.  