### PR TITLE
Add InsertToMysqlVideo*.allow_empty_insert

### DIFF
--- a/edx/analytics/tasks/insights/video.py
+++ b/edx/analytics/tasks/insights/video.py
@@ -778,6 +778,12 @@ class InsertToMysqlVideoTimelineTask(VideoTableDownstreamMixin, MysqlInsertTask)
                     'want.',
         significant=False
     )
+    allow_empty_insert = luigi.BooleanParameter(
+        default=False,
+        description='Allow the video table to be empty (e.g. if no video activity has occurred)',
+        config_path={'section': 'videos', 'name': 'allow_empty_insert'},
+        significant=False,
+    )
 
     @property
     def table(self):  # pragma: no cover
@@ -927,6 +933,12 @@ class InsertToMysqlVideoTask(VideoTableDownstreamMixin, MysqlInsertTask):
         description='Overwrite the table when writing to it by default. Allow users to override this behavior if they '
                     'want.',
         significant=False
+    )
+    allow_empty_insert = luigi.BooleanParameter(
+        default=False,
+        description='Allow the video table to be empty (e.g. if no video activity has occurred)',
+        config_path={'section': 'videos', 'name': 'allow_empty_insert'},
+        significant=False,
     )
 
     @property


### PR DESCRIPTION
Let `allow_empty_insert` be configurable for the `InsertToMysqlVideo*` tasks, because some deployments don't use video in their courses, or have quiet days when no one watches a video.

`allow_empty_insert` behaves like its equivalent on [`ModuleEngagementMysqlTask`](https://github.com/edx/edx-analytics-pipeline/blob/2da1413eebc6d0aa1a1fe3ba293a0e92e96405e7/edx/analytics/tasks/insights/module_engagement.py#L267):
* a boolean parameter
* default False
* configurable from the `[videos]` section in override.cfg