### PR TITLE
AN-8707 fix 

### DIFF
--- a/edx/analytics/tasks/insights/enrollments.py
+++ b/edx/analytics/tasks/insights/enrollments.py
@@ -1151,6 +1151,13 @@ class CourseProgramMetadataInsertToMysqlTask(CourseSummaryEnrollmentDownstreamMi
                                              MysqlInsertTask):  # pragma: no cover
     """Creates/populates the `course_program_metadata` Result Store table."""
 
+    overwrite = luigi.BooleanParameter(
+        default=True,
+        description='Overwrite the table when writing to it by default. Allow users to override this behavior if they '
+                    'want.',
+        significant=False
+    )
+
     @property
     def table(self):
         return 'course_program_metadata'

--- a/edx/analytics/tasks/insights/video.py
+++ b/edx/analytics/tasks/insights/video.py
@@ -770,6 +770,13 @@ class VideoTimelineDataTask(VideoTableDownstreamMixin, HiveQueryTask):
 class InsertToMysqlVideoTimelineTask(VideoTableDownstreamMixin, MysqlInsertTask):
     """Insert information about video timelines from a Hive table into MySQL."""
 
+    overwrite = luigi.BooleanParameter(
+        default=True,
+        description='Overwrite the table when writing to it by default. Allow users to override this behavior if they '
+                    'want.',
+        significant=False
+    )
+
     @property
     def table(self):  # pragma: no cover
         return 'video_timeline'
@@ -912,6 +919,13 @@ class VideoDataTask(VideoTableDownstreamMixin, HiveQueryTask):
 
 class InsertToMysqlVideoTask(VideoTableDownstreamMixin, MysqlInsertTask):
     """Insert summary information into the video table in MySQL."""
+
+    overwrite = luigi.BooleanParameter(
+        default=True,
+        description='Overwrite the table when writing to it by default. Allow users to override this behavior if they '
+                    'want.',
+        significant=False
+    )
 
     @property
     def table(self):  # pragma: no cover


### PR DESCRIPTION
Found that the default overwrite handler was previously set to true, but was dropped from the last production release.  This re-instates the overwrite handler's value back to true