### PR TITLE
support extra repos and packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ docs/source/toctree.rst
 docs/source/workflow_entry_point.rst
 !docs/source/
 !docs/source/_themes/*
+
+*.java
+TempStatsStore/
+derby.log

--- a/share/task.yml
+++ b/share/task.yml
@@ -22,13 +22,10 @@
   gather_facts: True
 
   vars:
-    - repo: https://github.com/edx/edx-analytics-pipeline.git
-    - branch: master
     # - root_data_dir: /var/lib/analytics-tasks
     # - root_log_dir: /var/log/analytics-tasks
     - working_dir: "{{ root_data_dir }}/{{ uuid }}"
     - log_dir: "{{ root_log_dir }}/{{ uuid}}"
-    - working_repo_dir: "{{ working_dir }}/repo"
     - working_venv_dir: "{{ working_dir }}/venv"
     - virtualenv_python: "/usr/bin/python2.7"
     - virtualenv_extra_args: ''
@@ -47,11 +44,19 @@
       - Amazon
 
     # - override_config: path/to/config.cfg (optionally adds a luigi config override)
+    # - secure_config: path/to/config.cfg on the remote machine, could be from a checked out repo
 
-    # - secure_config_repo: git@github.com:some/repo.git
-    - secure_config_branch: origin/release
-    - secure_config_repo_dir: "{{ working_dir }}/config"
-    # - secure_config: path/to/config.cfg which can be found in the secure config repo
+    - pipeline_repo_dir_name: repo
+    - repos:
+      - url: https://github.com/edx/edx-analytics-pipeline.git
+        branch: master
+        dir_name: "{{ pipeline_repo_dir_name }}"
+    - working_repo_dir: "{{ working_dir }}/{{ pipeline_repo_dir_name }}"
+
+    - packages: []
+
+    - debian_wheel_url: "{{ wheel_url | default('http://edx-wheelhouse.s3-website-us-east-1.amazonaws.com/Debian/squeeze') }}"
+    - redhat_wheel_url: "{{ wheel_url | default('http://edx-wheelhouse.s3-website-us-east-1.amazonaws.com/Amazon/emr4') }}"
 
   tasks:
     - name: find home directory
@@ -83,7 +88,6 @@
       sudo: True
       with_items:
         - "{{ working_dir }}"
-        - "{{ working_repo_dir }}"
         - "{{ working_venv_dir }}"
 
     - name: log directory created
@@ -102,17 +106,24 @@
       sudo: True
       when: ansible_distribution in common_redhat_variants
 
-    - name: analytics tasks repository checked out
-      git: repo={{ repo }} dest={{ working_repo_dir }} version=master
+    - name: repositories checked out
+      git: >
+        repo={{ item.url }}
+        dest={{ working_dir }}/{{ item.dir_name }}
+        version=master
+      with_items: repos
 
-    - name: branch fetched
-      command: git fetch --all chdir={{ working_repo_dir }}
+    - name: branches fetched
+      command: git fetch --all chdir={{ working_dir }}/{{ item.dir_name }}
+      with_items: repos
 
-    - name: update origin/HEAD
-      command: git remote set-head origin --auto chdir={{ working_repo_dir }}
+    - name: origin/HEAD updated
+      command: git remote set-head origin --auto chdir={{ working_dir }}/{{ item.dir_name }}
+      with_items: repos
 
-    - name: branch checked out
-      command: git checkout {{ branch }} chdir={{ working_repo_dir }}
+    - name: branches checked out
+      command: git checkout {{ item.branch }} chdir={{ working_dir }}/{{ item.dir_name }}
+      with_items: repos
 
     - name: ensure system packages are installed
       command: make system-requirements chdir={{ working_repo_dir }}
@@ -145,7 +156,7 @@
         . {{ working_venv_dir }}/bin/activate && make install
         chdir={{ working_repo_dir }}
       environment:
-        WHEEL_URL: "{{ wheel_url | default('http://edx-wheelhouse.s3-website-us-east-1.amazonaws.com/Debian/squeeze') }}"
+        WHEEL_URL: "{{ debian_wheel_url }}"
         WHEEL_PYVER: "{{ wheel_pyver }}"
       when: ansible_distribution in common_debian_variants
 
@@ -154,9 +165,29 @@
         . {{ working_venv_dir }}/bin/activate && make install
         chdir={{ working_repo_dir }}
       environment:
-        WHEEL_URL: "{{ wheel_url | default('http://edx-wheelhouse.s3-website-us-east-1.amazonaws.com/Amazon/emr4') }}"
+        WHEEL_URL: "{{ redhat_wheel_url }}"
         WHEEL_PYVER: "{{ wheel_pyver }}"
       when: ansible_distribution in common_redhat_variants
+
+    - name: additional packages installed on Debian
+      shell: >
+        . {{ working_venv_dir }}/bin/activate && pip install {{ item }}
+        chdir={{ working_repo_dir }}
+      environment:
+        WHEEL_URL: "{{ debian_wheel_url }}"
+        WHEEL_PYVER: "{{ wheel_pyver }}"
+      when: ansible_distribution in common_debian_variants
+      with_items: packages
+
+    - name: additional packages installed on RHEL
+      shell: >
+        . {{ working_venv_dir }}/bin/activate && pip install {{ item }}
+        chdir={{ working_repo_dir }}
+      environment:
+        WHEEL_URL: "{{ redhat_wheel_url }}"
+        WHEEL_PYVER: "{{ wheel_pyver }}"
+      when: ansible_distribution in common_redhat_variants
+      with_items: packages
 
     - name: logging configured
       template: src=logging.cfg.j2 dest={{ working_repo_dir }}/logging.cfg
@@ -164,20 +195,8 @@
     - name: configuration override removed
       file: path={{ working_repo_dir }}/override.cfg state=absent
 
-    - name: secure config repository checked out
-      git: repo={{ secure_config_repo }} dest={{ secure_config_repo_dir }} version=master
-      when: secure_config is defined
-
-    - name: secure config branch fetched
-      command: git fetch --all chdir={{ secure_config_repo_dir }}
-      when: secure_config is defined
-
-    - name: secure config branch checked out
-      command: git checkout {{ secure_config_branch }} chdir={{ secure_config_repo_dir }}
-      when: secure_config is defined
-
     - name: secure config installed
-      command: cp {{ secure_config_repo_dir }}/{{ secure_config }} {{ working_repo_dir }}/override.cfg
+      command: cp {{ working_dir }}/{{ secure_config }} {{ working_repo_dir }}/override.cfg
       when: secure_config is defined
 
     - name: configuration override installed


### PR DESCRIPTION
This allows us to pass in two new parameters into the remote-task script.

"--package":
This parameter allows additional python packages to be specified at deploy time. This allows tasks to be gathered from a variety of different repos etc and all installed into the same virtualenv.

For example: `--package flask --package git@github.com:edx/pipeline-tasks.git`

"--extra-repo":
A URL to a git repository that is checked out on the cluster alongside edx-analytics-pipeline. Internally we actually use the same mechanism to checkout the pipeline repo, the secure config and whatever other repos the user has specified. This allows us to gather static files from different repos and make them available to the data pipeline at runtime. Specifically, we are looking to land SQL scripts to disk so that they can be run by #320.

For example: `--extra-repo git+ssh://git@github.com:edx/some-private-repo.git?dir_name=private&branch=origin%2Frelease --extra-repo https://github.com:edx/edx-public-repo.git?dir_name=public_repo&branch=master`

On the cluster these repos will be checked out alongside the pipeline, so you will see:

<pipeline root dir>/
  config/ (optional, this is the secure config repo)
  repo/ (this is edx-analytics-pipeline)
  private/ (this is git@github.com:edx/some-private-repo.git in the above example)
  public/ (this is https://github.com:edx/edx-public-repo.git in the above example)

When the pipeline runs it can reference files in these other locations:

`launch-task SomeTask --sql-script-root ../private/sql-scripts/`