### PR TITLE
Remove libatlas3gf-base.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ system-requirements:
 ifeq (,$(wildcard /usr/bin/yum))
 	sudo apt-get update -q
 	# This is not great, we can't use these libraries on slave nodes using this method.
-	sudo apt-get install -y -q libmysqlclient-dev libatlas3gf-base libpq-dev python-dev libffi-dev libssl-dev libxml2-dev libxslt1-dev
+	sudo apt-get install -y -q libmysqlclient-dev libpq-dev python-dev libffi-dev libssl-dev libxml2-dev libxslt1-dev
 else
 	sudo yum update -q -y
 	sudo yum install -y -q postgresql-devel libffi-devel


### PR DESCRIPTION
It is not needed, and doesn't exist by that name on Xenial.