### PR TITLE
Update boto.cfg to support V4 signature

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 # These packages are required for bootstrapping.
 
 ansible==1.4.5 --no-binary ansible          # GPL v3 License
-boto==2.22.1            # MIT
+boto==2.48.0            # MIT
 ecdsa==0.13 		# MIT
 Jinja2==2.8.1		# BSD
 pycrypto==2.6.1 	# public domain

--- a/share/boto.cfg
+++ b/share/boto.cfg
@@ -1,3 +1,7 @@
 [Boto]
 metadata_service_timeout = 60.0
 metadata_service_num_attempts = 60
+[s3]
+use-sigv4 = True
+[ec2]
+use-sigv4 = True

--- a/share/boto.cfg
+++ b/share/boto.cfg
@@ -3,5 +3,8 @@ metadata_service_timeout = 60.0
 metadata_service_num_attempts = 60
 [s3]
 use-sigv4 = True
+host = s3.eu-central-1.amazonaws.com
 [ec2]
 use-sigv4 = True
+host = s3.eu-central-1.amazonaws.com
+

--- a/share/task.yml
+++ b/share/task.yml
@@ -194,6 +194,9 @@
 
     - name: boto configured
       copy: src=boto.cfg dest={{ working_repo_dir }}/.boto mode=644
+      
+    - name: awscli upgraded
+      command: sudo pip install awscli --upgrade
 
     - name: show working directory
       debug: var=working_repo_dir


### PR DESCRIPTION
Updated the boto.cfg file to support supports the V4 signature in certain AWS regions.