### PR TITLE
Use a retry library to retry calls to the HistoryServer API.

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -21,7 +21,6 @@ python-dateutil==2.6.0 	# BSD
 python-gnupg==0.3.9	# BSD
 pytz==2016.10		# ZPL
 requests==2.12.4        # Apache 2.0
-retrying==1.3.3
 six==1.10.0		# MIT
 statsd==3.2.1  # MIT
 stevedore==1.19.1 	# Apache 2.0

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -21,6 +21,7 @@ python-dateutil==2.6.0 	# BSD
 python-gnupg==0.3.9	# BSD
 pytz==2016.10		# ZPL
 requests==2.12.4        # Apache 2.0
+retrying==1.3.3
 six==1.10.0		# MIT
 statsd==3.2.1  # MIT
 stevedore==1.19.1 	# Apache 2.0

--- a/scripts/collect-hadoop-metrics.py
+++ b/scripts/collect-hadoop-metrics.py
@@ -2,6 +2,7 @@ import json
 import sys
 import boto3
 import requests
+import retrying
 import statsd
 import yaml
 from yarn_api_client import HistoryServer
@@ -186,6 +187,7 @@ def facet_metrics(metrics, templates, context={}):
     return output_metrics
 
 
+@retry(stop_max_attempt_number=6, wait_exponential_multipler=1000, wait_exponential_max=10000)
 def collect_metrics(hs_address, metric_templates):
     """
     Collects Hadoop counters from all jobs on the local HistoryServer, transforming them for forwarding
@@ -197,6 +199,8 @@ def collect_metrics(hs_address, metric_templates):
     print "[collect-hadoop-metrics] Context for this run:"
     for (k,v) in context.iteritems():
         print "                 {} => {}".format(k, v)
+
+    formatted_metrics = {}
 
     # Grab all jobs from the history server.
     hs = HistoryServer(hs_address)
@@ -224,7 +228,6 @@ def collect_metrics(hs_address, metric_templates):
 
         job_counters = hs.job_counters(job['id']).data['jobCounters']
 
-        formatted_metrics = {}
         for counter_group in job_counters.get('counterGroup', []):
             metric_prefix = get_prefix_from_counter_group_name(counter_group['counterGroupName'])
 

--- a/scripts/collect-hadoop-metrics.py
+++ b/scripts/collect-hadoop-metrics.py
@@ -2,9 +2,9 @@ import json
 import sys
 import boto3
 import requests
-import retrying
 import statsd
 import yaml
+from retrying import retry
 from yarn_api_client import HistoryServer
 
 


### PR DESCRIPTION
It seems like the HistoryServer can get a little choked up on bigger jobs, or by calling it too quickly after the jobs finish.

Now we have a little exponential backoff going on.  We'll try a total of six times to collect the metrics, with an exponential backoff of 2^n*1000ms (n is number of retries) with a maximum of 10000ms delay.

So... 0 seconds delay, then 1s, then 4s, then 10s, and 10s until the retries are up.