### PR TITLE
Strip id.

### DIFF
--- a/edx/analytics/tasks/insights/module_engagement.py
+++ b/edx/analytics/tasks/insights/module_engagement.py
@@ -181,7 +181,7 @@ class ModuleEngagementDataTask(EventLogSelectionMixin, OverwriteOutputMixin, Map
         elif event_type == 'play_video':
             entity_type = 'video'
             user_actions.append('viewed')
-            entity_id = event_data.get('id')
+            entity_id = event_data.get('id', '').strip() # we have seen id values with leading newlines
         elif event_type.startswith('edx.forum.'):
             entity_type = 'discussion'
             if event_type.endswith('.created'):


### PR DESCRIPTION
Some play_video events are appearing with a newline character at the start of the id field:

\"id\": \"\\n52968fb55cd14c428c58069812ca28b1\"

This breaks module-engagement. This fix just strips out any new line characters. 