### PR TITLE
Workaround for travis boto issue with GCE. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+
 cache: pip
 
 addons:
@@ -9,6 +10,9 @@ addons:
       - libblas-dev
       - liblapack-dev
       - libatlas-base-dev
+
+before_install:
+  - export BOTO_CONFIG=/dev/null
 
 script:
   - make test


### PR DESCRIPTION
Workaround is to override BOTO_CONFIG so it's not pulling in extraneous values.

See https://github.com/travis-ci/travis-ci/issues/7940 for details and the proposed workaround. 