### PR TITLE
Remove output() from VideoUsageTableTask.

### DIFF
--- a/edx/analytics/tasks/insights/video.py
+++ b/edx/analytics/tasks/insights/video.py
@@ -664,9 +664,6 @@ class VideoUsageTableTask(VideoTableDownstreamMixin, HiveTableTask):
             output_root=self.partition_location
         )
 
-    def output(self):  # pragma: no cover
-        return self.requires().output()
-
 
 class VideoTimelineTableTask(BareHiveTableTask):
     """Creates the Hive storage table used to hold video_timeline data."""


### PR DESCRIPTION
This method points to the usage data on disk, but the downstream tasks don't actually use this, but rather need to query it in Hive.  So the right output() is the one provided by HiveTableTask. 