### PR TITLE
fix complete function

### DIFF
--- a/edx/analytics/tasks/location_per_course.py
+++ b/edx/analytics/tasks/location_per_course.py
@@ -316,7 +316,7 @@ class LastCountryOfUser(LastCountryOfUserDownstreamMixin, GeolocationMixin, MapR
         if self.overwrite and not self.attempted_removal:
             return False
         else:
-            return get_target_from_url(url_path_join(self.output().path, '_SUCCESS')).exists()
+            return get_target_from_url(self.hive_partition_path('last_country_of_user', self.interval.date_b) + '_SUCCESS')).exists()
 
     def run(self):
         self.remove_output_on_overwrite()


### PR DESCRIPTION
url_path_join(self.output().path, '_SUCCESS') will return hdfs path without "hdfs://", so get_target_from_url will use default type(luigi.LocalTarget), however this file not exist and complete will return false although LastCountryOfUser task finished successfully