### PR TITLE
Cleaned up and added logic to figure out the latest completion date.

### DIFF
--- a/edx/analytics/tasks/warehouse/financial/payment.py
+++ b/edx/analytics/tasks/warehouse/financial/payment.py
@@ -1,23 +1,17 @@
 
 import luigi
-from luigi import date_interval
-from luigi.configuration import get_config
 
-from edx.analytics.tasks.warehouse.financial.cybersource import IntervalPullFromCybersourceTask
-from edx.analytics.tasks.warehouse.financial.paypal import PaypalTransactionsIntervalTask
-from edx.analytics.tasks.util.url import ExternalURL, url_path_join
-from edx.analytics.tasks.util.hive import WarehouseMixin
+from edx.analytics.tasks.warehouse.financial.cybersource import IntervalPullFromCybersourceTask, CybersourceDataValidationTask
+from edx.analytics.tasks.warehouse.financial.paypal import PaypalTransactionsIntervalTask, PaypalDataValidationTask
 
 
-class PaymentTaskMixin(object):
+class PaymentTask(luigi.WrapperTask):
+
     import_date = luigi.DateParameter()
     cybersource_merchant_ids = luigi.Parameter(
         default_from_config={'section': 'payment', 'name': 'cybersource_merchant_ids'},
         is_list=True
     )
-
-
-class PaymentTask(PaymentTaskMixin, luigi.WrapperTask):
 
     def requires(self):
         yield PaypalTransactionsIntervalTask(
@@ -33,28 +27,11 @@ class PaymentTask(PaymentTaskMixin, luigi.WrapperTask):
         return [task.output() for task in self.requires()]
 
 
-class PaymentValidationTask(WarehouseMixin, PaymentTaskMixin, luigi.WrapperTask):
+class PaymentValidationTask(luigi.WrapperTask):
     """Task to validate existence of Payment data."""
 
-    paypal_interval_start = luigi.DateParameter(
-        default_from_config={'section': 'paypal', 'name': 'interval_start'},
-        significant=False,
-    )
+    import_date = luigi.DateParameter()
 
     def requires(self):
-        paypal_interval = date_interval.Custom(self.paypal_interval_start, self.import_date)
-
-        for date in paypal_interval:
-            url = url_path_join(self.warehouse_path, 'payments', 'dt=' + date.isoformat(), 'paypal.tsv')
-            yield ExternalURL(url=url)
-
-        config = get_config()
-        for merchant_id in self.cybersource_merchant_ids:
-            section_name = 'cybersource:' + merchant_id
-            interval_start = luigi.DateParameter().parse(config.get(section_name, 'interval_start'))
-            cybersource_interval = date_interval.Custom(interval_start, self.import_date)
-
-            for date in cybersource_interval:
-                filename = "cybersource_{}.tsv".format(merchant_id)
-                url = url_path_join(self.warehouse_path, 'payments', 'dt=' + date.isoformat(), filename)
-                yield ExternalURL(url=url)
+        yield PaypalDataValidationTask(import_date=self.import_date)
+        yield CybersourceDataValidationTask(import_date=self.import_date)


### PR DESCRIPTION
Currently, finance-report need to be successfully completed each day in order to produce correct data. 
The new logic looks up the latest completion date and builds dependencies accordingly. 

This would allow us to run this regardless if the job had failed on previous days. 