### PR TITLE
Adds counter calls to event-loading, enrollment, and video workflows

### DIFF
--- a/edx/analytics/tasks/common/pathutil.py
+++ b/edx/analytics/tasks/common/pathutil.py
@@ -275,10 +275,12 @@ class EventLogSelectionMixin(EventLogSelectionDownstreamMixin):
         """Default mapper implementation, that always outputs the log line, but with a configurable key."""
         event = eventlog.parse_json_event(line)
         if event is None:
+            self.incr_counter('Event', 'Discard Unparseable Event', 1)
             return None
 
         event_time = self.get_event_time(event)
         if not event_time:
+            self.incr_counter('Event', 'Discard Missing Time Field', 1)
             return None
 
         # Don't use strptime to parse the date, it is extremely slow
@@ -288,6 +290,7 @@ class EventLogSelectionMixin(EventLogSelectionDownstreamMixin):
         date_string = event_time.split("T")[0]
 
         if date_string < self.lower_bound_date_string or date_string >= self.upper_bound_date_string:
+            self.incr_counter('Event', 'Discard Outside Date Interval', 1)
             return None
 
         return event, date_string
@@ -297,7 +300,6 @@ class EventLogSelectionMixin(EventLogSelectionDownstreamMixin):
         try:
             return event['time']
         except KeyError:
-            self.incr_counter('Event', 'Missing Time Field', 1)
             return None
 
     def get_map_input_file(self):
@@ -312,4 +314,5 @@ class EventLogSelectionMixin(EventLogSelectionDownstreamMixin):
                 return os.environ['map_input_file']
             except KeyError:
                 log.warn('mapreduce_map_input_file not defined in os.environ, unable to determine input file path')
+                self.incr_counter('Event', 'Missing map_input_file', 1)
                 return ''

--- a/edx/analytics/tasks/insights/video.py
+++ b/edx/analytics/tasks/insights/video.py
@@ -52,6 +52,8 @@ class UserVideoViewingTask(EventLogSelectionMixin, MapReduceJobTask):
     # Persist this across calls to the reducer.
     video_durations = {}
 
+    counter_category_name = 'Video Events'
+
     def init_local(self):
         super(UserVideoViewingTask, self).init_local()
         # Providing an api_key is optional.
@@ -62,20 +64,26 @@ class UserVideoViewingTask(EventLogSelectionMixin, MapReduceJobTask):
     def mapper(self, line):
         # Add a filter here to permit quicker rejection of unrelated events.
         if VIDEO_EVENT_MINIMUM_STRING not in line:
+            self.incr_counter(self.counter_category_name, 'Discard Missing Video String', 1)
             return
 
         value = self.get_event_and_date_string(line)
         if value is None:
             return
         event, _date_string = value
+        self.incr_counter(self.counter_category_name, 'Inputs with Dates', 1)
 
         event_type = event.get('event_type')
         if event_type is None:
             log.error("encountered event with no event_type: %s", event)
+            self.incr_counter(self.counter_category_name, 'Discard Missing Event Type', 1)
             return
 
         if event_type not in VIDEO_EVENT_TYPES:
+            self.incr_counter(self.counter_category_name, 'Discard Non-Video Event Type', 1)
             return
+
+        self.incr_counter(self.counter_category_name, 'Input Video Events', 1)
 
         # This has already been checked when getting the event, so just fetch the value.
         timestamp = eventlog.get_event_time_string(event)
@@ -84,22 +92,32 @@ class UserVideoViewingTask(EventLogSelectionMixin, MapReduceJobTask):
         username = event.get('username', '').strip()
         if not username:
             log.error("Video event without username: %s", event)
+            self.incr_counter(self.counter_category_name, 'Discard Video Missing Something', 1)
+            self.incr_counter(self.counter_category_name, 'Discard Video Missing username', 1)
             return
 
         course_id = eventlog.get_course_id(event)
         if course_id is None:
             log.warn('Video event without valid course_id: {0}'.format(line))
+            self.incr_counter(self.counter_category_name, 'Discard Video Missing Something', 1)
+            self.incr_counter(self.counter_category_name, 'Discard Video Missing course_id', 1)
             return
 
         event_data = eventlog.get_event_data(event)
         if event_data is None:
             # This should already have been logged.
+            self.incr_counter(self.counter_category_name, 'Discard Video Missing Something', 1)
+            self.incr_counter(self.counter_category_name, 'Discard Video Missing Event Data', 1)
             return
 
         encoded_module_id = event_data.get('id')
         if encoded_module_id is None:
             log.warn('Video event without valid encoded_module_id (id): {0}'.format(line))
+            self.incr_counter(self.counter_category_name, 'Discard Video Missing Something', 1)
+            self.incr_counter(self.counter_category_name, 'Discard Video Missing encoded_module_id', 1)
             return
+
+        self.incr_counter(self.counter_category_name, 'Video Events Before Time Check', 1)
 
         current_time = None
         old_time = None
@@ -110,26 +128,43 @@ class UserVideoViewingTask(EventLogSelectionMixin, MapReduceJobTask):
                 youtube_id = code
             current_time = self._check_time_offset(event_data.get('currentTime'), line)
             if current_time is None:
+                self.incr_counter(self.counter_category_name, 'Discard Video Missing Something', 1)
+                self.incr_counter(self.counter_category_name, 'Discard Video Missing Time', 1)
+                self.incr_counter(self.counter_category_name, 'Discard Video Missing Time From Play', 1)
                 return
+            self.incr_counter(self.counter_category_name, 'Subset Play', 1)
         elif event_type == VIDEO_PAUSED:
             # Pause events may have a missing currentTime value if video is paused at the beginning,
             # so provide a default of zero.
             current_time = self._check_time_offset(event_data.get('currentTime', 0), line)
             if current_time is None:
+                self.incr_counter(self.counter_category_name, 'Discard Video Missing Something', 1)
+                self.incr_counter(self.counter_category_name, 'Discard Video Missing Time', 1)
+                self.incr_counter(self.counter_category_name, 'Discard Video Missing Time From Pause', 1)
                 return
+            self.incr_counter(self.counter_category_name, 'Subset Pause', 1)
         elif event_type == VIDEO_SEEK:
             current_time = self._check_time_offset(event_data.get('new_time'), line)
             old_time = self._check_time_offset(event_data.get('old_time'), line)
             if current_time is None or old_time is None:
+                self.incr_counter(self.counter_category_name, 'Discard Video Missing Something', 1)
+                self.incr_counter(self.counter_category_name, 'Discard Video Missing Time', 1)
+                self.incr_counter(self.counter_category_name, 'Discard Video Missing Time From Seek', 1)
                 return
+            self.incr_counter(self.counter_category_name, 'Subset Seek', 1)
         elif event_type == VIDEO_STOPPED:
             current_time = self._check_time_offset(event_data.get('currentTime'), line)
             if current_time is None:
+                self.incr_counter(self.counter_category_name, 'Discard Video Missing Something', 1)
+                self.incr_counter(self.counter_category_name, 'Discard Video Missing Time', 1)
+                self.incr_counter(self.counter_category_name, 'Discard Video Missing Time From Stop', 1)
                 return
+            self.incr_counter(self.counter_category_name, 'Subset Stop', 1)
 
         if youtube_id is not None:
             youtube_id = youtube_id.encode('utf8')
 
+        self.incr_counter(self.counter_category_name, 'Output Video Events from Mapper', 1)
         yield (
             (username.encode('utf8'), course_id.encode('utf8'), encoded_module_id.encode('utf8')),
             (timestamp, event_type, current_time, old_time, youtube_id)
@@ -145,18 +180,22 @@ class UserVideoViewingTask(EventLogSelectionMixin, MapReduceJobTask):
             time_value = float(time_value)
         except ValueError:
             log.warn('Video event with invalid time-offset value: {0}'.format(line))
+            self.incr_counter(self.counter_category_name, 'Quality Invalid Time-Offset Value', 1)
             return None
         except TypeError:
             log.warn('Video event with invalid time-offset type: {0}'.format(line))
+            self.incr_counter(self.counter_category_name, 'Quality Invalid Time-Offset Type', 1)
             return None
 
         # Some events have ridiculous (and dangerous) values for time.
         if time_value > VIDEO_MAXIMUM_DURATION:
             log.warn('Video event with huge time-offset value: {0}'.format(line))
+            self.incr_counter(self.counter_category_name, 'Quality Huge Time-Offset Value', 1)
             return None
 
         if time_value < 0.0:
             log.warn('Video event with negative time-offset value: {0}'.format(line))
+            self.incr_counter(self.counter_category_name, 'Quality Negative Time-Offset Value', 1)
             return None
 
         # We must screen out 'nan' and 'inf' values, as they do not "round-trip".
@@ -164,6 +203,7 @@ class UserVideoViewingTask(EventLogSelectionMixin, MapReduceJobTask):
         # eval(repr(float('nan'))) throws a NameError rather than returning float('nan').
         if math.isnan(time_value) or math.isinf(time_value):
             log.warn('Video event with nan or inf time-offset value: {0}'.format(line))
+            self.incr_counter(self.counter_category_name, 'Quality Nan-Inf Time-Offset Value', 1)
             return None
 
         return time_value
@@ -176,6 +216,7 @@ class UserVideoViewingTask(EventLogSelectionMixin, MapReduceJobTask):
         play_video/non-play_video events.
         """
         username, course_id, encoded_module_id = key
+        self.incr_counter(self.counter_category_name, 'Input User_course_videos', 1)
 
         sorted_events = sorted(events)
 
@@ -188,6 +229,8 @@ class UserVideoViewingTask(EventLogSelectionMixin, MapReduceJobTask):
         last_viewing_end_event = None
         viewing = None
         for event in sorted_events:
+            self.incr_counter(self.counter_category_name, 'Input User_course_video events', 1)
+
             timestamp, event_type, current_time, old_time, youtube_id = event
             parsed_timestamp = ciso8601.parse_datetime(timestamp)
             if current_time is not None:
@@ -197,8 +240,10 @@ class UserVideoViewingTask(EventLogSelectionMixin, MapReduceJobTask):
 
             def start_viewing():
                 """Returns a 'viewing' object representing the point where a video began to be played."""
+                self.incr_counter(self.counter_category_name, 'Viewing Start', 1)
                 video_duration = VIDEO_UNKNOWN_DURATION
                 if youtube_id:
+                    self.incr_counter(self.counter_category_name, 'Viewing Start with Video Id', 1)
                     video_duration = self.video_durations.get(youtube_id)
                     if not video_duration:
                         video_duration = self.get_video_duration(youtube_id)
@@ -207,9 +252,10 @@ class UserVideoViewingTask(EventLogSelectionMixin, MapReduceJobTask):
 
                 if last_viewing_end_event is not None and last_viewing_end_event[1] == VIDEO_SEEK:
                     start_offset = last_viewing_end_event[2]
+                    self.incr_counter(self.counter_category_name, 'Subset Viewing Start With Offset From Preceding Seek', 1)
                 else:
                     start_offset = current_time
-
+                    self.incr_counter(self.counter_category_name, 'Subset Viewing Start With Offset From Current Play', 1)
                 return VideoViewing(
                     start_timestamp=parsed_timestamp,
                     course_id=course_id,
@@ -224,19 +270,30 @@ class UserVideoViewingTask(EventLogSelectionMixin, MapReduceJobTask):
                 # Check that end_time is within the bounds of the duration.
                 # Note that duration may be an int, and end_time may be a float,
                 # so just add +1 to avoid these round-off errors (instead of actually checking types).
+                self.incr_counter(self.counter_category_name, 'Viewing End', 1)
+
                 if viewing.video_duration != VIDEO_UNKNOWN_DURATION and end_time > (viewing.video_duration + 1):
                     log.error('End time of viewing past end of video.\nViewing Start: %r\nEvent: %r\nKey:%r',
                               viewing, event, key)
+                    self.incr_counter(self.counter_category_name, 'Discard Viewing End Time Past End Of Video', 1)
+                    self.incr_counter(self.counter_category_name, 'Discard Viewing End', 1)
+                    self.incr_counter(self.counter_category_name, 'Discard Viewing', 1)
                     return None
 
                 if end_time < viewing.start_offset:
                     log.error('End time is before the start time.\nViewing Start: %r\nEvent: %r\nKey:%r',
                               viewing, event, key)
+                    self.incr_counter(self.counter_category_name, 'Discard Viewing End Time Before Start Time', 1)
+                    self.incr_counter(self.counter_category_name, 'Discard Viewing End', 1)
+                    self.incr_counter(self.counter_category_name, 'Discard Viewing', 1)
                     return None
 
                 if (end_time - viewing.start_offset) < VIDEO_VIEWING_MINIMUM_LENGTH:
                     log.error('Viewing too short and discarded.\nViewing Start: %r\nEvent: %r\nKey:%r',
                               viewing, event, key)
+                    self.incr_counter(self.counter_category_name, 'Discard Viewing End Time Too Short', 1)
+                    self.incr_counter(self.counter_category_name, 'Discard Viewing End', 1)
+                    self.incr_counter(self.counter_category_name, 'Discard Viewing', 1)
                     return None
 
                 return (
@@ -251,6 +308,10 @@ class UserVideoViewingTask(EventLogSelectionMixin, MapReduceJobTask):
                 )
 
             if event_type == VIDEO_PLAYED:
+                if viewing:
+                    self.incr_counter(self.counter_category_name, 'Discard Viewing Start On Successive Play', 1)
+                    self.incr_counter(self.counter_category_name, 'Discard Viewing Start', 1)
+                    self.incr_counter(self.counter_category_name, 'Discard Viewing', 1)
                 viewing = start_viewing()
                 last_viewing_end_event = None
             elif viewing:
@@ -258,15 +319,20 @@ class UserVideoViewingTask(EventLogSelectionMixin, MapReduceJobTask):
                 if event_type in (VIDEO_PAUSED, VIDEO_STOPPED):
                     # play -> pause or play -> stop
                     viewing_end_time = current_time
+                    self.incr_counter(self.counter_category_name, 'Subset Viewing End By Stop Or Pause', 1)
                 elif event_type == VIDEO_SEEK:
                     # play -> seek
                     viewing_end_time = old_time
+                    self.incr_counter(self.counter_category_name, 'Subset Viewing End By Seek', 1)
                 else:
                     log.error('Unexpected event in viewing.\nViewing Start: %r\nEvent: %r\nKey:%r', viewing, event, key)
-
+                    self.incr_counter(self.counter_category_name, 'Discard End Viewing Unexpected Event', 1)
+                    self.incr_counter(self.counter_category_name, 'Discard Viewing End', 1)
+                    self.incr_counter(self.counter_category_name, 'Discard Viewing', 1)
                 if viewing_end_time is not None:
                     record = end_viewing(viewing_end_time)
                     if record:
+                        self.incr_counter(self.counter_category_name, 'Output Viewing', 1)
                         yield record
                     # Throw away the viewing even if it didn't yield a valid record. We assume that this is malformed
                     # data and untrustworthy.
@@ -274,12 +340,16 @@ class UserVideoViewingTask(EventLogSelectionMixin, MapReduceJobTask):
                     last_viewing_end_event = event
             else:
                 # This is a non-play video event outside of a viewing.  It is probably too frequent to be logged.
+                self.incr_counter(self.counter_category_name, 'Discard Event Outside Of Viewing', 1)
                 pass
 
-        # This happens too often!  Comment out for now...
-        # if viewing is not None:
-        #     log.error('Unexpected viewing started with no matching end.\n'
-        #               'Viewing Start: %r\nLast Event: %r\nKey:%r', viewing, last_viewing_end_event, key)
+        if viewing is not None:
+            # This happens too often!  Comment out for now...
+            # log.error('Unexpected viewing started with no matching end.\n'
+            #           'Viewing Start: %r\nLast Event: %r\nKey:%r', viewing, last_viewing_end_event, key)
+            self.incr_counter(self.counter_category_name, 'Discard Viewing Start With No Matching End', 1)
+            self.incr_counter(self.counter_category_name, 'Discard Viewing Start', 1)
+            self.incr_counter(self.counter_category_name, 'Discard Viewing', 1)
 
     def output(self):
         return get_target_from_url(self.output_root)
@@ -294,6 +364,7 @@ class UserVideoViewingTask(EventLogSelectionMixin, MapReduceJobTask):
         if self.api_key is None:
             return duration
 
+        self.incr_counter(self.counter_category_name, 'Subset Calls to Youtube API', 1)
         video_file = None
         try:
             video_url = "https://www.googleapis.com/youtube/v3/videos?id={0}&part=contentDetails&key={1}".format(
@@ -309,15 +380,19 @@ class UserVideoViewingTask(EventLogSelectionMixin, MapReduceJobTask):
                 matcher = re.match(r'PT(?:(?P<hours>\d+)H)?(?:(?P<minutes>\d+)M)?(?:(?P<seconds>\d+)S)?', duration_str)
                 if not matcher:
                     log.error('Unable to parse duration returned for video %s: %s', youtube_id, duration_str)
+                    self.incr_counter(self.counter_category_name, 'Quality Unparseable Response From Youtube API', 1)
                 else:
                     duration_secs = int(matcher.group('hours') or 0) * 3600
                     duration_secs += int(matcher.group('minutes') or 0) * 60
                     duration_secs += int(matcher.group('seconds') or 0)
                     duration = duration_secs
+                    self.incr_counter(self.counter_category_name, 'Subset Calls to Youtube API Succeeding', 1)
             else:
                 log.error('Unable to find items in response to duration request for youtube video: %s', youtube_id)
+                self.incr_counter(self.counter_category_name, 'Quality No Items In Response From Youtube API', 1)
         except Exception:  # pylint: disable=broad-except
             log.exception("Unrecognized response from Youtube API")
+            self.incr_counter(self.counter_category_name, 'Quality Unrecognized Response From Youtube API', 1)
         finally:
             if video_file is not None:
                 video_file.close()

--- a/edx/analytics/tasks/monitor/tests/test_overall_events.py
+++ b/edx/analytics/tasks/monitor/tests/test_overall_events.py
@@ -108,7 +108,7 @@ class TotalEventsTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMixin, TestCas
         sys.stderr = test_stderr
         self.assert_no_map_output_for(line)
         test_stderr = test_stderr.getvalue().strip()
-        self.assertEquals(test_stderr, 'reporter:counter:Event,Missing Time Field,1')
+        self.assertEquals(test_stderr, 'reporter:counter:Event,Discard Missing Time Field,1')
 
 
 class TotalEventsTaskReducerTest(ReducerTestMixin, TestCase):

--- a/edx/analytics/tasks/warehouse/load_internal_reporting_events.py
+++ b/edx/analytics/tasks/warehouse/load_internal_reporting_events.py
@@ -390,6 +390,9 @@ class BaseEventRecordDataTask(EventRecordDataDownstreamMixin, MultiOutputMapRedu
     # values for assignment to DateField objects.
     date_field_for_converting = DateField()
 
+    # This is a placeholder.  It is expected to be overridden in derived classes.
+    counter_category_name = 'Event Record Exports'
+
     def __init__(self, *args, **kwargs):
         super(BaseEventRecordDataTask, self).__init__(*args, **kwargs)
 
@@ -438,7 +441,7 @@ class BaseEventRecordDataTask(EventRecordDataDownstreamMixin, MultiOutputMapRedu
             output_file.write('\n')
             # WARNING: This line ensures that Hadoop knows that our process is not sitting in an infinite loop.
             # Do not remove it.
-            self.incr_counter('Event Record Exports', 'Raw Bytes Written', len(value) + 1)
+            self.incr_counter(self.counter_category_name, 'Raw Bytes Written', len(value) + 1)
 
     def output_path_for_key(self, key):
         """
@@ -499,7 +502,7 @@ class BaseEventRecordDataTask(EventRecordDataDownstreamMixin, MultiOutputMapRedu
                 # ciso8601.parse_datetime(ts).astimezone(pytz.utc).date().isoformat()
                 return self.date_field_for_converting.deserialize_from_string(date_string).isoformat()
             except ValueError:
-                self.incr_counter('Event Record Exports', 'Cannot convert to date', 1)
+                self.incr_counter(self.counter_category_name, 'Cannot convert to date', 1)
                 # Don't bother to make sure we return a good value
                 # within the interval, so we can find the output for
                 # debugging.  Should not be necessary, as this is only
@@ -507,7 +510,7 @@ class BaseEventRecordDataTask(EventRecordDataDownstreamMixin, MultiOutputMapRedu
                 return u"BAD: {}".format(date_string)
                 # return self.lower_bound_date_string
         else:
-            self.incr_counter('Event Record Exports', 'Missing date', 1)
+            self.incr_counter(self.counter_category_name, 'Missing date', 1)
             return date_string
 
     def _canonicalize_user_agent(self, agent):
@@ -524,6 +527,7 @@ class BaseEventRecordDataTask(EventRecordDataDownstreamMixin, MultiOutputMapRedu
         try:
             user_agent = user_agents.parse(agent)
         except Exception:  # If the user agent can't be parsed, just drop the agent data on the floor since it's of no use to us.
+            self.incr_counter(self.counter_category_name, 'Quality Unparseable agent', 1)
             return agent_dict
 
         device_type = ''  # It is possible that the user agent isn't any of the below.
@@ -542,6 +546,8 @@ class BaseEventRecordDataTask(EventRecordDataDownstreamMixin, MultiOutputMapRedu
             agent_dict['os'] = user_agent.os.family
             agent_dict['browser'] = user_agent.browser.family
             agent_dict['touch_capable'] = unicode(user_agent.is_touch_capable)
+        else:
+            self.incr_counter(self.counter_category_name, 'Quality Unrecognized agent type', 1)
 
         return agent_dict
 
@@ -566,6 +572,7 @@ class BaseEventRecordDataTask(EventRecordDataDownstreamMixin, MultiOutputMapRedu
                 if value_length > field_length:
                     log.error("Record value length (%d) exceeds max length (%d) for field %s: %r", value_length, field_length, event_record_key, value)
                     value = u"{}...".format(value[:field_length - 4])
+                    self.incr_counter(self.counter_category_name, 'Quality Truncated string value', 1)
             event_dict[event_record_key] = value
         elif isinstance(event_record_field, IntegerField):
             try:
@@ -620,6 +627,8 @@ class TrackingEventRecordDataTask(EventLogSelectionMixin, BaseEventRecordDataTas
     interval = None
     event_mapping = None
     PROJECT_NAME = 'tracking_prod'
+
+    counter_category_name = 'Tracking Event Exports'
 
     def get_event_emission_time(self, event):
         return super(TrackingEventRecordDataTask, self).get_event_time(event)
@@ -688,13 +697,16 @@ class TrackingEventRecordDataTask(EventLogSelectionMixin, BaseEventRecordDataTas
         event, date_received = self.get_event_and_date_string(line) or (None, None)
         if event is None:
             return
+        self.incr_counter(self.counter_category_name, 'Inputs with Dates', 1)
 
         event_type = event.get('event_type')
         if event_type is None:
+            self.incr_counter(self.counter_category_name, 'Discard Missing Event Type', 1)
             return
 
         # Ignore events that begin with a slash (i.e. implicit events).
         if event_type.startswith('/'):
+            self.incr_counter(self.counter_category_name, 'Discard Implicit Events', 1)
             return
 
         username = event.get('username', '').strip()
@@ -707,12 +719,14 @@ class TrackingEventRecordDataTask(EventLogSelectionMixin, BaseEventRecordDataTas
 
         event_data = eventlog.get_event_data(event)
         if event_data is None:
+            self.incr_counter(self.counter_category_name, 'Discard Missing Event Data', 1)
             return
         # Put the fixed value back, so it can be properly mapped.
         event['event'] = event_data
 
         event_source = event.get('event_source')
         if event_source is None:
+            self.incr_counter(self.counter_category_name, 'Discard Missing Event Source', 1)
             return
 
         if (event_source, event_type) in self.known_events:
@@ -743,6 +757,8 @@ class TrackingEventRecordDataTask(EventLogSelectionMixin, BaseEventRecordDataTas
         record = EventRecord(**event_dict)
 
         key = (date_received, project_name)
+
+        self.incr_counter(self.counter_category_name, 'Output From Mapper', 1)
 
         # Convert to form for output by reducer here,
         # so that reducer doesn't do any conversion.
@@ -783,6 +799,8 @@ class SegmentEventRecordDataTask(SegmentEventLogSelectionMixin, BaseEventRecordD
 
     event_mapping = None
 
+    counter_category_name = 'Segment Event Exports'
+
     def _get_project_name(self, project_id):
         if project_id not in self.project_names:
             if self.config is None:
@@ -802,27 +820,27 @@ class SegmentEventRecordDataTask(SegmentEventLogSelectionMixin, BaseEventRecordD
                     event_time = self.extended_normalize_time(event[key])
                     if event_time is None:
                         log.error("Really unparseable %s time from event: %r", key, event)
-                        self.incr_counter('Event', 'Unparseable {} Time Field'.format(key), 1)
+                        self.incr_counter(self.counter_category_name, 'Quality Unparseable {} Time Field'.format(key), 1)
                     else:
                         # Log this for now, until we have confidence this is reasonable.
                         log.warning("Parsable unparseable type for %s time in event: %r", key, event)
-                        self.incr_counter('Event', 'Parsable unparseable for {} Time Field'.format(key), 1)
+                        self.incr_counter(self.counter_category_name, 'Quality Parsable unparseable for {} Time Field'.format(key), 1)
                 except Exception:
                     log.error("Unparseable %s time from event: %r", key, event)
-                    self.incr_counter('Event', 'Unparseable {} Time Field'.format(key), 1)
+                    self.incr_counter(self.counter_category_name, 'Quality Unparseable {} Time Field'.format(key), 1)
             return event_time
         except KeyError:
             log.error("Missing %s time from event: %r", key, event)
-            self.incr_counter('Event', 'Missing {} Time Field'.format(key), 1)
+            self.incr_counter(self.counter_category_name, 'Quality Missing {} Time Field'.format(key), 1)
             return None
         except TypeError:
             log.error("Bad type for %s time in event: %r", key, event)
-            self.incr_counter('Event', 'Bad type for {} Time Field'.format(key), 1)
+            self.incr_counter(self.counter_category_name, 'Quality Bad type for {} Time Field'.format(key), 1)
             return None
         except UnicodeEncodeError:
             # This is more specific than ValueError, so it is processed first.
             log.error("Bad encoding for %s time in event: %r", key, event)
-            self.incr_counter('Event', 'Bad encoding for {} Time Field'.format(key), 1)
+            self.incr_counter(self.counter_category_name, 'Quality Bad encoding for {} Time Field'.format(key), 1)
             return None
         except ValueError:
             # Try again, with a more powerful (and more flexible) parser.
@@ -830,15 +848,15 @@ class SegmentEventRecordDataTask(SegmentEventLogSelectionMixin, BaseEventRecordD
                 event_time = self.extended_normalize_time(event[key])
                 if event_time is None:
                     log.error("Unparseable %s time from event: %r", key, event)
-                    self.incr_counter('Event', 'Unparseable {} Time Field'.format(key), 1)
+                    self.incr_counter(self.counter_category_name, 'Quality Unparseable {} Time Field'.format(key), 1)
                 else:
                     # Log this for now, until we have confidence this is reasonable.
                     log.warning("Parsable bad value for %s time in event: %r", key, event)
-                    self.incr_counter('Event', 'Parsable bad value for {} Time Field'.format(key), 1)
+                    self.incr_counter(self.counter_category_name, 'Quality Parsable bad value for {} Time Field'.format(key), 1)
                 return event_time
             except Exception:
                 log.error("Bad value for %s time in event: %r", key, event)
-                self.incr_counter('Event', 'Bad value for {} Time Field'.format(key), 1)
+                self.incr_counter(self.counter_category_name, 'Quality Bad value for {} Time Field'.format(key), 1)
             return None
 
     def get_event_arrival_time(self, event):
@@ -929,29 +947,31 @@ class SegmentEventRecordDataTask(SegmentEventLogSelectionMixin, BaseEventRecordD
         return self.event_mapping
 
     def mapper(self, line):
+        self.incr_counter(self.counter_category_name, 'Inputs', 1)
+
         value = self.get_event_and_date_string(line)
         if value is None:
             return
         event, date_received = value
-        self.incr_counter('Segment_Event_Dist', 'Inputs with Dates', 1)
+        self.incr_counter(self.counter_category_name, 'Inputs with Dates', 1)
 
         segment_type = event.get('type')
-        self.incr_counter('Segment_Event_Dist', u'Type {}'.format(segment_type), 1)
+        self.incr_counter(self.counter_category_name, u'Subset Type {}'.format(segment_type), 1)
 
         channel = event.get('channel')
-        self.incr_counter('Segment_Event_Dist', u'Channel {}'.format(channel), 1)
+        self.incr_counter(self.counter_category_name, u'Subset Channel {}'.format(channel), 1)
 
         if segment_type == 'track':
             event_type = event.get('event')
 
             if event_type is None or date_received is None:
                 # Ignore if any of the keys is None
-                self.incr_counter('Segment_Event_Dist', 'Tracking with missing type', 1)
+                self.incr_counter(self.counter_category_name, 'Discard Tracking with missing type', 1)
                 return
 
             if event_type.startswith('/'):
                 # Ignore events that begin with a slash.  How many?
-                self.incr_counter('Segment_Event_Dist', 'Tracking with implicit type', 1)
+                self.incr_counter(self.counter_category_name, 'Discard Tracking with implicit type', 1)
                 return
 
             # Not all 'track' events have event_source information.  In particular, edx.bi.XX events.
@@ -964,22 +984,22 @@ class SegmentEventRecordDataTask(SegmentEventLogSelectionMixin, BaseEventRecordD
                     event_source = 'track-server'
                 elif (event_source, event_type) in self.known_events:
                     event_category = self.known_events[(event_source, event_type)]
-                self.incr_counter('Segment_Event_Dist', 'Tracking server', 1)
+                self.incr_counter(self.counter_category_name, 'Subset Type track And Channel server', 1)
             else:
                 # expect that channel is 'client'.
                 event_source = channel
-                self.incr_counter('Segment_Event_Dist', 'Tracking non-server', 1)
+                self.incr_counter(self.counter_category_name, 'Subset Type track And Channel Not server', 1)
 
         else:
-            # 'page' or 'identify'
+            # type is 'page' or 'identify' or 'screen'
             event_category = segment_type
             event_type = segment_type
             event_source = channel
 
-        self.incr_counter('Segment_Event_Dist', 'Output From Mapper', 1)
-
         project_id = event.get('projectId')
         project_name = self._get_project_name(project_id) or project_id
+
+        self.incr_counter(self.counter_category_name, u'Subset Project {}'.format(project_name), 1)
 
         event_dict = {'version': VERSION}
         self.add_calculated_event_entry(event_dict, 'input_file', self.get_map_input_file())
@@ -990,7 +1010,6 @@ class SegmentEventRecordDataTask(SegmentEventLogSelectionMixin, BaseEventRecordD
         self.add_calculated_event_entry(event_dict, 'timestamp', self.get_event_emission_time(event))
         self.add_calculated_event_entry(event_dict, 'received_at', self.get_event_arrival_time(event))
         self.add_calculated_event_entry(event_dict, 'date', self.convert_date(date_received))
-
         self.add_agent_info(event_dict, event.get('context', {}).get('userAgent'))
         self.add_agent_info(event_dict, event.get('properties', {}).get('context', {}).get('agent'))
 
@@ -999,6 +1018,8 @@ class SegmentEventRecordDataTask(SegmentEventLogSelectionMixin, BaseEventRecordD
 
         record = EventRecord(**event_dict)
         key = (date_received, project_name)
+
+        self.incr_counter(self.counter_category_name, 'Output From Mapper', 1)
 
         # Convert to form for output by reducer here,
         # so that reducer doesn't do any conversion.


### PR DESCRIPTION
The main goal is to provide easier access to event volumes and error rates in certain map-reduce tasks than is provided by logging.   A secondary goal was to provide some degree of completeness, so that if problems are identified at a coarse level, some finer-grained counts can provide further information.  Thirdly, the naming of counters is hopefully more self-documenting by following some conventions. 

Counters for events being removed from processing are prefixed with "Discard".   Counters for events that are subsetted by a certain property are prefixed by "Subset".    Counters for events that contain some data problem but are not removed from processing are prefixed with "Quality". 

This does not provide a measure of "total events per day", because counters only apply to a single map-reduce job, and the processing of segment and tracking log events are done in separate tasks. 

* Number of segment events per day: SegmentEventRecordDataTask:Segment Event Exports:Output From Mapper
* Number of tracking log events per day:  TrackingEventRecordDataTask:Tracking Event Exports:Output From Mapper
* Malformed events per day:
** Each workflow provides central output of :Event:Discard Parseable Event, while other forms of malformedness are addressed on a per-workflow basis.
** No errors currently found from Segment
** Tracking-loading task returns counts for Tracking Event Exports:Discard Missing Event Data
** Enrollment workflow checks for several things, but not currently encountering any problems.
** Video workflow checks for several things, but currently encountering only missing username, course_id, and video time offsets.

Enrollment and video workflows also have state machines which this instruments.  For Video, three main categories exist:  the video events themselves, then "viewing starts" and "viewing ends".   Events discarded from each are counted with more general categories as well as specific labels.   Categories include "Discard Video Missing Something", "Discard Viewing Start", and "Discard Viewing End".  Counts for what was not discarded are also maintained, as well as some subsets by event type.   

For Enrollment, there are three tasks that perform map-reduce.  CourseEnrollmentEventsTask, CourseEnrollmentTask, and CourseEnrollmentSummaryTask.  The first provides counts related to checking and discarding enrollment events.  The second and third process nearly-identical state machines, but differ only in aggregation.  So issues with state transitions are counted up similarly for both.    
