### PR TITLE
Run coverage and tests seperately.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
 install:
   - git clone https://github.com/$TRAVIS_REPO_SLUG.git $TRAVIS_REPO_SLUG
   - cd $TRAVIS_REPO_SLUG
-  - git checkout -qf $TRAVIS_PULL_REQUEST_SHA || git checkout -qf $TRAVIS_BRANCH
+  - git checkout -f ${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
 
 script:
   - make $MAKE_TARGET

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,17 @@ addons:
       - liblapack-dev
       - libatlas-base-dev
 
+env:
+  - MAKE_TARGET=test
+  - MAKE_TARGET=coverage
+
+install:
+  - git clone https://github.com/$TRAVIS_REPO_SLUG.git $TRAVIS_REPO_SLUG
+  - cd $TRAVIS_REPO_SLUG
+  - git checkout -qf $TRAVIS_PULL_REQUEST_SHA || git checkout -qf $TRAVIS_BRANCH
+
 script:
-  - make test
+  - make $MAKE_TARGET
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
As stated in the subject.  This will run TravisCI in a build matrix mode, running both unit tests and coverage/quality separately and concurrently.

I had to do some annoying git reclone action here because Travis defaults to cloning in a detached state, which prevents `diff-cover` and `diff-quality` from comparing the branch to `master`.