### PR TITLE
Handle problem-checks with bad answer_ids.

### DIFF
--- a/edx/analytics/tasks/insights/answer_dist.py
+++ b/edx/analytics/tasks/insights/answer_dist.py
@@ -1031,3 +1031,8 @@ def _check_answer_ids(answer_dict):
     for answer_id in answer_dict:
         if '\n' in answer_id or '\t' in answer_id:
             raise ValueError('Malformed answer_id')
+
+        try:
+            answer_id.encode('ascii')
+        except UnicodeEncodeError:
+            raise ValueError('Non-ascii answer_id')

--- a/edx/analytics/tasks/insights/tests/test_answer_dist.py
+++ b/edx/analytics/tasks/insights/tests/test_answer_dist.py
@@ -189,6 +189,11 @@ class ProblemCheckEventMapTest(InitializeOpaqueKeysMixin, ProblemCheckEventBaseT
         line = self.create_event_log_line()
         self.assert_no_map_output_for(line)
 
+    def test_invalid_answer_id_with_nonascii(self):
+        self.answer_id = u"R\ufffd\ufffd\ufffdn\u0010.Y\u0001\ufffd.\ufffd\u0007\u0013*\ufffd\ufffd\ufffd\ufffdI\ufffd3}"
+        line = self.create_event_log_line()
+        self.assert_no_map_output_for(line)
+
     def test_good_problem_check_event(self):
         # Here, we make the event as a dictionary since we're comparing based on dictionaries anyway.
         event = self.create_event_dict()


### PR DESCRIPTION
Rather than trying to output non-ascii answer id's, just screen out those that are not ascii.