### PR TITLE
Fix requires() bug in run_vertica_sql_scripts.

### DIFF
--- a/edx/analytics/tasks/run_vertica_sql_scripts.py
+++ b/edx/analytics/tasks/run_vertica_sql_scripts.py
@@ -40,11 +40,7 @@ class RunVerticaSqlScriptsTask(RunVerticaSqlScriptsTaskMixin, luigi.WrapperTask)
     downstream_task = None
 
     def requires(self):
-        if self.downstream_task is None:
-            self.downstream_task = self.get_downstream_task()
-
-        if self.downstream_task is not None:
-            yield self.downstream_task
+        return self.get_downstream_task()
 
     def validate_script_entry(self, script):
       # It has to be a dictionary.


### PR DESCRIPTION
Previously, we were storing a generator and then trying to yield that generator once we lazily generated it.  Here, we're still letting `get_downstream_task()` do its own internal caching/lazy loading, but we're returning the generator it produces directly in `requires()`.