### PR TITLE
Add support for templating to Luigi configuration files, redux.

### DIFF
--- a/edx/analytics/tasks/launchers/__init__.py
+++ b/edx/analytics/tasks/launchers/__init__.py
@@ -1,0 +1,9 @@
+import os
+
+REMOTE_DATA_DIR = '/var/lib/analytics-tasks'
+REMOTE_LOG_DIR = '/var/log/analytics-tasks'
+
+REMOTE_CONFIG_DIR_BASE = 'config'
+
+# The 'automation' bit is hard-coded. *shrug*
+REMOTE_CONFIG_DIR = os.path.join(REMOTE_DATA_DIR, 'automation', REMOTE_CONFIG_DIR_BASE)

--- a/edx/analytics/tasks/launchers/__init__.py
+++ b/edx/analytics/tasks/launchers/__init__.py
@@ -1,9 +1,0 @@
-import os
-
-REMOTE_DATA_DIR = '/var/lib/analytics-tasks'
-REMOTE_LOG_DIR = '/var/log/analytics-tasks'
-
-REMOTE_CONFIG_DIR_BASE = 'config'
-
-# The 'automation' bit is hard-coded. *shrug*
-REMOTE_CONFIG_DIR = os.path.join(REMOTE_DATA_DIR, 'automation', REMOTE_CONFIG_DIR_BASE)

--- a/edx/analytics/tasks/launchers/local.py
+++ b/edx/analytics/tasks/launchers/local.py
@@ -46,10 +46,6 @@ def main():
         default=None, action='append')
     arguments, _extra_args = parser.parse_known_args()
 
-    # This is a relative level of terrible depending on who you are.  We're removing our --additional-config command
-    # arguments because Luigi will blow up if the underlying workflow isn't actually saying that it expects to see
-    # an argument called --additional-config.
-
     # We get a cleaned command-line arguments list, free of the arguments *we* care about, since Luigi will throw
     # errors when it sees arguments that it or the workflow didn't specify.  We pass these in when invoking Luigi.
     cmdline_args = get_cleaned_command_line_args()

--- a/edx/analytics/tasks/launchers/local.py
+++ b/edx/analytics/tasks/launchers/local.py
@@ -7,6 +7,7 @@ Main method for running tasks on a local machine.
 
 """
 
+import argparse
 from contextlib import contextmanager
 import logging
 import os
@@ -39,6 +40,10 @@ OVERRIDE_CONFIGURATION_FILE = 'override.cfg'
 
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--additional-config', help='additional configuration file to be loaded after default/override', default=None, action='append')
+    arguments, _extra_args = parser.parse_known_args()
+
     # In order to see errors during extension loading, you can uncomment the next line.
     logging.basicConfig(level=logging.DEBUG)
 
@@ -46,12 +51,23 @@ def main():
     # TODO: launch tasks by their entry_point name
     stevedore.ExtensionManager('edx.analytics.tasks')
 
+    # Load the override configuration if it's specified/exists.
     configuration = luigi.configuration.get_config()
     if os.path.exists(OVERRIDE_CONFIGURATION_FILE):
-        log.debug('Using %s', OVERRIDE_CONFIGURATION_FILE)
+        log.debug('Loading override configuration \'%s\'...', OVERRIDE_CONFIGURATION_FILE)
         configuration.add_config_path(OVERRIDE_CONFIGURATION_FILE)
     else:
-        log.debug('Configuration file %s does not exist', OVERRIDE_CONFIGURATION_FILE)
+        log.debug('Configuration file \'%s\' does not exist!', OVERRIDE_CONFIGURATION_FILE)
+
+    # Load any additional configuration files passed in.
+    if arguments.additional_config is not None:
+        for additional_config in arguments.additional_config:
+            if os.path.exists(additional_config):
+                log.debug('Loading additional configuration file \'%s\'...', additional_config)
+                configuration.add_config_path(additional_config)
+            else:
+                log.debug('Configuration file \'%s\' does not exist!', additional_config)
+
 
     # Tell luigi what dependencies to pass to the Hadoop nodes
     # - edx.analytics.tasks is used to load the pipeline code, since we cannot trust all will be loaded automatically.

--- a/edx/analytics/tasks/launchers/remote.py
+++ b/edx/analytics/tasks/launchers/remote.py
@@ -10,8 +10,6 @@ import sys
 from urlparse import urlparse, parse_qsl
 import uuid
 
-from . import *
-
 STATIC_FILES_PATH = os.path.join(sys.prefix, 'share', 'edx.analytics.tasks')
 EC2_INVENTORY_PATH = os.path.join(STATIC_FILES_PATH, 'ec2.py')
 ANSIBLE_MAX_RETRY = 3

--- a/share/task.yml
+++ b/share/task.yml
@@ -184,10 +184,6 @@
     - name: configuration override removed
       file: path={{ working_repo_dir }}/override.cfg state=absent
 
-    - name: secure config installed
-      command: cp {{ working_dir }}/{{ secure_config }} {{ working_repo_dir }}/override.cfg
-      when: secure_config is defined
-
     - name: configuration override installed
       copy: src={{ override_config }} dest={{ working_repo_dir }}/override.cfg mode=644
       when: override_config is defined


### PR DESCRIPTION
This approach is intended to utilize the fact that Luigi's configuration code is based on Python's ConfigParser, which has native support for templated variables.

The catch is that the variables must be present in the config already, and we intended to load multiple files, in order, to make these "base" variables available to the templatized configurations loaded after.

This PR adds support to the remote and local launchers, as well as changes the small bootstrap task run through Ansible, to allow passing in multiple configuration files from the secure configuration repository to be loaded.