### PR TITLE
Upgrade setuptools, and other supporting packages.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,17 +9,24 @@ pycrypto==2.6.1 	# public domain
 # The following are dependencies pulled in by the above,
 # but are pinned here.
 
-cffi==1.9.1
-cryptography==1.7.1
+asn1crypto==0.22.0
+bcrypt==3.1.3
+cffi==1.10.0
+cryptography==2.0.3
 enum34==1.1.6
-httplib2==0.9.2		# MIT
-idna==2.2
-ipaddress==1.0.17
-MarkupSafe==0.23	# BSD
-paramiko==2.1.1 	# LGPL
-pyasn1==0.1.9
-pycparser==2.17
-PyYAML==3.12		# MIT License
-setuptools==32.3.1
+httplib2==0.10.3
+idna==2.6
+ipaddress==1.0.18
+MarkupSafe==1.0
+paramiko==2.2.1
+pyasn1==0.3.4
+pycparser==2.18
+PyNaCl==1.1.2
+PyYAML==3.12
 six==1.10.0
 
+# Already present, but not affected by the above, is setuptools and wheel.
+# Pin these here as well.
+
+setuptools==36.4.0
+wheel==0.30.0

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -5,8 +5,8 @@
 argparse==1.2.1 	# Python Software Foundation License
 boto3==1.4.4 # Apache 2.0
 ciso8601==1.0.3         # MIT
-edx-opaque-keys==0.4    # AGPL
 edx-ccx-keys==0.2.1     # AGPL
+edx-opaque-keys==0.4    # AGPL
 elasticsearch==1.7.0    # Apache
 filechunkio==1.8	# MIT
 graphitesend==0.10.0 # Apache
@@ -36,13 +36,19 @@ git+https://github.com/edx/pyinstrument.git@a35ff76df4c3d5ff9a2876d859303e33d895
 # These dependencies are pulled in by the above requirements,
 # and are pinned here.
 
-distlib==0.2.4
+botocore==1.5.95
+distlib==0.2.2
+docutils==0.14
 future==0.16.0
-pymongo==3.4.0		# Apache 2.0
-pyOpenSSL==16.2.0       # Apache 2.0
-pbr==1.10.0 		# Apache
+futures==3.1.1
+jmespath==0.9.3
+pbr==3.1.1
+pymongo==3.5.1
+pyOpenSSL==17.2.0
+s3transfer==0.1.11
 
-# These dependencies are already pulled in by earlier requirements (e.g.
+
+# These dependencies are already pulled in by earlier requirements (e.g. base.txt)
 # and are NOT pinned here.
 
 # cffi==1.9.1             # MIT
@@ -54,12 +60,6 @@ pbr==1.10.0 		# Apache
 # pycparser==2.17         # BSD
 # setuptools==32.3.1
 
-# These dependencies are not used?
 
-# backports_abc==0.5
-# certifi==2016.9.26
-# mechanize==0.2.5	# BSD
-# ndg-httpsclient==0.4.2  # BSD
-# singledispatch==3.4.0.3
-# tornado==4.4.2 		# Apache 2.0
-# wsgiref==0.1.2 		# ZPL
+
+

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,21 +13,21 @@ pylint==1.6.4
 # are being pinned.
 
 astroid==1.4.9
-backports.functools-lru-cache==1.3
+backports.functools-lru-cache==1.4
 configparser==3.5.0
 funcsigs==1.0.2
 inflect==0.2.5
-isort==4.2.5
+isort==4.2.15
 jinja2-pluralize==0.3.0
-lazy-object-proxy==1.2.2
-mccabe==0.5.3
-wrapt==1.10.8
+lazy-object-proxy==1.3.1
+mccabe==0.6.1
+Pygments==2.2.0
+wrapt==1.10.11
 
 # dependencies that are already pinned earlier.
 
-# Jinja2==2.8.1
-# MarkupSafe==0.23
-# pbr==1.10.0
-# python-dateutil==2.6.0
-# Pygments==2.1.3
-# six==1.10.0
+Jinja2==2.8.1
+MarkupSafe==1.0
+pbr==3.1.1
+python-dateutil==2.6.0
+six==1.10.0


### PR DESCRIPTION
The old pinned version of setuptools seemed to be breaking Travis builds.  This upgrades to the latest version of setuptools.

While in here changing dependencies, let the pinned values for supporting modules float to their most recent valid release.   This does not upgrade any of the explicitly required packages, only the packages that the required packages pull in.  

Test.txt should also be pinning the dependencies specified earlier, so that it doesn't install the latest of these packages (as it sometimes does, depending on the order of makefile calls).

This builds cleanly on Travis, and runs locally and on analyticstack.  Currently running acceptance tests.