### PR TITLE
Update boto to support eu-central-1 usage.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 # These packages are required for bootstrapping.
 
 ansible==1.4.5 --no-binary ansible         # GPL v3 License
-boto==2.22.1            # MIT
+boto==2.34.0            # MIT
 ecdsa==0.13 		# MIT
 Jinja2==2.8.1		# BSD
 pycrypto==2.6.1 	# public domain


### PR DESCRIPTION
Long story short, the `eu-central-1` AWS region has some idiosyncrasies that were accounted for in code by boto, but not on the current version of it that we use.

This just uprevs the version of boto to something that supports talking to `eu-central-1`, which Open edX users have been trying to work with, to much dismay, on the code as-is.