### PR TITLE
Close Vertica connection if the connection is not passed.

### DIFF
--- a/edx/analytics/tasks/util/vertica_target.py
+++ b/edx/analytics/tasks/util/vertica_target.py
@@ -78,7 +78,9 @@ class VerticaTarget(luigi.Target):
         assert self.exists(connection)
 
     def exists(self, connection=None):  # pylint: disable-msg=W0221
+        close_connection = False
         if connection is None:
+            close_connection = True
             connection = self.connect()
             connection.autocommit = True
         cursor = connection.cursor()
@@ -95,6 +97,9 @@ class VerticaTarget(luigi.Target):
                 row = None
             else:
                 raise
+        finally:
+            if close_connection:
+                connection.close()
         return row is not None
 
     def connect(self, autocommit=False):


### PR DESCRIPTION
'ImportMysqlToVerticaTask' fails when it checks for completeness. Luigi calls exists() on the all dependencies, which opens a new connection per task(per table).
The workflow fails with 
"ConnectionError: Severity: FATAL, Message: New session rejected due to limit, already 50 sessions active"

This PR aims to resolve this issue by closing the connection. I'm open to suggestions.

@mulby @brianhw 