### PR TITLE
Trap exceptions that occur while collecting metrics.

### DIFF
--- a/scripts/collect-hadoop-metrics.py
+++ b/scripts/collect-hadoop-metrics.py
@@ -285,7 +285,11 @@ if __name__ == "__main__":
     statsd_prefix = statsd_config.get('prefix', 'edx.analytics.emr')
 
     # Actually collect the metrics.
-    metrics = collect_metrics(hs_address, metric_templates)
+    metrics = []
+    try:
+      metrics = collect_metrics(hs_address, metric_templates)
+    except Exception as ex:
+      print "[collect-hadoop-metrics] Caught exception while running collection: {}".format(str(ex))
 
     # Ship them to the local statsd endpoint.
     statsd_client = statsd.StatsClient(statsd_host, statsd_port, prefix=statsd_prefix)


### PR DESCRIPTION
In all cases, we do not want a metrics collection issue to actually fail a workflow in the eyes on Jenkins.  We specifically look for traceback output to signal us to a job that had an error, but this check also catches errors from the metrics collection.

Now, we'll catch exceptions and simply log their message, rather than dumping out the traceback.  This should be sufficient for help guide further debugging without triggering any of the checks that we use to introspect the status of the workflow itself.