### PR TITLE
Speed up finance report

### DIFF
--- a/edx/analytics/tasks/warehouse/financial/payment.py
+++ b/edx/analytics/tasks/warehouse/financial/payment.py
@@ -1,17 +1,23 @@
 
 import luigi
+from luigi import date_interval
+from luigi.configuration import get_config
 
 from edx.analytics.tasks.warehouse.financial.cybersource import IntervalPullFromCybersourceTask
 from edx.analytics.tasks.warehouse.financial.paypal import PaypalTransactionsIntervalTask
+from edx.analytics.tasks.util.url import ExternalURL, url_path_join
+from edx.analytics.tasks.util.hive import WarehouseMixin
 
 
-class PaymentTask(luigi.WrapperTask):
-
+class PaymentTaskMixin(object):
     import_date = luigi.DateParameter()
     cybersource_merchant_ids = luigi.Parameter(
         default_from_config={'section': 'payment', 'name': 'cybersource_merchant_ids'},
         is_list=True
     )
+
+
+class PaymentTask(PaymentTaskMixin, luigi.WrapperTask):
 
     def requires(self):
         yield PaypalTransactionsIntervalTask(
@@ -25,3 +31,30 @@ class PaymentTask(luigi.WrapperTask):
 
     def output(self):
         return [task.output() for task in self.requires()]
+
+
+class PaymentValidationTask(WarehouseMixin, PaymentTaskMixin, luigi.WrapperTask):
+    """Task to validate existence of Payment data."""
+
+    paypal_interval_start = luigi.DateParameter(
+        default_from_config={'section': 'paypal', 'name': 'interval_start'},
+        significant=False,
+    )
+
+    def requires(self):
+        paypal_interval = date_interval.Custom(self.paypal_interval_start, self.import_date)
+
+        for date in paypal_interval:
+            url = url_path_join(self.warehouse_path, 'payments', 'dt=' + date.isoformat(), 'paypal.tsv')
+            yield ExternalURL(url=url)
+
+        config = get_config()
+        for merchant_id in self.cybersource_merchant_ids:
+            section_name = 'cybersource:' + merchant_id
+            interval_start = luigi.DateParameter().parse(config.get(section_name, 'interval_start'))
+            cybersource_interval = date_interval.Custom(interval_start, self.import_date)
+
+            for date in cybersource_interval:
+                filename = "cybersource_{}.tsv".format(merchant_id)
+                url = url_path_join(self.warehouse_path, 'payments', 'dt=' + date.isoformat(), filename)
+                yield ExternalURL(url=url)


### PR DESCRIPTION
I've ran this and compared the numbers between our current workflow, I couldn't get an exact match as the current workflow last succeeded on 4th and I ran the optimized one on 7th, but the two result sets only differed by some extra data produced by the optimized version.

I plan to compare with data produced by the existing workflow for 7th with the one produced by this.

The problem I see is making sure we have a complete build every day or there could be missing data. We could also overwrite paypal/cybersource data for the last n days, similar to what we do for enrollments, module-engagement.

It completed in 3 hours.