### PR TITLE
Ship metrics as both counters and gauges for alternative analysis.

### DIFF
--- a/scripts/collect-hadoop-metrics.py
+++ b/scripts/collect-hadoop-metrics.py
@@ -295,5 +295,6 @@ if __name__ == "__main__":
     statsd_client = statsd.StatsClient(statsd_host, statsd_port, prefix=statsd_prefix)
     for (metric_name, metric_value) in metrics:
         statsd_client.gauge(metric_name, metric_value)
+        statsd_client.incr(metric_name, metric_value)
 
     print "[collect-hadoop-metrics] Done.  Exiting."


### PR DESCRIPTION
Despite the branch name, I decided to ship the metrics as both counters and gauges.

This will let us experiment with counter-based visualizations while still populating our gauge-based versions.