### PR TITLE
Ship metrics to Graphite directly.

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -9,6 +9,7 @@ edx-opaque-keys==0.4    # AGPL
 edx-ccx-keys==0.2.1     # AGPL
 elasticsearch==1.7.0    # Apache
 filechunkio==1.8	# MIT
+graphitesend==0.10.0 # Apache
 html5lib==1.0b3 	# MIT
 isoweek==1.3.1		# BSD
 http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-1.2.2.zip  	# GPL v2 with FOSS License Exception
@@ -22,7 +23,6 @@ python-gnupg==0.3.9	# BSD
 pytz==2016.10		# ZPL
 requests==2.12.4        # Apache 2.0
 six==1.10.0		# MIT
-statsd==3.2.1  # MIT
 stevedore==1.19.1 	# Apache 2.0
 ua-parser==0.3.6 	# Apache
 urllib3==1.19.1         # MIT

--- a/scripts/collect-hadoop-metrics.py
+++ b/scripts/collect-hadoop-metrics.py
@@ -257,7 +257,7 @@ if __name__ == "__main__":
     # Load our configuration.
     if len(sys.argv) < 2:
         print "[collect-hadoop-metrics] You must specify the configuration file to load!  Exiting."
-        sys.exit(1)
+        sys.exit(0)
 
     conf_file = sys.argv[1]
     config = {}
@@ -267,7 +267,7 @@ if __name__ == "__main__":
             config = yaml.load(f)
     except IOError:
         print "[collect-hadoop-metrics] Error reading configuration file or configuration does not exist!  Exiting."
-        sys.exit(1)
+        sys.exit(0)
 
     input_config = config.get('input', {})
     output_config = config.get('output', {})
@@ -280,7 +280,7 @@ if __name__ == "__main__":
         hs_address = get_local_address_on_emr()
     if hs_address is None:
         print "[collect-hadoop-metrics] No HistoryServer address specified and unable to query instance metadata!  Exiting."
-        sys.exit(1)
+        sys.exit(0)
 
     print "[collect-hadoop-metrics] Targeting HistoryServer at '{}'.".format(hs_address)
 
@@ -289,15 +289,12 @@ if __name__ == "__main__":
     graphite_port = graphite_config.get('port', 2003)
     graphite_prefix = graphite_config.get('prefix', 'edx.analytics.emr')
 
-    # Actually collect the metrics.
-    metrics = []
     try:
-      metrics = collect_metrics(hs_address, metric_templates)
-    except Exception as ex:
-      print "[collect-hadoop-metrics] Caught exception while running collection: {}".format(str(ex))
+        metrics = collect_metrics(hs_address, metric_templates)
 
-    # Ship them to the local statsd endpoint.
-    stats_client = graphitesend.init(graphite_server=graphite_host, graphite_port=graphite_port, prefix=graphite_prefix, system_name='')
-    stats_client.send_list(metrics)
+        stats_client = graphitesend.init(graphite_server=graphite_host, graphite_port=graphite_port, prefix=graphite_prefix, system_name='')
+        stats_client.send_list(metrics)
+    except Exception as ex:
+        print "[collect-hadoop-metrics] Caught exception while running collection: {}".format(str(ex))
 
     print "[collect-hadoop-metrics] Done.  Exiting."

--- a/scripts/collect-hadoop-metrics.py
+++ b/scripts/collect-hadoop-metrics.py
@@ -262,8 +262,13 @@ if __name__ == "__main__":
 
     conf_file = sys.argv[1]
     config = {}
-    with open(conf_file, 'r') as f:
-        config = yaml.load(f)
+
+    try:
+        with open(conf_file, 'r') as f:
+            config = yaml.load(f)
+    except IOError:
+        print "[collect-hadoop-metrics] Error reading configuration file or configuration does not exist!  Exiting."
+        sys.exit(1)
 
     input_config = config.get('input', {})
     output_config = config.get('output', {})

--- a/scripts/collect-hadoop-metrics.py
+++ b/scripts/collect-hadoop-metrics.py
@@ -1,6 +1,5 @@
 import json
 import sys
-import time
 import boto3
 import graphitesend
 import requests
@@ -298,9 +297,7 @@ if __name__ == "__main__":
       print "[collect-hadoop-metrics] Caught exception while running collection: {}".format(str(ex))
 
     # Ship them to the local statsd endpoint.
-    emission_ts = int(time.time())
     stats_client = graphitesend.init(graphite_server=graphite_host, graphite_port=graphite_port, prefix=graphite_prefix, system_name='')
-    for (metric_name, metric_value) in metrics:
-        stats_client.send(metric_name, metric_value, emission_ts)
+    stats_client.send_list(metrics)
 
     print "[collect-hadoop-metrics] Done.  Exiting."

--- a/scripts/collect-hadoop-metrics.yaml.example
+++ b/scripts/collect-hadoop-metrics.yaml.example
@@ -3,7 +3,7 @@ input:
   templates:
     - "{cluster_name}.{job_flow_id}.{job_name}.{job_index}.{metric}"
 output:
-  statsd:
+  graphite:
     host: localhost
-    port: 8125
+    port: 2003
     prefix: edx.analytics.emr


### PR DESCRIPTION
Instead of first shipping metrics to statsd, and then onwards to Graphite, we should just ship them directly to Graphite.

As far as I can tell, we were seeing issues where metrics were being shipped from EMR master nodes to the Graphite machine we had running statsd, over UDP, and things were being mysteriously dropped.

We'll be shipping via TCP now, which eliminates at least one variable.  We're also dropping the baggage of statsd defaults such as namespacing metrics by type (like gauge vs counter) and automatic rate calculations, etc.