### PR TITLE
Reorganize and upgrade requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 
 # If a wheel repository is defined, then have pip use that.  But don't require the use of wheel.
 ifneq ($(strip $(WHEEL_URL)),)
-	PIP_INSTALL = pip install --use-wheel --find-links=$$WHEEL_URL/Python-$$WHEEL_PYVER --allow-external mysql-connector-python
+	PIP_INSTALL = pip install --use-wheel --find-links=$$WHEEL_URL/Python-$$WHEEL_PYVER
 else
-	PIP_INSTALL = pip install --allow-external mysql-connector-python
+	PIP_INSTALL = pip install
 endif
 
 .PHONY:	requirements test test-requirements .tox

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,5 +20,6 @@ paramiko==2.1.1 	# LGPL
 pyasn1==0.1.9
 pycparser==2.17
 PyYAML==3.12		# MIT License
+setuptools==32.3.1
 six==1.10.0
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,10 +1,24 @@
-Jinja2==2.7.3		# BSD
-MarkupSafe==0.23	# BSD
-PyYAML==3.10		# MIT License
-ecdsa==0.11 		# MIT
-httplib2==0.9 		# MIT
-paramiko==1.14.0 	# LGPL
-pycrypto==2.6.1 	# public domain
+# These packages are required for bootstrapping.
+
 ansible==1.4.5          # GPL v3 License
 boto==2.22.1            # MIT
+ecdsa==0.13 		# MIT
+Jinja2==2.8.1		# BSD
+pycrypto==2.6.1 	# public domain
+
+# The following are dependencies pulled in by the above,
+# but are pinned here.
+
+cffi==1.9.1
+cryptography==1.7.1
+enum34==1.1.6
+httplib2==0.9.2		# MIT
+idna==2.2
+ipaddress==1.0.17
+MarkupSafe==0.23	# BSD
+paramiko==2.1.1 	# LGPL
+pyasn1==0.1.9
+pycparser==2.17
+PyYAML==3.12		# MIT License
+six==1.10.0
 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,40 +1,60 @@
 -r base.txt
+
+# These dependencies are explicitly included in code.
+
 argparse==1.2.1 	# Python Software Foundation License
-cffi==1.9.1             # MIT
-ciso8601==1.0.1         # MIT
-cryptography==1.7.1     # BSD or Apache 2.0
+ciso8601==1.0.3         # MIT
 edx-opaque-keys==0.2.1  # AGPL
 edx-ccx-keys==0.1.2     # AGPL
 elasticsearch==1.7.0    # Apache
-enum34==1.0.4           # BSD
-filechunkio==1.5	# MIT
+filechunkio==1.8	# MIT
 html5lib==1.0b3 	# MIT
-idna==2.0               # BSD-like
-isoweek==1.3.0		# BSD
-mechanize==0.2.5	# BSD
+isoweek==1.3.1		# BSD
 http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-1.2.2.zip  	# GPL v2 with FOSS License Exception
-ndg-httpsclient==0.4.0  # BSD
 numpy==1.11.3 		# BSD
 pandas==0.13.0 		# BSD
 paypalrestsdk==1.9.0    # Paypal SDK License
-pbr==0.5.23 		# Apache
-pyOpenSSL==0.15.1       # Apache 2.0
-pyasn1==0.1.7           # BSD
-pycparser==2.13         # BSD
-pygeoip==0.3.1 		# LGPL
-pymongo==2.7.2		# Apache 2.0
-python-cjson==1.0.5	# LGPL
-python-dateutil==2.2 	# BSD
-python-gnupg==0.3.6	# BSD
-pytz==2014.4		# ZPL
-requests==2.7.0         # Apache 2.0
-setuptools==23.1.0
-six==1.6.1		# MIT
-stevedore==0.14.1 	# Apache 2.0
-tornado==3.1.1 		# Apache 2.0
-urllib3==1.10.4         # MIT
-vertica-python==0.5.1   # MIT
-wsgiref==0.1.2 		# ZPL
-pip==9.0.1
+pygeoip==0.3.2 		# LGPL
+python-cjson==1.1.0	# LGPL
+python-dateutil==2.6.0 	# BSD
+python-gnupg==0.3.9	# BSD
+pytz==2016.10		# ZPL
+requests==2.12.4         # Apache 2.0
+six==1.10.0		# MIT
+stevedore==1.19.1 	# Apache 2.0
+urllib3==1.19.1         # MIT
+vertica-python==0.6.11  # MIT
+
 git+https://github.com/edx/luigi.git@d55592dc3502f19897e3687332d5cf3754104458#egg=luigi 		# Apache License 2.0
 git+https://github.com/edx/pyinstrument.git@a35ff76df4c3d5ff9a2876d859303e33d895e78f#egg=pyinstrument     # BSD
+
+# These dependencies are pulled in by the above requirements,
+# and are pinned here.
+
+distlib==0.2.4
+future==0.16.0
+pymongo==3.4.0		# Apache 2.0
+pyOpenSSL==16.2.0       # Apache 2.0
+pbr==1.10.0 		# Apache
+
+# These dependencies are already pulled in by earlier requirements (e.g.
+# and are NOT pinned here.
+
+# cffi==1.9.1             # MIT
+# cryptography==1.7.1     # BSD or Apache 2.0
+# enum34==1.1.6           # BSD
+# idna==2.2               # BSD-like
+# pip==9.0.1
+# pyasn1==0.1.9           # BSD
+# pycparser==2.17         # BSD
+# setuptools==32.3.1
+
+# These dependencies are not used?
+
+# backports_abc==0.5
+# certifi==2016.9.26
+# mechanize==0.2.5	# BSD
+# ndg-httpsclient==0.4.2  # BSD
+# singledispatch==3.4.0.3
+# tornado==4.4.2 		# Apache 2.0
+# wsgiref==0.1.2 		# ZPL

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -19,13 +19,13 @@ python-cjson==1.1.0	# LGPL
 python-dateutil==2.6.0 	# BSD
 python-gnupg==0.3.9	# BSD
 pytz==2016.10		# ZPL
-requests==2.12.4         # Apache 2.0
+requests==2.12.4        # Apache 2.0
 six==1.10.0		# MIT
 stevedore==1.19.1 	# Apache 2.0
 urllib3==1.19.1         # MIT
 vertica-python==0.6.11  # MIT
 
-git+https://github.com/edx/luigi.git@d55592dc3502f19897e3687332d5cf3754104458#egg=luigi 		# Apache License 2.0
+git+https://github.com/edx/luigi.git@a73700ca51685974220ef6069d2f078312055444#egg=luigi 		# Apache License 2.0
 git+https://github.com/edx/pyinstrument.git@a35ff76df4c3d5ff9a2876d859303e33d895e78f#egg=pyinstrument     # BSD
 
 # These dependencies are pulled in by the above requirements,

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,2 +1,2 @@
 -r default.txt
-Sphinx==1.3.5
+Sphinx==1.5.1

--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -1,1 +1,1 @@
-psycopg2==2.6.1         # LGPL
+psycopg2==2.6.2         # LGPL

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,11 +1,33 @@
-coverage==3.7.1
-ddt==1.0.0
+coverage==4.3.1
+ddt==1.1.1
 diff-cover >= 0.2.1
-httpretty==0.8.10
-mock==1.0.1
+freezegun==0.3.8
+httpretty==0.8.14
+mock==2.0.0
 nose-ignore-docstring==0.2
-nose==1.3.4
-pep8==1.6.0
-pylint==1.5.0
-unittest2==0.5.1
-freezegun==0.3.6
+nose==1.3.7
+pep8==1.7.0
+pylint==1.6.4
+
+# dependencies pulled in by the above, that
+# are being pinned.
+
+astroid==1.4.9
+backports.functools-lru-cache==1.3
+configparser==3.5.0
+funcsigs==1.0.2
+inflect==0.2.5
+isort==4.2.5
+jinja2-pluralize==0.3.0
+lazy-object-proxy==1.2.2
+mccabe==0.5.3
+wrapt==1.10.8
+
+# dependencies that are already pinned earlier.
+
+# Jinja2==2.8.1
+# MarkupSafe==0.23
+# pbr==1.10.0
+# python-dateutil==2.6.0
+# Pygments==2.1.3
+# six==1.10.0


### PR DESCRIPTION
Separate the explicit requirements from the pinning of their
dependencies.  This makes later updating easier, when we can
comment out the dependencies and repin after updates.