### PR TITLE
Revert "Add support for templating to Luigi configuration files. (#398)"

### DIFF
--- a/edx/analytics/tasks/launchers/local.py
+++ b/edx/analytics/tasks/launchers/local.py
@@ -7,7 +7,6 @@ Main method for running tasks on a local machine.
 
 """
 
-import argparse
 from contextlib import contextmanager
 import logging
 import os
@@ -40,10 +39,6 @@ OVERRIDE_CONFIGURATION_FILE = 'override.cfg'
 
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--additional-config', help='additional configuration file to be loaded after default/override', default=None, action='append')
-    arguments, _extra_args = parser.parse_known_args()
-
     # In order to see errors during extension loading, you can uncomment the next line.
     logging.basicConfig(level=logging.DEBUG)
 
@@ -51,23 +46,12 @@ def main():
     # TODO: launch tasks by their entry_point name
     stevedore.ExtensionManager('edx.analytics.tasks')
 
-    # Load the override configuration if it's specified/exists.
     configuration = luigi.configuration.get_config()
     if os.path.exists(OVERRIDE_CONFIGURATION_FILE):
-        log.debug('Loading override configuration \'%s\'...', OVERRIDE_CONFIGURATION_FILE)
+        log.debug('Using %s', OVERRIDE_CONFIGURATION_FILE)
         configuration.add_config_path(OVERRIDE_CONFIGURATION_FILE)
     else:
-        log.debug('Configuration file \'%s\' does not exist!', OVERRIDE_CONFIGURATION_FILE)
-
-    # Load any additional configuration files passed in.
-    if arguments.additional_config is not None:
-        for additional_config in arguments.additional_config:
-            if os.path.exists(additional_config):
-                log.debug('Loading additional configuration file \'%s\'...', additional_config)
-                configuration.add_config_path(additional_config)
-            else:
-                log.debug('Configuration file \'%s\' does not exist!', additional_config)
-
+        log.debug('Configuration file %s does not exist', OVERRIDE_CONFIGURATION_FILE)
 
     # Tell luigi what dependencies to pass to the Hadoop nodes
     # - edx.analytics.tasks is used to load the pipeline code, since we cannot trust all will be loaded automatically.

--- a/edx/analytics/tasks/launchers/remote.py
+++ b/edx/analytics/tasks/launchers/remote.py
@@ -10,15 +10,14 @@ import sys
 from urlparse import urlparse, parse_qsl
 import uuid
 
+
 STATIC_FILES_PATH = os.path.join(sys.prefix, 'share', 'edx.analytics.tasks')
 EC2_INVENTORY_PATH = os.path.join(STATIC_FILES_PATH, 'ec2.py')
-ANSIBLE_MAX_RETRY = 3
 
 REMOTE_DATA_DIR = '/var/lib/analytics-tasks'
 REMOTE_LOG_DIR = '/var/log/analytics-tasks'
+ANSIBLE_MAX_RETRY = 3
 
-REMOTE_CONFIG_DIR_BASE = 'config'
-REMOTE_CODE_DIR_BASE = 'repo'
 
 def main():
     """Parse arguments and run the remote task."""
@@ -36,7 +35,7 @@ def main():
     parser.add_argument('--user', help='remote user name to connect as', default=None)
     parser.add_argument('--private-key', help='a private key file to use to connect to the host', default=None)
     parser.add_argument('--override-config', help='config file to use to run the job', default=None)
-    parser.add_argument('--secure-config', help='config file in secure config repo to use to run the job', default=None, action='append')
+    parser.add_argument('--secure-config', help='config file in secure config repo to use to run the job', default=None)
     parser.add_argument('--secure-config-branch', help='git branch to checkout to find the secure config file', default=None)
     parser.add_argument('--secure-config-repo', help='git repository to clone to find the secure config file', default=os.getenv('ANALYTICS_SECURE_REPO'))
     parser.add_argument('--shell', help='execute a shell command on the cluster and exit', default=None)
@@ -54,16 +53,6 @@ def main():
     log('Running commands from path = {0}'.format(STATIC_FILES_PATH))
     uid = arguments.remote_name or str(uuid.uuid4())
     log('Remote name = {0}'.format(uid))
-
-    # Push in any secure config values that we got.
-    if arguments.secure_config:
-      for config_path in arguments.secure_config:
-        # We construct an absolute path here because the parameter that comes in is simply
-        # relative to the checkout of the configuration repository, but the local scheduler
-        # shouldn't have to know that, which in turn makes --additional-config agnostic of
-        # how we're using it for edX's purposes (with a repository).
-        arguments.launch_task_arguments.append('--additional-config')
-        arguments.launch_task_arguments.append(os.path.join(REMOTE_DATA_DIR, uid, REMOTE_CONFIG_DIR_BASE, config_path))
 
     if arguments.vagrant_path:
         parse_vagrant_ssh_config(arguments)
@@ -107,7 +96,6 @@ def run_task_playbook(inventory, arguments, uid):
             return prep_result
 
     data_dir = os.path.join(REMOTE_DATA_DIR, uid)
-    code_dir = os.path.join(data_dir, REMOTE_CODE_DIR_BASE)
     log_dir = os.path.join(REMOTE_LOG_DIR, uid)
     sudo_user = arguments.sudo_user
 
@@ -118,10 +106,9 @@ def run_task_playbook(inventory, arguments, uid):
 
     env_var_string = ' '.join('{0}={1}'.format(k, v) for k, v in env_vars.iteritems())
 
-    command = 'cd {code_dir} && . $HOME/.bashrc && {env_vars}{bg}{data_dir}/venv/bin/launch-task {task_arguments}{end_bg}'.format(
+    command = 'cd {data_dir}/repo && . $HOME/.bashrc && {env_vars}{bg}{data_dir}/venv/bin/launch-task {task_arguments}{end_bg}'.format(
         env_vars=env_var_string + ' ' if env_var_string else '',
         data_dir=data_dir,
-        code_dir=code_dir,
         task_arguments=' '.join(arguments.launch_task_arguments),
         log_dir=log_dir,
         bg='nohup ' if not arguments.wait else '',
@@ -173,7 +160,7 @@ def convert_args_to_extra_vars(arguments, uid):
         'pipeline': {
             'url': 'https://github.com/edx/edx-analytics-pipeline.git',
             'branch': 'origin/master',
-            'dir_name': REMOTE_CODE_DIR_BASE
+            'dir_name': 'repo'
         }
     }
     if arguments.repo:
@@ -193,13 +180,15 @@ def convert_args_to_extra_vars(arguments, uid):
         repos['secure'] = {
             'url': arguments.secure_config_repo,
             'branch': 'origin/release',
-            'dir_name': REMOTE_CONFIG_DIR_BASE
+            'dir_name': 'config'
         }
         if arguments.secure_config_branch:
             repos['secure']['branch'] = arguments.secure_config_branch
 
     if arguments.override_config:
         extra_vars['override_config'] = arguments.override_config
+    elif arguments.secure_config and 'secure' in repos:
+        extra_vars['secure_config'] = os.path.join(repos['secure']['dir_name'], arguments.secure_config)
 
     if arguments.extra_repo:
         # additional repos are specified as URLs with query string parameters for the branch and dir_name.

--- a/share/task.yml
+++ b/share/task.yml
@@ -184,6 +184,10 @@
     - name: configuration override removed
       file: path={{ working_repo_dir }}/override.cfg state=absent
 
+    - name: secure config installed
+      command: cp {{ working_dir }}/{{ secure_config }} {{ working_repo_dir }}/override.cfg
+      when: secure_config is defined
+
     - name: configuration override installed
       copy: src={{ override_config }} dest={{ working_repo_dir }}/override.cfg mode=644
       when: override_config is defined


### PR DESCRIPTION
This reverts commit 82c99915b43a1eab6ac1de0e73d8c152efae4c43.

There's an issue with what Luigi expects to find for command-line arguments that doesn't quite mesh with what I was trying to do here, and the options to remedy it are all with their cons, so reverting this for now to not block up other things being mergable/deployable.