### PR TITLE
Don't run a system package manager update when installing deps.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,9 @@ develop-local: uninstall
 
 system-requirements:
 ifeq (,$(wildcard /usr/bin/yum))
-	sudo apt-get update -q
 	# This is not great, we can't use these libraries on slave nodes using this method.
 	sudo apt-get install -y -q libmysqlclient-dev libpq-dev python-dev libffi-dev libssl-dev libxml2-dev libxslt1-dev
 else
-	sudo yum update -q -y
 	sudo yum install -y -q postgresql-devel libffi-devel
 endif
 


### PR DESCRIPTION
This seems to break EMR after they, presumably, added a new version of Java to the repositories used by EMR 4.x.  Updating the version of Java *after* hive-server2 is already running leads to a weird class loading issue.