### PR TITLE
Do not use --no-cache-dir for pre.txt.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ install: requirements uninstall
 	python setup.py install --force
 
 bootstrap: uninstall
-	pip install -U -r requirements/pre.txt --no-cache-dir
+	pip install -U -r requirements/pre.txt
 	pip install -U -r requirements/base.txt --no-cache-dir
 	python setup.py install --force
 
@@ -28,7 +28,7 @@ else
 endif
 
 requirements:
-	pip install -U -r requirements/pre.txt --no-cache-dir
+	pip install -U -r requirements/pre.txt
 	pip install -U -r requirements/default.txt --no-cache-dir
 	pip install -U -r requirements/extra.txt --no-cache-dir
 


### PR DESCRIPTION
The --no-cache-dir option is not defined on older versions of pip.
The pre.txt requirements specifically upgrade to a newer pip, so
the option may not work on that file, but should work fine after it
has been loaded.