### PR TITLE
Add TravisCI support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+python:
+  - "2.7"
+cache: pip
+
+addons:
+  apt:
+    packages:
+      - libblas-dev
+      - liblapack-dev
+      - libatlas-base-dev
+
+script:
+  - make test
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,6 @@ test-local:
 
 test: test-requirements develop test-local
 
-
 test-acceptance: test-requirements
 	LUIGI_CONFIG_PATH='config/test.cfg' python -m coverage run --rcfile=./.coveragerc -m nose --nocapture --with-xunit -A acceptance $(ONLY_TESTS)
 


### PR DESCRIPTION
TravisCI is already enabled on the repository, but it won't build branches without a `.travis.yml` present, so this will add that.

Right now, we only build against Python 2.7 since some of the Ansible stuff seems to break on Python 3. x and it would just red light every single build.

Builds are somewhere between 5m and 6m30s.  There's packages that just don't have wheels (like `psycopg2`) and some that seem to need OS-based libraries (like ATLAS, BLAS, LAPACK, etc) which I've yet to figure out a clean way to install precompiled.