### PR TITLE
Add backquotes for additional Hive columns.

### DIFF
--- a/edx/analytics/tasks/warehouse/load_internal_reporting_user_activity.py
+++ b/edx/analytics/tasks/warehouse/load_internal_reporting_user_activity.py
@@ -58,7 +58,7 @@ class AggregateInternalReportingUserActivityTableHive(HiveTableFromQueryTask):
             SELECT
               au.id
             , uad.course_id
-            , uad.date
+            , uad.`date`
             , uad.category
             , uad.count
             FROM auth_user au


### PR DESCRIPTION
This is needed for upgrading past Hive 1.2.

It turns out that AggregateInternalReportingUserActivityTableHive is the one task in user_activity stuff that is not included in acceptance tests, so we didn't catch this sooner. 