### PR TITLE
Event Exporter Improved Encryption Logging & Error Handling 

### DIFF
--- a/edx/analytics/tasks/util/encrypt.py
+++ b/edx/analytics/tasks/util/encrypt.py
@@ -4,6 +4,7 @@ Tasks for performing encryption on export files.
 from contextlib import contextmanager
 import logging
 import tempfile
+import datetime
 
 import gnupg
 
@@ -35,7 +36,8 @@ def get_key_from_target(key_file_target):
 
 
 @contextmanager
-def make_encrypted_file(output_file, key_file_targets, recipients=None, progress=None, dir=None):
+def make_encrypted_file(output_file, key_file_targets, recipients=None, progress=None, dir=None,
+                        hadoop_counter_incr_func=None):
     """
     Creates a file object to be written to, whose contents will afterwards be encrypted.
 
@@ -44,12 +46,15 @@ def make_encrypted_file(output_file, key_file_targets, recipients=None, progress
         key_file_targets: a list of luigi.Target objects defining the gpg public key files to be loaded.
         recipients:  an optional list of recipients to be loaded.  If not specified, uses all loaded keys.
         progress:  a function that is called periodically as progress is made.
+        hadoop_counter_incr_func:  A callback to a function that can generate MR counters so that non-critical GPG
+            messages can be promoted to a visible section of the MR run log.
     """
     with make_temp_directory(prefix="encrypt", dir=dir) as temp_dir:
         # Use temp directory to hold gpg keys.
         gpg = gnupg.GPG(gnupghome=temp_dir)
         gpg.encoding = 'utf-8'
-        _import_key_files(gpg, key_file_targets)
+        _import_key_files(gpg_instance=gpg, key_file_targets=key_file_targets,
+                          hadoop_counter_incr_func=hadoop_counter_incr_func)
 
         # Create a temp file to contain the unencrypted output, in the same temp directory.
         with tempfile.NamedTemporaryFile(dir=temp_dir, delete=False) as temp_input_file:
@@ -67,7 +72,7 @@ def make_encrypted_file(output_file, key_file_targets, recipients=None, progress
             copy_file_to_file(temp_encrypted_file, output_file, progress)
 
 
-def _import_key_files(gpg_instance, key_file_targets):
+def _import_key_files(gpg_instance, key_file_targets, hadoop_counter_incr_func):
     """
     Load key-file targets into the GPG instance.
 
@@ -75,17 +80,52 @@ def _import_key_files(gpg_instance, key_file_targets):
     """
     for key_file_target in key_file_targets:
         log.info("Importing keyfile from %s", key_file_target.path)
-        gpg_instance.import_keys(get_key_from_target(key_file_target))
+        import_result = gpg_instance.import_keys(get_key_from_target(key_file_target))
+
+        for key_fingerprint in import_result.fingerprints:
+            pub_keys = gpg_instance.list_keys()
+            for test_key in pub_keys:
+                if test_key["fingerprint"] == key_fingerprint:
+                    if len(test_key["expires"]) > 0:
+                        current_time = datetime.datetime.now()
+                        next_week = current_time + datetime.timedelta(days=7)
+                        key_expire = datetime.datetime.fromtimestamp(int(test_key["expires"]))
+
+                        if current_time > key_expire:
+                            # Ignore this error for now because a more serious and appropriate IOException will be
+                            # generated when the key is used for encryption
+                            log.error("Error key with fingerprint: '%s' and recipient '%s' has expired!!!",
+                                      key_fingerprint, test_key["uids"])
+                            for recipient in test_key["uids"]:
+                                hadoop_counter_incr_func("GPG Key for {} has expired".format(recipient))
+                                hadoop_counter_incr_func("Keys expired")
+                        elif next_week > key_expire:
+                            log.info("Warning key with fingerprint: " +
+                                     "'%s' and recipient '%s' will expire in the next week",
+                                     key_fingerprint, test_key["uids"])
+                            for recipient in test_key["uids"]:
+                                hadoop_counter_incr_func("GPG Key for {} is near expiry".format(recipient))
+                                hadoop_counter_incr_func("Keys expiring")
 
 
 def _encrypt_file(gpg_instance, input_file, encrypted_filepath, recipients):
     """Encrypts a given file open for read, and writes result to a file."""
     log.info('Generating encrypted file: %s', encrypted_filepath)
-    gpg_instance.encrypt_file(
+    encryption_result = gpg_instance.encrypt_file(
         input_file,
         recipients,
         always_trust=True,
         output=encrypted_filepath,
         armor=False,
     )
-    log.info('Encryption complete.')
+
+    if not encryption_result.ok:
+        status = getattr(encryption_result, "status", "")
+        stderr = getattr(encryption_result, "stderr", "")
+        log.error("Encrypted file completed: %s", str(encryption_result.ok))
+        log.error("Encryption status: %s", status)
+        log.error("Encryption error: %s", stderr)
+
+        raise IOError("Error while encrypting.  Status: {}  StdErr: {}".format(status, stderr))
+
+    log.info('Encryption process complete.')


### PR DESCRIPTION
This work is originally for bug fix DE-274, with the final work captured in DE-282.  The target is to improve logging during GPG encryption failures and to allow other organizations to continue to receive exported events when one encryption process fails.  Reviews are gladly welcomed on this one as I'm doing a bulk capture of IOErrors and it will do the job but feels like overkill.