### PR TITLE
Add overwrite flag to LastCountryOfUserTableTask.

### DIFF
--- a/edx/analytics/tasks/insights/location_per_course.py
+++ b/edx/analytics/tasks/insights/location_per_course.py
@@ -405,6 +405,7 @@ class LastCountryOfUserPartitionTask(LastCountryOfUserDownstreamMixin, HiveParti
     def hive_table_task(self):
         return LastCountryOfUserTableTask(
             warehouse_path=self.warehouse_path,
+            overwrite=self.overwrite,
         )
 
     @property


### PR DESCRIPTION
When testing ficus.master, it was found that running the location task
was resulting in multiple entries in the resultstore. The
last_country_of_user table is supposed to only have one partition of
data loaded into it, but when run with overwrite flag set, the table's
contents weren't being deleted. This resulted in a left join (against
student_courseenrollment) would have multiple entries per student
enrollment.

Fix is to drop and recreate the table each time, if the overwrite flag
is set.

This was first identified and fixed on Ficus.  See PR #400.