### PR TITLE
Use merchant close date to compute interval.

### DIFF
--- a/edx/analytics/tasks/warehouse/financial/paypal.py
+++ b/edx/analytics/tasks/warehouse/financial/paypal.py
@@ -698,7 +698,7 @@ class PaypalTransactionsIntervalTask(PaypalTaskMixin, WarehouseMixin, luigi.Wrap
             self.output_root = self.warehouse_path
 
         path = url_path_join(self.warehouse_path, 'payments')
-        path_targets = PathSetTask([path]).output()
+        path_targets = PathSetTask([path], include=['*paypal.tsv']).output()
         paths = list(set([os.path.dirname(target.path) for target in path_targets]))
         dates = [path.rsplit('/', 2)[-1] for path in paths]
         latest_date = sorted(dates)[-1]


### PR DESCRIPTION
Default interval_end from config if present restricting look up to cybersource API. 

Only caveat I see here is that selection interval would go beyond the interval_end from config, but would still work correctly as it would only look up payment data files for the particular merchant.