### PR TITLE
Brian/also load json events

### DIFF
--- a/edx/analytics/tasks/common/bigquery_load.py
+++ b/edx/analytics/tasks/common/bigquery_load.py
@@ -9,16 +9,22 @@ import urlparse
 
 import luigi
 
-from google.cloud import bigquery
-from google.oauth2 import service_account
-from google.cloud.exceptions import NotFound
-
 from edx.analytics.tasks.util.url import ExternalURL, url_path_join
 from edx.analytics.tasks.util.overwrite import OverwriteOutputMixin
 from edx.analytics.tasks.util.hive import WarehouseMixin
 
-
 log = logging.getLogger(__name__)
+
+try:
+    from google.cloud import bigquery
+    from google.oauth2 import service_account
+    from google.cloud.exceptions import NotFound
+    bigquery_available = True  # pylint: disable=invalid-name
+except ImportError:
+    log.warn('Unable to import Bigquery libraries')
+    # On hadoop slave nodes we don't have bigquery libraries installed,
+    # so just fail noisily if we attempt to use these libraries there.
+    bigquery_available = False  # pylint: disable=invalid-name
 
 
 RETRY_LIMIT = 500
@@ -76,6 +82,11 @@ class BigQueryTarget(luigi.Target):
             tmp.close()
             os.unlink(tmp.name)
 
+    def marker_table_exists(self):
+        dataset = self.client.dataset(self.dataset_id)
+        table = dataset.table('table_updates')
+        return table.exists()
+
     def create_marker_table(self):
         marker_table_schema = [
             bigquery.SchemaField('update_id', 'STRING'),
@@ -87,10 +98,36 @@ class BigQueryTarget(luigi.Target):
         if not table.exists():
             table.create()
 
+    def clear_marker_table(self):
+        if not self.marker_table_exists():
+            return
+
+        query_string = "DELETE {dataset}.table_updates WHERE target_table='{dataset}.{table}'".format(
+            dataset=self.dataset_id, table=self.table
+        )
+        query = self.client.run_sync_query(query_string)
+        query.use_legacy_sql = False
+        query.run()
+
+    def clear_marker_table_entry(self):
+        if not self.marker_table_exists():
+            return
+
+        query_string = "DELETE {dataset}.table_updates WHERE update_id='{update_id}' AND target_table='{dataset}.{table}'".format(
+            dataset=self.dataset_id, update_id=self.update_id, table=self.table
+        )
+        query = self.client.run_sync_query(query_string)
+        query.use_legacy_sql = False
+        query.run()
+
     def exists(self):
-        query_string = "SELECT 1 FROM {dataset}.table_updates where update_id = '{update_id}'".format(
+        if not self.marker_table_exists():
+            return False
+
+        query_string = "SELECT 1 FROM {dataset}.table_updates WHERE update_id='{update_id}' AND target_table='{dataset}.{table}'".format(
             dataset=self.dataset_id,
             update_id=self.update_id,
+            table=self.table,
         )
         log.debug(query_string)
 
@@ -103,11 +140,20 @@ class BigQueryTarget(luigi.Target):
 
         return len(query.rows) == 1
 
-
-class BigQueryLoadTask(OverwriteOutputMixin, luigi.Task):
+class BigQueryLoadDownstreamMixin(OverwriteOutputMixin):
 
     dataset_id = luigi.Parameter()
     credentials = luigi.Parameter()
+    max_bad_records = luigi.IntParameter(
+        default=0, description="Number of bad records ignored by BigQuery before failing a load job."
+    )
+
+
+class BigQueryLoadTask(BigQueryLoadDownstreamMixin, luigi.Task):
+
+    # Regardless whether loading only a partition or an entire table,
+    # we still need a date to use to mark the table.
+    date = luigi.DateParameter()
 
     output_target = None
     required_tasks = None
@@ -133,6 +179,19 @@ class BigQueryLoadTask(OverwriteOutputMixin, luigi.Task):
         raise NotImplementedError
 
     @property
+    def table_description(self):
+        return ''
+
+    @property
+    def table_friendly_name(self):
+        return ''
+
+    @property
+    def partitioning_type(self):
+        """Set to 'DAY' in order to partition by day.  Default is to not partition at all."""
+        return None
+
+    @property
     def field_delimiter(self):
         return "\t"
 
@@ -153,37 +212,46 @@ class BigQueryLoadTask(OverwriteOutputMixin, luigi.Task):
         dataset = client.dataset(self.dataset_id)
         table = dataset.table(self.table, self.schema)
         if not table.exists():
+            if self.partitioning_type:
+                table.partitioning_type = self.partitioning_type
+            if self.table_description:
+                table.description = self.table_description
+            if self.table_friendly_name:
+                table.friendly_name = self.table_friendly_name
             table.create()
-
-    def init_touch(self, client):
-        if self.overwrite:
-            query = client.run_sync_query("delete {dataset}.table_updates where target_table='{dataset}.{table}'".format(
-                dataset=self.dataset_id, table=self.table
-            ))
-            query.use_legacy_sql = False
-            query.run()
 
     def init_copy(self, client):
         self.attempted_removal = True
         if self.overwrite:
             dataset = client.dataset(self.dataset_id)
             table = dataset.table(self.table)
-            if table.exists():
-                table.delete()
+            if self.partitioning_type:
+                # Delete only the specific partition, and clear the marker only for the partition.
+                # Note that there is no partition.exists() functionality that is useful.  Instead,
+                # it returns table.exists().  Likewise, partition.delete() is a no-op if the actual
+                # partition doesn't exist.  So if the table exists, we just try to delete the partition.
+                if table.exists():
+                    partition = self._get_table_partition(dataset, table)
+                    partition.delete()
+                self.output().clear_marker_table_entry()
+            else:
+                # Delete the entire table and all markers related to the table.
+                if table.exists():
+                    table.delete()
+                self.output().clear_marker_table()
 
-    def run(self):
-        client = self.output().client
-        self.create_dataset(client)
-        self.init_copy(client)
-        self.create_table(client)
-
-        dataset = client.dataset(self.dataset_id)
-        table = dataset.table(self.table, self.schema)
-
-        source_path = self.input()['source'].path
+    def _get_destination_from_source(self, source_path):
         parsed_url = urlparse.urlparse(source_path)
         destination_path = url_path_join('gs://{}'.format(parsed_url.netloc), parsed_url.path)
+        return destination_path
 
+    def _get_table_partition(self, dataset, table):
+        date_string = self.date.isoformat()
+        stripped_date = date_string.replace('-', '')
+        partition_name = '{}${}'.format(table.name, stripped_date)
+        return dataset.table(partition_name)
+
+    def _copy_data_to_gs(self, source_path, destination_path):
         if self.is_file(source_path):
             return_code = subprocess.call(['gsutil', 'cp', source_path, destination_path])
         else:
@@ -196,36 +264,63 @@ class BigQueryLoadTask(OverwriteOutputMixin, luigi.Task):
                 destination=destination_path,
             ))
 
+    def _get_load_url_from_destination(self, destination_path):
         if self.is_file(destination_path):
-            load_uri = destination_path
+            return destination_path
         else:
-            load_uri = url_path_join(destination_path, '*')
+            return url_path_join(destination_path, '*')
 
-        job = client.load_table_from_storage(
-            'load_{table}_{timestamp}'.format(table=self.table, timestamp=int(time.time())),
-            table,
-            load_uri
-        )
+    def _run_load_table_job(self, client, job_id, table, load_uri):
+        job = client.load_table_from_storage(job_id, table, load_uri)
         job.field_delimiter = self.field_delimiter
         job.quote_character = self.quote_character
         job.null_marker = self.null_marker
-
+        if self.max_bad_records > 0:
+            job.max_bad_records = self.max_bad_records
         log.debug("Starting BigQuery Load job.")
         job.begin()
-        wait_for_job(job)
-        try:
-            log.debug(
-                "Load job started: %s ended: %s input_files: %s output_rows: %s output_bytes: %s",
-                job.started,
-                job.ended,
-                job.input_files,
-                job.output_rows,
-                job.output_bytes,
-            )
-        except KeyError:
-            log.debug("Load job started: %s ended: %s No load stats.", job.started, job.ended)
+        wait_for_job(job, check_error_result=False)
 
-        self.init_touch(client)
+        try:
+            log.debug(" Load job started: %s ended: %s input_files: %s output_rows: %s output_bytes: %s",
+                      job.started, job.ended, job.input_files, job.output_rows, job.output_bytes)
+        except KeyError as keyerr:
+            log.debug(" Load job started: %s ended: %s No load stats.", job.started, job.ended)
+
+        if job.error_result:
+            for error in job.errors:
+                log.debug("   Load error: %s", error)
+            raise RuntimeError(job.errors)
+        else:
+            log.debug("   No errors encountered!")
+
+    def run(self):
+        self.check_bigquery_availability()
+
+        client = self.output().client
+        self.create_dataset(client)
+        self.init_copy(client)
+        self.create_table(client)
+
+        dataset = client.dataset(self.dataset_id)
+        table = dataset.table(self.table, self.schema)
+
+        source_path = self.input()['source'].path
+        destination_path = self._get_destination_from_source(source_path)
+        self._copy_data_to_gs(source_path, destination_path)
+        load_uri = self._get_load_url_from_destination(destination_path)
+
+        if self.partitioning_type:
+            partition = self._get_table_partition(dataset, table)
+            partition.partitioning_type = self.partitioning_type
+            job_id = 'load_{table}_{date_string}_{timestamp}'.format(
+                table=self.table, date_string=self.date.isoformat(), timestamp=int(time.time())
+            )
+            self._run_load_table_job(client, job_id, partition, load_uri)
+        else:
+            job_id = 'load_{table}_{timestamp}'.format(table=self.table, timestamp=int(time.time()))
+            self._run_load_table_job(client, job_id, table, load_uri)
+
         self.output().touch()
 
     def output(self):
@@ -248,3 +343,7 @@ class BigQueryLoadTask(OverwriteOutputMixin, luigi.Task):
         else:
             return False
 
+    def check_bigquery_availability(self):
+        """Call to ensure fast failure if this machine doesn't have the Bigquery libraries available."""
+        if not bigquery_available:
+            raise ImportError('Bigquery library not available')

--- a/edx/analytics/tasks/util/record.py
+++ b/edx/analytics/tasks/util/record.py
@@ -5,6 +5,12 @@ import re
 import datetime
 import itertools
 
+try:
+    from google.cloud.bigquery import SchemaField
+    bigquery_available = True  # pylint: disable=invalid-name
+except ImportError:
+    bigquery_available = False  # pylint: disable=invalid-name
+
 
 DEFAULT_NULL_VALUE = '\\N'  # This is the default string used by Hive to represent a NULL value.
 
@@ -352,6 +358,28 @@ class Record(object):
         return schema
 
     @classmethod
+    def get_bigquery_schema(cls):
+        """
+        A skeleton schema of the BigQuery table that could store this data.
+
+        Accepted types for legacy tables are 'STRING', 'INTEGER', 'FLOAT', 'BOOLEAN', 'TIMESTAMP', 'BYTES', 'DATE', 'TIME', 'DATETIME'.
+        Accepted types for standard tables are 'STRING', 'INT64', 'FLOAT64', 'BOOL', 'TIMESTAMP', 'BYTES', 'DATE', 'TIME', 'DATETIME'.
+        Going with legacy values for now.
+        Accepted modes are 'NULLABLE' or 'REQUIRED'.
+
+        Returns: A list of BigQuery SchemaField objects.
+        """
+        if not bigquery_available:
+            raise ImportError('Bigquery library not available')
+
+        schema = []
+        for field_name, field_obj in cls.get_fields().items():
+            mode = 'NULLABLE' if field_obj.nullable else 'REQUIRED'
+            description=getattr(field_obj, 'description', None)
+            schema.append(SchemaField(field_name, field_obj.bigquery_type, description=description, mode=mode))
+        return schema
+
+    @classmethod
     def get_elasticsearch_properties(cls):
         """
         An elasticsearch mapping that could store this data.
@@ -517,6 +545,11 @@ class Field(object):
         raise NotImplementedError
 
     @property
+    def biqquery_type(self):
+        """Returns the BigQuery data type for this type of field."""
+        raise NotImplementedError
+
+    @property
     def elasticsearch_type(self):
         """Returns the elasticsearch type for this type of field."""
         raise NotImplementedError
@@ -526,6 +559,7 @@ class StringField(Field):  # pylint: disable=abstract-method
     """Represents a field that contains a relatively short string."""
 
     hive_type = 'STRING'
+    bigquery_type = 'STRING'
     elasticsearch_type = 'string'
 
     def validate_parameters(self):
@@ -569,6 +603,7 @@ class DelimitedStringField(Field):
     """Represents a list of strings, stored as a single delimited string."""
 
     hive_type = 'STRING'
+    bigquery_type = 'STRING'
     sql_base_type = 'VARCHAR'
     elasticsearch_type = 'string'
     delimiter = '\0'
@@ -595,6 +630,7 @@ class BooleanField(Field):
     """Represents a field that contains a boolean."""
 
     hive_type = 'TINYINT'
+    bigquery_type = 'BOOLEAN'
     sql_base_type = 'BOOLEAN'
     elasticsearch_type = 'boolean'
 
@@ -622,6 +658,7 @@ class IntegerField(Field):  # pylint: disable=abstract-method
     """Represents a field that contains an integer."""
 
     hive_type = sql_base_type = 'INT'
+    bigquery_type = 'INTEGER'
     elasticsearch_type = 'integer'
 
     def validate(self, value):
@@ -638,6 +675,7 @@ class DateField(Field):  # pylint: disable=abstract-method
     """Represents a field that contains a date."""
 
     hive_type = 'STRING'
+    bigquery_type = 'DATE'
     sql_base_type = 'DATE'
     elasticsearch_type = 'date'
 
@@ -655,6 +693,7 @@ class DateTimeField(Field):  # pylint: disable=abstract-method
     """Represents a field that contains a date and time."""
 
     hive_type = 'TIMESTAMP'
+    bigquery_type = 'TIMESTAMP'
     sql_base_type = 'DATETIME'
     elasticsearch_type = 'date'
     elasticsearch_format = 'yyyy-MM-dd HH:mm:ss.SSSSSS'
@@ -689,6 +728,10 @@ class DateTimeField(Field):  # pylint: disable=abstract-method
             validation_errors.append('The value is a naive datetime.')
         elif value.utcoffset().total_seconds() != 0:
             validation_errors.append('The value must use UTC timezone.')
+        elif value.year < 1900:
+            # https://docs.python.org/2/library/datetime.html?highlight=strftime#strftime-strptime-behavior
+            # "The exact range of years for which strftime() works also varies across platforms. Regardless of platform, years before 1900 cannot be used."
+            validation_errors.append('The value must be a date after 1900.')
 
         return validation_errors
 
@@ -710,6 +753,7 @@ class FloatField(Field):  # pylint: disable=abstract-method
     """Represents a field that contains a floating point number."""
 
     hive_type = sql_base_type = 'FLOAT'
+    bigquery_type = 'FLOAT'
     elasticsearch_type = 'float'
 
     def validate(self, value):

--- a/edx/analytics/tasks/warehouse/load_internal_reporting_events.py
+++ b/edx/analytics/tasks/warehouse/load_internal_reporting_events.py
@@ -8,7 +8,10 @@ from event values to column values.
 
 """
 import datetime
+import json
+from importlib import import_module
 import logging
+import re
 
 import ciso8601
 import dateutil
@@ -22,20 +25,28 @@ import user_agents
 
 from edx.analytics.tasks.common.mapreduce import MultiOutputMapReduceJobTask, MapReduceJobTaskMixin
 from edx.analytics.tasks.common.pathutil import EventLogSelectionMixin, EventLogSelectionDownstreamMixin
+from edx.analytics.tasks.common.bigquery_load import BigQueryLoadDownstreamMixin, BigQueryLoadTask
 from edx.analytics.tasks.common.vertica_load import VerticaCopyTask, VerticaCopyTaskMixin, SchemaManagementTask
 from edx.analytics.tasks.util import eventlog
 from edx.analytics.tasks.util.hive import (
     WarehouseMixin, BareHiveTableTask, HivePartitionTask, HivePartition
 )
 from edx.analytics.tasks.util.obfuscate_util import backslash_encode_value
-from edx.analytics.tasks.util.record import SparseRecord, StringField, DateField, IntegerField, FloatField, BooleanField
+from edx.analytics.tasks.util.opaque_key_util import is_valid_course_id, get_org_id_for_course, get_course_key_from_url
+from edx.analytics.tasks.util.record import SparseRecord, StringField, DateField, DateTimeField, IntegerField, FloatField, BooleanField
 from edx.analytics.tasks.util.url import ExternalURL, url_path_join
 
 log = logging.getLogger(__name__)
 
-VERSION = '0.2.3'
+VERSION = '0.2.4'
 
 EVENT_TABLE_NAME = 'event_records'
+
+# Define pattern to extract a course_id from a string by looking
+# explicitly for a version string and two plus-delimiters.
+# TODO: avoid this hack by finding a more opaque-keys-respectful way.
+NEW_COURSE_ID_PATTERN = r'(?P<course_id>course\-v1\:[^/+]+(\+)[^/+]+(\+)[^/]+)'
+NEW_COURSE_REGEX = re.compile(r'^.*?{}'.format(NEW_COURSE_ID_PATTERN))
 
 
 class EventRecord(SparseRecord):
@@ -64,7 +75,7 @@ class EventRecord(SparseRecord):
     agent = StringField(length=1023, nullable=True, description='')
     # 'agent' string gets parsed into the following:
     agent_type = StringField(length=20, nullable=True, description='')
-    agent_device_name = StringField(length=100, nullable=True, description='')
+    agent_device_name = StringField(length=100, nullable=True, description='', truncate=True)
     agent_os = StringField(length=100, nullable=True, description='')
     agent_browser = StringField(length=100, nullable=True, description='')
     # agent_touch_capable = BooleanField(nullable=True, description='')
@@ -364,7 +375,94 @@ class EventRecord(SparseRecord):
     campaign_name = StringField(length=255, nullable=True, description='')
 
 
-class EventRecordDownstreamMixin(WarehouseMixin, MapReduceJobTaskMixin):
+class JsonEventRecord(SparseRecord):
+    """Represents an event, either a tracking log event or segment event."""
+
+    timestamp = DateTimeField(nullable=True, description='Timestamp when event was emitted.')
+
+    received_at = DateTimeField(nullable=True, description='Timestamp when event was received/recorded.')
+
+    # was context_user_id:
+    user_id = StringField(length=255, nullable=True, description='The identifier of the user who was logged in when the event was emitted. '
+                          'This is often but not always numeric.')
+
+    username = StringField(length=50, nullable=True, description='The username of the user who was logged in when the event was emitted.')
+
+    anonymous_id = StringField(length=255, nullable=True, description='The anonymous_id of the user.')
+
+    event_type = StringField(
+        length=255,
+        nullable=False,
+        description='The name of the event (event name in the segment logs). For implicit events, this should be "edx.server.request".'
+    )
+
+    # was context_course_id
+    course_id = StringField(length=255, nullable=True, description='The course_id associated with this event (if any).')
+    org_id = StringField(length=255, nullable=True, description='Id of organization, as used in course_id.')
+
+    label = StringField(length=511, nullable=True, description='The GA label associated with this event.')
+
+    # This is not the same as "event_category".
+    category = StringField(length=255, nullable=True, description='The GA category for this event.')
+
+    # This was event_source:
+    emitter_type = StringField(length=255, nullable=False, description='Where the event was collected from (browser, mobile, server, etc).')
+
+    # This is populated for most segment events, but also forum, googlecomponent tracking log events.
+    url = StringField(
+        length=2047,
+        nullable=True,
+        description='For page events, the full URL (including hostname) that was accessed by the user. '
+        'For implicit events, this should be the full URL that the request was for.'
+    )
+
+    # use the length (and name) from segment version (referrer), and write tracking log 'referer' here as well.
+    referrer = StringField(length=8191, nullable=True, description='The HTTP referrer - also as a full URL.')
+
+    # was project:
+    source = StringField(length=255, nullable=False, description='The segment.com project the event was sent to.')
+
+    input_file = StringField(length=255, nullable=False, description='The full URL of the file that contains this event in S3.')
+
+    agent_type = StringField(length=20, nullable=True, description='The type of device used.')
+    agent_device_name = StringField(length=100, nullable=True, description='The name of the device used.', truncate=True)
+    agent_os = StringField(length=100, nullable=True, description='The name of the OS on the device used. ')
+    agent_browser = StringField(length=100, nullable=True, description='The name of the browser used.')
+
+    # So having a StringField (as with EventRecord) has this write out to disk as "True".
+    # Using a BooleanField here has this end up being written out as 0 or 1.
+    # However, when loading to BigQuery as BOOLEAN, the boolean is translated back to True/False, or null.
+    agent_touch_capable = BooleanField(nullable=True, description='A boolean value indicating that the device was touch-capable.')
+
+    raw_event = StringField(length=60000, nullable=True, description='The full text of the event as a JSON string. This can be parsed at query time using UDFs.')
+
+    # This was originally a StringField, but a DateField outputs the same format and is more useful.
+    date = DateField(nullable=False, description='The date when the event was received.')
+
+
+class EventRecordClassMixin(object):
+
+    event_record_type = luigi.Parameter(
+        description='The kind of event record to load.  Default is EventRecord, override with JsonEventRecord as needed.',
+        default='EventRecord',
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(EventRecordClassMixin, self).__init__(*args, **kwargs)
+        module_name = self.__class__.__module__
+        local_module = import_module(module_name)
+        self.record_class = getattr(local_module, self.event_record_type)
+        if not self.record_class:
+            raise ValueError("No event record class found:  {}".format(self.event_record_type))
+
+    def get_event_record_class(self):
+        return self.record_class
+
+    def uses_JSON_event_record(self):
+        return self.event_record_type == 'JsonEventRecord'
+
+
+class EventRecordDownstreamMixin(EventRecordClassMixin, WarehouseMixin, MapReduceJobTaskMixin):
 
     events_list_file_path = luigi.Parameter(default=None)
 
@@ -372,16 +470,6 @@ class EventRecordDownstreamMixin(WarehouseMixin, MapReduceJobTaskMixin):
 class EventRecordDataDownstreamMixin(EventRecordDownstreamMixin):
 
     """Common parameters and base classes used to pass parameters through the event record workflow."""
-
-    # Required parameter
-    date = luigi.DateParameter(
-        description='Upper bound date for the end of the interval to analyze. Data produced before 00:00 on this'
-                    ' date will be analyzed. This workflow is intended to run nightly and this parameter is intended'
-                    ' to be set to "today\'s" date, so that all of yesterday\'s data is included and none of today\'s.'
-    )
-
-    # Override superclass to disable this parameter
-    interval = None
     output_root = luigi.Parameter()
 
 
@@ -391,14 +479,10 @@ class BaseEventRecordDataTask(EventRecordDataDownstreamMixin, MultiOutputMapRedu
     # Create a DateField object to help with converting date_string
     # values for assignment to DateField objects.
     date_field_for_converting = DateField()
+    date_time_field_for_validating = DateTimeField()
 
     # This is a placeholder.  It is expected to be overridden in derived classes.
     counter_category_name = 'Event Record Exports'
-
-    def __init__(self, *args, **kwargs):
-        super(BaseEventRecordDataTask, self).__init__(*args, **kwargs)
-
-        self.interval = luigi.date_interval.Date.from_date(self.date)
 
     # TODO: maintain support for info about events.  We may need something similar to identify events
     # that should -- or should not -- be included in the event dump.
@@ -447,24 +531,18 @@ class BaseEventRecordDataTask(EventRecordDataDownstreamMixin, MultiOutputMapRedu
 
     def output_path_for_key(self, key):
         """
-        Output based on date and something else.  What else?  Type?
+        Output based on date and project.
 
         Mix them together by date, but identify with different files for each project/environment.
 
         Output is in the form {warehouse_path}/event_records/dt={CCYY-MM-DD}/{project}.tsv
         """
-        # If we're only running now with a specific date, then there
-        # is no reason to sort by date_received.
-        _date_received, project = key
+        date_received, project = key
 
-        # return url_path_join(
-        #     self.output_root,
-        #     'event_records',
-        #     'dt={date}'.format(date=date_received),
-        #     '{project}.tsv'.format(project=project),
-        # )
         return url_path_join(
             self.output_root,
+            EVENT_TABLE_NAME,
+            'dt={date}'.format(date=date_received),
             '{project}.tsv'.format(project=project),
         )
 
@@ -547,7 +625,10 @@ class BaseEventRecordDataTask(EventRecordDataDownstreamMixin, MultiOutputMapRedu
             agent_dict['device_name'] = user_agent.device.family
             agent_dict['os'] = user_agent.os.family
             agent_dict['browser'] = user_agent.browser.family
-            agent_dict['touch_capable'] = unicode(user_agent.is_touch_capable)
+            # TODO: figure out how to handle this, so that it works
+            # when the target field is either BooleanField or StringField.
+            # agent_dict['touch_capable'] = unicode(user_agent.is_touch_capable)
+            agent_dict['touch_capable'] = user_agent.is_touch_capable
         else:
             self.incr_counter(self.counter_category_name, 'Quality Unrecognized agent type', 1)
 
@@ -558,7 +639,8 @@ class BaseEventRecordDataTask(EventRecordDataDownstreamMixin, MultiOutputMapRedu
             agent_dict = self._canonicalize_user_agent(agent)
             for key in agent_dict.keys():
                 new_key = u"agent_{}".format(key)
-                event_dict[new_key] = agent_dict[key]
+                # event_dict[new_key] = agent_dict[key]
+                self.add_calculated_event_entry(event_dict, new_key, agent_dict[key])
 
     def _add_event_entry(self, event_dict, event_record_key, event_record_field, label, obj):
         if isinstance(event_record_field, StringField):
@@ -567,6 +649,8 @@ class BaseEventRecordDataTask(EventRecordDataDownstreamMixin, MultiOutputMapRedu
                 value = None
             else:
                 value = backslash_encode_value(unicode(obj))
+                if '\x00' in value:
+                    value = value.replace('\x00', '\0')
                 # Avoid validation errors later due to length by truncating here.
                 field_length = event_record_field.length
                 value_length = len(value)
@@ -581,6 +665,44 @@ class BaseEventRecordDataTask(EventRecordDataDownstreamMixin, MultiOutputMapRedu
                 event_dict[event_record_key] = int(obj)
             except ValueError:
                 log.error('Unable to cast value to int for %s: %r', label, obj)
+        elif isinstance(event_record_field, DateTimeField):
+            datetime_obj = None
+            try:
+                if obj is not None:
+                    datetime_obj = ciso8601.parse_datetime(obj)
+                    if datetime_obj.tzinfo:
+                        datetime_obj = datetime_obj.astimezone(pytz.utc)
+                else:
+                    datetime_obj = obj
+            except ValueError:
+                log.error('Unable to cast value to datetime for %s: %r', label, obj)
+
+            # Because it's not enough just to create a datetime object, also perform
+            # validation here.
+            if datetime_obj is not None:
+                validation_errors = self.date_time_field_for_validating.validate(datetime_obj)
+                if len(validation_errors) > 0:
+                    log.error('Invalid assigment of value %r to field "%s": %s', datetime_obj, label, ', '.join(validation_errors))
+                    datetime_obj = None
+
+            event_dict[event_record_key] = datetime_obj
+        elif isinstance(event_record_field, DateField):
+            date_obj = None
+            try:
+                if obj is not None:
+                    date_obj = self.date_field_for_converting.deserialize_from_string(obj)
+            except ValueError:
+                log.error('Unable to cast value to date for %s: %r', label, obj)
+
+            # Because it's not enough just to create a datetime object, also perform
+            # validation here.
+            if date_obj is not None:
+                validation_errors = self.date_field_for_converting.validate(date_obj)
+                if len(validation_errors) > 0:
+                    log.error('Invalid assigment of value %r to field "%s": %s', date_obj, label, ', '.join(validation_errors))
+                    date_obj = None
+
+            event_dict[event_record_key] = date_obj
         elif isinstance(event_record_field, BooleanField):
             try:
                 event_dict[event_record_key] = bool(obj)
@@ -617,7 +739,7 @@ class BaseEventRecordDataTask(EventRecordDataDownstreamMixin, MultiOutputMapRedu
 
     def add_calculated_event_entry(self, event_dict, event_record_key, obj):
         """Use this to explicitly add calculated entry values."""
-        event_record_field = EventRecord.get_fields()[event_record_key]
+        event_record_field = self.get_event_record_class().get_fields()[event_record_key]
         label = event_record_key
         self._add_event_entry(event_dict, event_record_key, event_record_field, label, obj)
 
@@ -626,7 +748,6 @@ class TrackingEventRecordDataTask(EventLogSelectionMixin, BaseEventRecordDataTas
     """Task to compute event_type and event_source values being encountered on each day in a given time interval."""
 
     # Override superclass to disable this parameter
-    interval = None
     event_mapping = None
     PROJECT_NAME = 'tracking_prod'
 
@@ -653,7 +774,7 @@ class TrackingEventRecordDataTask(EventLogSelectionMixin, BaseEventRecordDataTas
         """Return dictionary of event attributes to the output keys they map to."""
         if self.event_mapping is None:
             self.event_mapping = {}
-            fields = EventRecord.get_fields()
+            fields = self.get_event_record_class().get_fields()
             field_keys = fields.keys()
             for field_key in field_keys:
                 field_tuple = (field_key, fields[field_key])
@@ -661,12 +782,21 @@ class TrackingEventRecordDataTask(EventLogSelectionMixin, BaseEventRecordDataTas
                 def add_event_mapping_entry(source_key):
                     self.event_mapping[source_key] = field_tuple
                 # Most common is to map first-level entries in event data directly.
-                # Skip values that are explicitly set:
+                # Skip values that are explicitly set in EventRecord:
                 if field_key in ['version', 'input_file', 'project', 'event_type', 'event_source', 'context_course_id', 'username']:
+                    pass
+                # Skip values that are explicitly set in JSONEventRecord:
+                elif field_key in ['source', 'emitter_type', 'raw_event']:
                     pass
                 # Skip values that are explicitly calculated rather than copied:
                 elif field_key.startswith('agent_') or field_key in ['event_category', 'timestamp', 'received_at', 'date']:
                     pass
+                elif self.uses_JSON_event_record() and field_key == 'course_id':
+                    pass
+                elif self.uses_JSON_event_record() and field_key == 'referrer':
+                    add_event_mapping_entry('root.referer')
+                elif self.uses_JSON_event_record() and field_key == 'user_id':
+                    add_event_mapping_entry('root.context.user_id')
                 # Handle special-cases:
                 elif field_key == "currenttime":
                     # Collapse values from either form into a single column.  No event should have both,
@@ -706,10 +836,18 @@ class TrackingEventRecordDataTask(EventLogSelectionMixin, BaseEventRecordDataTas
             self.incr_counter(self.counter_category_name, 'Discard Missing Event Type', 1)
             return
 
-        # Ignore events that begin with a slash (i.e. implicit events).
+        # Handle events that begin with a slash (i.e. implicit events).
+        # * For JSON events, give them a marker event_type so we can more easily search (or filter) them,
+        #   and treat the type as the URL that was called.
+        # * For regular events, ignore those that begin with a slash (i.e. implicit events).
+        event_url = None
         if event_type.startswith('/'):
-            self.incr_counter(self.counter_category_name, 'Discard Implicit Events', 1)
-            return
+            if self.uses_JSON_event_record():
+                event_url = event_type
+                event_type = 'edx.server.request'
+            else:
+                self.incr_counter(self.counter_category_name, 'Discard Implicit Events', 1)
+                return
 
         username = event.get('username', '').strip()
         # if not username:
@@ -731,33 +869,58 @@ class TrackingEventRecordDataTask(EventLogSelectionMixin, BaseEventRecordDataTas
             self.incr_counter(self.counter_category_name, 'Discard Missing Event Source', 1)
             return
 
-        if (event_source, event_type) in self.known_events:
-            event_category = self.known_events[(event_source, event_type)]
-        else:
-            event_category = 'unknown'
-
         project_name = self.PROJECT_NAME
 
-        event_dict = {'version': VERSION}
 
+        event_dict = {}
         self.add_calculated_event_entry(event_dict, 'input_file', self.get_map_input_file())
-        self.add_calculated_event_entry(event_dict, 'project', project_name)
         self.add_calculated_event_entry(event_dict, 'event_type', event_type)
-        self.add_calculated_event_entry(event_dict, 'event_source', event_source)
-        self.add_calculated_event_entry(event_dict, 'event_category', event_category)
         self.add_calculated_event_entry(event_dict, 'timestamp', self.get_event_emission_time(event))
         self.add_calculated_event_entry(event_dict, 'received_at', self.get_event_arrival_time(event))
         self.add_calculated_event_entry(event_dict, 'date', self.convert_date(date_received))
-
-        self.add_calculated_event_entry(event_dict, 'context_course_id', course_id)
         self.add_calculated_event_entry(event_dict, 'username', username)
-
         self.add_agent_info(event_dict, event.get('agent'))
+
+        if self.uses_JSON_event_record():
+            # Add a check in the payload for a course_id -- it is sometimes there
+            # instead of in context.
+            if not course_id and event_data.get('course_id'):
+                course_id = event_data.get('course_id')
+
+            # was project
+            self.add_calculated_event_entry(event_dict, 'source', project_name)
+            # was event_source
+            self.add_calculated_event_entry(event_dict, 'emitter_type', event_source)
+            # was context_course_id
+            self.add_calculated_event_entry(event_dict, 'course_id', course_id)
+            self.add_calculated_event_entry(event_dict, 'raw_event', json.dumps(event, sort_keys=True))
+
+            # Additional fields:
+            # The event_url is the original event_type of implicit events.
+            if event_url is not None:
+                self.add_calculated_event_entry(event_dict, 'url', event_url)
+            # Try to extract information from course_id.
+            if course_id is not None:
+                org_id = get_org_id_for_course(course_id)
+                if org_id:
+                    self.add_calculated_event_entry(event_dict, 'org_id', org_id)
+
+        else:
+            if (event_source, event_type) in self.known_events:
+                event_category = self.known_events[(event_source, event_type)]
+            else:
+                event_category = 'unknown'
+
+            self.add_calculated_event_entry(event_dict, 'version', VERSION)
+            self.add_calculated_event_entry(event_dict, 'project', project_name)
+            self.add_calculated_event_entry(event_dict, 'event_source', event_source)
+            self.add_calculated_event_entry(event_dict, 'event_category', event_category)
+            self.add_calculated_event_entry(event_dict, 'context_course_id', course_id)
+
         event_mapping = self.get_event_mapping()
         self.add_event_info(event_dict, event_mapping, event)
 
-        record = EventRecord(**event_dict)
-
+        record = self.get_event_record_class()(**event_dict)
         key = (date_received, project_name)
 
         self.incr_counter(self.counter_category_name, 'Output From Mapper', 1)
@@ -792,9 +955,6 @@ class SegmentEventLogSelectionMixin(SegmentEventLogSelectionDownstreamMixin, Eve
 class SegmentEventRecordDataTask(SegmentEventLogSelectionMixin, BaseEventRecordDataTask):
     """Task to compute event_type and event_source values being encountered on each day in a given time interval."""
 
-    # Override superclass to disable this parameter
-    interval = None
-
     # Project information, pulled from config file.
     project_names = {}
     config = None
@@ -803,6 +963,7 @@ class SegmentEventRecordDataTask(SegmentEventLogSelectionMixin, BaseEventRecordD
 
     counter_category_name = 'Segment Event Exports'
 
+    # TODO: this never actually worked in a cluster.  Figure out how to get it to work.
     def _get_project_name(self, project_id):
         if project_id not in self.project_names:
             if self.config is None:
@@ -828,6 +989,8 @@ class SegmentEventRecordDataTask(SegmentEventLogSelectionMixin, BaseEventRecordD
                         log.warning("Parsable unparseable type for %s time in event: %r", key, event)
                         self.incr_counter(self.counter_category_name, 'Quality Parsable unparseable for {} Time Field'.format(key), 1)
                 except Exception:
+                    # This was commented out in the JSON event code because presumably it was happening a lot
+                    # in cases where it was using multipe key values (e.g. get_event_arrival_time).
                     log.error("Unparseable %s time from event: %r", key, event)
                     self.incr_counter(self.counter_category_name, 'Quality Unparseable {} Time Field'.format(key), 1)
             return event_time
@@ -862,7 +1025,21 @@ class SegmentEventRecordDataTask(SegmentEventLogSelectionMixin, BaseEventRecordD
             return None
 
     def get_event_arrival_time(self, event):
-        return self._get_time_from_segment_event(event, 'receivedAt')
+        if 'receivedAt' in event:
+            return self._get_time_from_segment_event(event, 'receivedAt')
+
+        if 'requestTime' in event:
+            self.incr_counter(self.counter_category_name, 'Event arrival from requestTime', 1)
+            return self._get_time_from_segment_event(event, 'requestTime')
+
+        if 'timestamp' in event:
+            self.incr_counter(self.counter_category_name, 'Event arrival from timestamp', 1)
+            return self._get_time_from_segment_event(event, 'timestamp')
+
+        self.incr_counter(self.counter_category_name, 'Event arrival not set', 1)
+        log.error("Missing event arrival time in event '%r'", event)
+
+        return None
 
     def get_event_emission_time(self, event):
         return self._get_time_from_segment_event(event, 'sentAt')
@@ -885,7 +1062,7 @@ class SegmentEventRecordDataTask(SegmentEventLogSelectionMixin, BaseEventRecordD
         """Return dictionary of event attributes to the output keys they map to."""
         if self.event_mapping is None:
             self.event_mapping = {}
-            fields = EventRecord.get_fields()
+            fields = self.get_event_record_class().get_fields()
             field_keys = fields.keys()
             for field_key in field_keys:
                 field_tuple = (field_key, fields[field_key])
@@ -900,12 +1077,17 @@ class SegmentEventRecordDataTask(SegmentEventLogSelectionMixin, BaseEventRecordD
                 # Skip values that are explicitly calculated rather than copied:
                 elif field_key.startswith('agent_') or field_key in ['event_category', 'timestamp', 'received_at', 'date']:
                     pass
+                # Skip values that are explicitly set or calculated for JSONEventRecord:
+                elif field_key in ['emitter_type', 'source', 'raw_event']:
+                     pass
                 # Map values that are top-level:
                 elif field_key in ['channel']:
                     add_event_mapping_entry(u"root.{}".format(field_key))
                 elif field_key in ['anonymous_id']:
                     add_event_mapping_entry(u"root.context.anonymousid")
                     add_event_mapping_entry("root.anonymousid")
+                    add_event_mapping_entry(u"root.context.traits.anonymousid")
+                    add_event_mapping_entry(u"root.traits.anonymousid")
                 elif field_key in ['agent']:
                     add_event_mapping_entry(u"root.context.useragent")
                     add_event_mapping_entry(u"root.properties.context.agent")
@@ -915,9 +1097,13 @@ class SegmentEventRecordDataTask(SegmentEventLogSelectionMixin, BaseEventRecordD
                     add_event_mapping_entry(u"root.properties.courseid")
                     add_event_mapping_entry(u"root.properties.course_id")
                     add_event_mapping_entry(u"root.properties.course")
+                    add_event_mapping_entry(u"root.properties.data.course_id")
+                    add_event_mapping_entry(u"root.properties.data.course-id")
+                    add_event_mapping_entry(u"root.properties.context.course_id")
                 elif field_key in ['username']:
                     add_event_mapping_entry(u"root.traits.username")
-                    add_event_mapping_entry(u"root.properties.context.{}".format(field_key))
+                    add_event_mapping_entry(u"root.properties.context.username")
+                    add_event_mapping_entry(u"root.context.traits.username")
                 elif field_key in ['client_id', 'host', 'session', 'referer']:
                     add_event_mapping_entry(u"root.properties.context.{}".format(field_key))
                 elif field_key in ['user_id']:
@@ -928,6 +1114,10 @@ class SegmentEventRecordDataTask(SegmentEventLogSelectionMixin, BaseEventRecordD
                     # even for the same projectId.  We may need more complicated
                     # logic to help sort that out (more) consistently.
                     add_event_mapping_entry(u"root.userid")
+                    add_event_mapping_entry(u"root.properties.context.user_id")
+                    add_event_mapping_entry(u"root.properties.data.user_id")
+                    add_event_mapping_entry(u"root.context.traits.userid")
+                    add_event_mapping_entry(u"root.traits.userid")
                 elif field_key in [
                         'os_name', 'os_version', 'app_name', 'app_version', 'device_manufacturer',
                         'device_model', 'network_carrier', 'screen_width', 'screen_height',
@@ -943,6 +1133,7 @@ class SegmentEventRecordDataTask(SegmentEventLogSelectionMixin, BaseEventRecordD
                     add_event_mapping_entry(u"root.properties.{}".format(field_key))
                     add_event_mapping_entry(u"root.context.page.{}".format(field_key))
                     add_event_mapping_entry(u"root.properties.context.page.{}".format(field_key))
+                    add_event_mapping_entry(u"root.data.{}".format(field_key))
                 else:
                     pass
 
@@ -958,6 +1149,8 @@ class SegmentEventRecordDataTask(SegmentEventLogSelectionMixin, BaseEventRecordD
         self.incr_counter(self.counter_category_name, 'Inputs with Dates', 1)
 
         segment_type = event.get('type')
+        if segment_type is None and 'action' in event:
+            segment_type = event.get('action').lower()
         self.incr_counter(self.counter_category_name, u'Subset Type {}'.format(segment_type), 1)
 
         channel = event.get('channel')
@@ -1003,22 +1196,81 @@ class SegmentEventRecordDataTask(SegmentEventLogSelectionMixin, BaseEventRecordD
 
         self.incr_counter(self.counter_category_name, u'Subset Project {}'.format(project_name), 1)
 
-        event_dict = {'version': VERSION}
+        event_dict = {}
         self.add_calculated_event_entry(event_dict, 'input_file', self.get_map_input_file())
-        self.add_calculated_event_entry(event_dict, 'project', project_name)
         self.add_calculated_event_entry(event_dict, 'event_type', event_type)
-        self.add_calculated_event_entry(event_dict, 'event_source', event_source)
-        self.add_calculated_event_entry(event_dict, 'event_category', event_category)
         self.add_calculated_event_entry(event_dict, 'timestamp', self.get_event_emission_time(event))
         self.add_calculated_event_entry(event_dict, 'received_at', self.get_event_arrival_time(event))
         self.add_calculated_event_entry(event_dict, 'date', self.convert_date(date_received))
-        self.add_agent_info(event_dict, event.get('context', {}).get('userAgent'))
-        self.add_agent_info(event_dict, event.get('properties', {}).get('context', {}).get('agent'))
+
+        # An issue with the original logic: if a key exists and contains a value of None, then None will
+        # be returned instead of an empty dict specified as the default, and the next get() will fail.
+        # So check specifically for non-false values.
+        # self.add_agent_info(event_dict, event.get('context', {}).get('userAgent'))
+        # self.add_agent_info(event_dict, event.get('properties', {}).get('context', {}).get('agent'))
+        if event.get('context'):
+            self.add_agent_info(event_dict, event.get('context').get('userAgent'))
+        properties = event.get('properties')
+        if properties and properties.get('context'):
+            self.add_agent_info(event_dict, properties.get('context').get('agent'))
+
+        if self.uses_JSON_event_record():
+            self.add_calculated_event_entry(event_dict, 'source', project_name)  # was 'project'
+            self.add_calculated_event_entry(event_dict, 'emitter_type', event_source)  # was 'event_source'
+
+            # TODO: figure out why we check for this here, and not much earlier.  Why would
+            # it be in event_type, but not in event_dict??  And why so bad if it's not found?
+            # Is it required and cannot be 'None'?
+            if event_dict.get("event_type") is None:
+                self.incr_counter(self.counter_category_name, 'Missing event_type field', 1)
+                return
+
+            self.add_calculated_event_entry(event_dict, 'raw_event', json.dumps(event, sort_keys=True))
+
+        else:
+            self.add_calculated_event_entry(event_dict, 'version', VERSION)
+            self.add_calculated_event_entry(event_dict, 'project', project_name)
+            self.add_calculated_event_entry(event_dict, 'event_source', event_source)
+            self.add_calculated_event_entry(event_dict, 'event_category', event_category)
+
 
         event_mapping = self.get_event_mapping()
         self.add_event_info(event_dict, event_mapping, event)
 
-        record = EventRecord(**event_dict)
+        if self.uses_JSON_event_record():
+            # Try harder to extract course_id and related information.
+            course_id = event_dict.get('course_id')
+            if course_id is None:
+                # course_id may be stored in 'label', so try to parse what is there.
+                label = event_dict.get('label')
+                if label and is_valid_course_id(label):
+                    self.add_calculated_event_entry(event_dict, 'course_id', label)
+                    course_id = event_dict.get('course_id')
+
+            if course_id is None:
+                # course_id may be extractable from 'url' in the usual
+                # way, so try to parse what is there.
+                url = event_dict.get('url')
+                course_key = get_course_key_from_url(url)
+                if course_key:
+                    course_id = unicode(course_key)
+                    self.add_calculated_event_entry(event_dict, 'course_id', course_id)
+                elif url:
+                    # course_id may be extractable from 'url' by looking for the
+                    # version string and plus-delimiters explicitly anywhere in the URL.
+                    match = NEW_COURSE_REGEX.match(url)
+                    if match:
+                        course_id_string = match.group('course_id')
+                        if is_valid_course_id(course_id_string):
+                            self.add_calculated_event_entry(event_dict, 'course_id', course_id_string)
+                            course_id = event_dict.get('course_id')
+
+            if course_id is not None:
+                org_id = get_org_id_for_course(course_id)
+                if org_id:
+                    self.add_calculated_event_entry(event_dict, 'org_id', org_id)
+
+        record = self.get_event_record_class()(**event_dict)
         key = (date_received, project_name)
 
         self.incr_counter(self.counter_category_name, 'Output From Mapper', 1)
@@ -1029,27 +1281,102 @@ class SegmentEventRecordDataTask(SegmentEventLogSelectionMixin, BaseEventRecordD
         yield key, record.to_separated_values()
 
 
-class GeneralEventRecordDataTask(EventRecordDataDownstreamMixin, luigi.WrapperTask):
-    """Runs all Event Record tasks for a given time interval."""
-    # Override superclass to disable this parameter
-    # TODO: check if this is redundant, if it's already in the mixin.
-    interval = None
+##########################
+# Bulk Loading into S3
+##########################
+
+
+class BulkEventRecordIntervalTask(EventRecordDownstreamMixin, luigi.WrapperTask):
+    """Compute event information over a range of dates and insert the results into Hive."""
+
+    interval = luigi.DateIntervalParameter(
+        description='The range of dates for which to create event records.',
+    )
 
     def requires(self):
         kwargs = {
-            'output_root': self.output_root,
+            'output_root': self.warehouse_path,
             'events_list_file_path': self.events_list_file_path,
             'n_reduce_tasks': self.n_reduce_tasks,
-            'date': self.date,
-            # 'warehouse_path': self.warehouse_path,
+            'interval': self.interval,
+            'event_record_type': self.event_record_type,
         }
         yield (
             TrackingEventRecordDataTask(**kwargs),
             SegmentEventRecordDataTask(**kwargs),
         )
 
+    def output(self):
+        return [task.output() for task in self.requires()]
 
-class EventRecordTableTask(BareHiveTableTask):
+
+##########################
+# Loading into S3 by Date
+##########################
+
+
+class PerDateEventRecordDataDownstreamMixin(EventRecordDataDownstreamMixin):
+
+    """Common parameters and base classes used to pass parameters through the event record workflow."""
+
+    # Required parameter
+    date = luigi.DateParameter(
+        description='Upper bound date for the end of the interval to analyze. Data produced before 00:00 on this'
+                    ' date will be analyzed. This workflow is intended to run nightly and this parameter is intended'
+                    ' to be set to "today\'s" date, so that all of yesterday\'s data is included and none of today\'s.'
+    )
+
+    # Override superclass to disable this parameter
+    interval = None
+
+
+class PerDateEventRecordDataMixin(PerDateEventRecordDataDownstreamMixin):
+
+    def __init__(self, *args, **kwargs):
+        super(BaseEventRecordDataTask, self).__init__(*args, **kwargs)
+        self.interval = luigi.date_interval.Date.from_date(self.date)
+
+    def output_path_for_key(self, key):
+        """
+        Output based on project.
+
+        Output is in the form {warehouse_path}/event_records/dt={CCYY-MM-DD}/{project}.tsv,
+        but output_root is assumed to be set externally to {warehouse_path}/event_records/dt={CCYY-MM-DD}.
+        """
+        date_received, project = key
+
+        return url_path_join(
+            self.output_root,
+            '{project}.tsv'.format(project=project),
+        )
+
+
+class PerDateTrackingEventRecordDataTask(PerDateEventRecordDataMixin, TrackingEventRecordDataTask):
+    pass
+
+
+class PerDateSegmentEventRecordDataTask(PerDateEventRecordDataMixin, SegmentEventRecordDataTask):
+    pass
+
+
+class PerDateGeneralEventRecordDataTask(PerDateEventRecordDataDownstreamMixin, luigi.WrapperTask):
+    """Runs all Event Record tasks for a given time interval."""
+
+    def requires(self):
+        kwargs = {
+            'event_record_type': self.event_record_type,
+            'output_root': self.output_root,
+            'events_list_file_path': self.events_list_file_path,
+            'n_reduce_tasks': self.n_reduce_tasks,
+            'date': self.date,
+        }
+        yield (
+            PerDateTrackingEventRecordDataTask(**kwargs),
+            PerDateSegmentEventRecordDataTask(**kwargs),
+        )
+
+
+class EventRecordTableTask(EventRecordClassMixin, BareHiveTableTask):
     """The hive table for event_record data."""
 
     @property
@@ -1062,15 +1389,12 @@ class EventRecordTableTask(BareHiveTableTask):
 
     @property
     def columns(self):
-        return EventRecord.get_hive_schema()
+        return self.get_event_record_class().get_hive_schema()
 
 
 class EventRecordPartitionTask(EventRecordDownstreamMixin, HivePartitionTask):
     """The hive table partition for this engagement data."""
 
-    # Required parameter
-    # TODO: these two should already be declared this way in EventRecordDownstreamMixin.
-    # Figure out if they really need to be declared here as well.
     date = luigi.DateParameter()
     interval = None
 
@@ -1082,13 +1406,15 @@ class EventRecordPartitionTask(EventRecordDownstreamMixin, HivePartitionTask):
     @property
     def hive_table_task(self):
         return EventRecordTableTask(
+            event_record_type=self.event_record_type,
             warehouse_path=self.warehouse_path,
             # overwrite=self.overwrite,
         )
 
     @property
     def data_task(self):
-        return GeneralEventRecordDataTask(
+        return PerDateGeneralEventRecordDataTask(
+            event_record_type=self.event_record_type,
             date=self.date,
             n_reduce_tasks=self.n_reduce_tasks,
             output_root=self.partition_location,
@@ -1098,7 +1424,7 @@ class EventRecordPartitionTask(EventRecordDownstreamMixin, HivePartitionTask):
 
 
 class EventRecordIntervalTask(EventRecordDownstreamMixin, luigi.WrapperTask):
-    """Compute engagement information over a range of dates and insert the results into Hive and Vertica and whatever else."""
+    """Compute event information over a range of dates and insert the results into Hive."""
 
     interval = luigi.DateIntervalParameter(
         description='The range of received dates for which to create event records.',
@@ -1108,6 +1434,7 @@ class EventRecordIntervalTask(EventRecordDownstreamMixin, luigi.WrapperTask):
         for date in reversed([d for d in self.interval]):  # pylint: disable=not-an-iterable
             # should_overwrite = date >= self.overwrite_from_date
             yield EventRecordPartitionTask(
+                event_record_type=self.event_record_type,
                 date=date,
                 n_reduce_tasks=self.n_reduce_tasks,
                 warehouse_path=self.warehouse_path,
@@ -1115,13 +1442,6 @@ class EventRecordIntervalTask(EventRecordDownstreamMixin, luigi.WrapperTask):
                 # overwrite_from_date=self.overwrite_from_date,
                 events_list_file_path=self.events_list_file_path,
             )
-            # yield LoadEventRecordToVerticaTask(
-            #     date=date,
-            #     n_reduce_tasks=self.n_reduce_tasks,
-            #     warehouse_path=self.warehouse_path,
-            #     overwrite=should_overwrite,
-            #     overwrite_from_date=self.overwrite_from_date,
-            # )
 
     def output(self):
         return [task.output() for task in self.requires()]
@@ -1137,11 +1457,14 @@ class EventRecordIntervalTask(EventRecordDownstreamMixin, luigi.WrapperTask):
                 yield task.data_task
 
 
+##########################
+# Loading into Vertica
+##########################
+
+
 class LoadDailyEventRecordToVertica(EventRecordDownstreamMixin, VerticaCopyTask):
 
     # Required parameter
-    # TODO: this should already be declared this way in EventRecordDownstreamMixin.
-    # Figure out if it really needs to be declared here as well.
     date = luigi.DateParameter()
 
     @property
@@ -1156,16 +1479,6 @@ class LoadDailyEventRecordToVertica(EventRecordDownstreamMixin, VerticaCopyTask)
         partition_location = url_path_join(self.warehouse_path, hive_table, self.partition.path_spec) + '/'
         return ExternalURL(url=partition_location)
 
-        # But this should actually work as well, without the partition property being needed.
-        # WRONG. It really needs the underlying data-generating task.  The partition task's output
-        # itself cannot be opened as a file for reading.
-        # return EventRecordPartitionTask(
-        #     date=self.date,
-        #     n_reduce_tasks=self.n_reduce_tasks,
-        #     warehouse_path=self.warehouse_path,
-        #     events_list_file_path=self.events_list_file_path,
-        # )
-
     @property
     def table(self):
         return EVENT_TABLE_NAME
@@ -1179,13 +1492,12 @@ class LoadDailyEventRecordToVertica(EventRecordDownstreamMixin, VerticaCopyTask)
     @property
     def auto_primary_key(self):
         # The default is to use 'id', which would cause a conflict with field already having that name.
-        # But I don't see that there's any value to having such a column.
-        # return ('row_number', 'AUTO_INCREMENT')
+        # But there seems to be little value in having such a column.
         return None
 
     @property
     def columns(self):
-        return EventRecord.get_sql_schema()
+        return self.get_event_record_class().get_sql_schema()
 
     @property
     def table_partition_key(self):
@@ -1206,6 +1518,7 @@ class LoadEventRecordIntervalToVertica(EventRecordDownstreamMixin, VerticaCopyTa
         for date in reversed([d for d in self.interval]):  # pylint: disable=not-an-iterable
             # should_overwrite = date >= self.overwrite_from_date
             yield LoadDailyEventRecordToVertica(
+                event_record_type=self.event_record_type,
                 date=date,
                 n_reduce_tasks=self.n_reduce_tasks,
                 warehouse_path=self.warehouse_path,
@@ -1252,6 +1565,7 @@ class PruneEventPartitionsInVertica(EventRecordLoadDownstreamMixin, SchemaManage
     def requires(self):
         return {
             'source': LoadEventRecordIntervalToVertica(
+                event_record_type=self.event_record_type,
                 interval=self.interval,
                 n_reduce_tasks=self.n_reduce_tasks,
                 warehouse_path=self.warehouse_path,
@@ -1325,6 +1639,7 @@ class LoadEventsIntoWarehouseWorkflow(EventRecordLoadDownstreamMixin, VerticaCop
 
     def requires(self):
         return PruneEventPartitionsInVertica(
+            event_record_type=self.event_record_type,
             interval=self.interval,
             n_reduce_tasks=self.n_reduce_tasks,
             warehouse_path=self.warehouse_path,
@@ -1332,3 +1647,64 @@ class LoadEventsIntoWarehouseWorkflow(EventRecordLoadDownstreamMixin, VerticaCop
             schema=self.schema,
             credentials=self.credentials,
         )
+
+
+##########################
+# Loading into BigQuery
+##########################
+
+
+class LoadDailyEventRecordToBigQuery(EventRecordDownstreamMixin, BigQueryLoadTask):
+
+    @property
+    def table(self):
+        if self.uses_JSON_event_record():
+            return 'json_event_records'
+        else:
+            return 'event_records'
+
+    @property
+    def partitioning_type(self):
+        """Set to 'DAY' in order to partition by day."""
+        return 'DAY'
+
+    @property
+    def schema(self):
+        return self.get_event_record_class().get_bigquery_schema()
+
+    @property
+    def insert_source_task(self):
+        return ExternalURL(url=self.hive_partition_path(EVENT_TABLE_NAME, self.date))
+
+
+class LoadEventRecordIntervalToBigQuery(EventRecordDownstreamMixin, BigQueryLoadDownstreamMixin, luigi.WrapperTask):
+    """
+    Loads the event records table from Hive into the BigQuery data warehouse.
+
+    """
+
+    interval = luigi.DateIntervalParameter(
+        description='The range of dates for which to create event records.',
+    )
+
+    def requires(self):
+        for date in reversed([d for d in self.interval]):  # pylint: disable=not-an-iterable
+            # should_overwrite = date >= self.overwrite_from_date
+            yield LoadDailyEventRecordToBigQuery(
+                event_record_type=self.event_record_type,
+                date=date,
+                n_reduce_tasks=self.n_reduce_tasks,
+                warehouse_path=self.warehouse_path,
+                events_list_file_path=self.events_list_file_path,
+                overwrite=self.overwrite,
+                dataset_id=self.dataset_id,
+                credentials=self.credentials,
+                max_bad_records=self.max_bad_records,
+            )
+
+    def output(self):
+        return [task.output() for task in self.requires()]
+
+    def complete(self):
+        # OverwriteOutputMixin changes the complete() method behavior, so we override it.
+        return all(r.complete() for r in luigi.task.flatten(self.requires()))

--- a/edx/analytics/tasks/warehouse/load_warehouse_bigquery.py
+++ b/edx/analytics/tasks/warehouse/load_warehouse_bigquery.py
@@ -2,18 +2,18 @@ import datetime
 import os
 
 import luigi
+from google.cloud import bigquery
 
 from edx.analytics.tasks.common.pathutil import PathSetTask
-from edx.analytics.tasks.common.bigquery_load import BigQueryLoadTask
+from edx.analytics.tasks.common.bigquery_load import BigQueryLoadTask, BigQueryLoadDownstreamMixin
+from edx.analytics.tasks.insights.enrollments import EnrollmentSummaryRecord
 from edx.analytics.tasks.util.hive import WarehouseMixin, HivePartition
 from edx.analytics.tasks.util.overwrite import OverwriteOutputMixin
 from edx.analytics.tasks.util.url import ExternalURL, url_path_join
-from google.cloud import bigquery
+from edx.analytics.tasks.warehouse.load_internal_reporting_course_catalog import CourseRecord, ProgramCourseRecord, CourseSeatRecord
 
 
 class LoadInternalReportingCertificatesToBigQuery(WarehouseMixin, BigQueryLoadTask):
-
-    date = luigi.DateParameter()
 
     @property
     def table(self):
@@ -21,6 +21,7 @@ class LoadInternalReportingCertificatesToBigQuery(WarehouseMixin, BigQueryLoadTa
 
     @property
     def schema(self):
+        # Defined in load_internal_reporting_certificates, but not in a Record.
         return [
             bigquery.SchemaField('user_id', 'INTEGER', mode='REQUIRED'),
             bigquery.SchemaField('course_id', 'STRING', mode='REQUIRED'),
@@ -39,14 +40,13 @@ class LoadInternalReportingCertificatesToBigQuery(WarehouseMixin, BigQueryLoadTa
 
 class LoadInternalReportingCountryToBigQuery(WarehouseMixin, BigQueryLoadTask):
 
-    date = luigi.DateParameter()
-
     @property
     def table(self):
         return 'd_country'
 
     @property
     def schema(self):
+        # Defined in load_internal_reporting_country, but not in a Record.
         return [
             bigquery.SchemaField('country_name', 'STRING'),
             bigquery.SchemaField('user_last_location_country_code', 'STRING', mode='REQUIRED'),
@@ -59,8 +59,6 @@ class LoadInternalReportingCountryToBigQuery(WarehouseMixin, BigQueryLoadTask):
 
 class LoadInternalReportingCourseToBigQuery(WarehouseMixin, BigQueryLoadTask):
 
-    date = luigi.DateParameter()
-
     @property
     def insert_source_task(self):
         url = url_path_join(self.hive_partition_path('course_catalog', self.date), 'course_catalog.tsv')
@@ -72,31 +70,10 @@ class LoadInternalReportingCourseToBigQuery(WarehouseMixin, BigQueryLoadTask):
 
     @property
     def schema(self):
-        return [
-            bigquery.SchemaField('course_id', 'STRING', mode='REQUIRED'),
-            bigquery.SchemaField('catalog_course', 'STRING', mode='REQUIRED'),
-            bigquery.SchemaField('catalog_course_title', 'STRING'),
-            bigquery.SchemaField('start_time', 'DATETIME'),
-            bigquery.SchemaField('end_time', 'DATETIME'),
-            bigquery.SchemaField('enrollment_start_time', 'DATETIME'),
-            bigquery.SchemaField('enrollment_end_time', 'DATETIME'),
-            bigquery.SchemaField('content_language', 'STRING'),
-            bigquery.SchemaField('pacing_type', 'STRING'),
-            bigquery.SchemaField('level_type', 'STRING'),
-            bigquery.SchemaField('availability', 'STRING'),
-            bigquery.SchemaField('org_id', 'STRING', mode='REQUIRED'),
-            bigquery.SchemaField('partner_short_code', 'STRING'),
-            bigquery.SchemaField('marketing_url', 'STRING'),
-            bigquery.SchemaField('min_effort', 'INTEGER'),
-            bigquery.SchemaField('max_effort', 'INTEGER'),
-            bigquery.SchemaField('announcement_time', 'DATETIME'),
-            bigquery.SchemaField('reporting_type', 'STRING'),
-        ] 
+        return CourseRecord.get_bigquery_schema()
 
 
 class LoadInternalReportingCourseSeatToBigQuery(WarehouseMixin, BigQueryLoadTask):
-
-    date = luigi.DateParameter()
 
     @property
     def insert_source_task(self):
@@ -109,20 +86,10 @@ class LoadInternalReportingCourseSeatToBigQuery(WarehouseMixin, BigQueryLoadTask
 
     @property
     def schema(self):
-        return [
-            bigquery.SchemaField('course_id', 'STRING', mode='REQUIRED'),
-            bigquery.SchemaField('course_seat_type', 'STRING', mode='REQUIRED'),
-            bigquery.SchemaField('course_seat_price', 'FLOAT', mode='REQUIRED'),
-            bigquery.SchemaField('course_seat_currency', 'STRING', mode='REQUIRED'),
-            bigquery.SchemaField('course_seat_upgrade_deadline', 'DATETIME'),
-            bigquery.SchemaField('course_seat_credit_provider', 'STRING'),
-            bigquery.SchemaField('course_seat_credit_hours', 'INTEGER'),
-        ]
+        return CourseSeatRecord.get_bigquery_schema()
 
 
 class LoadInternalReportingProgramCourseToBigQuery(WarehouseMixin, BigQueryLoadTask):
-
-    date = luigi.DateParameter()
 
     @property
     def insert_source_task(self):
@@ -135,32 +102,21 @@ class LoadInternalReportingProgramCourseToBigQuery(WarehouseMixin, BigQueryLoadT
 
     @property
     def schema(self):
-        return [
-            bigquery.SchemaField('program_id', 'STRING', mode='REQUIRED'),
-            bigquery.SchemaField('program_type', 'STRING', mode='REQUIRED'),
-            bigquery.SchemaField('program_title', 'STRING'),
-            bigquery.SchemaField('catalog_course', 'STRING', mode='REQUIRED'),
-            bigquery.SchemaField('catalog_course_title', 'STRING'),
-            bigquery.SchemaField('course_id', 'STRING', mode='REQUIRED'),
-            bigquery.SchemaField('org_id', 'STRING', mode='REQUIRED'),
-            bigquery.SchemaField('partner_short_code', 'STRING'),
-            bigquery.SchemaField('program_slot_number', 'INTEGER'),
-        ]
+        return ProgramCourseRecord.get_bigquery_schema()
 
 
-class LoadInternalReportingCourseCatalogToBigQuery(WarehouseMixin, OverwriteOutputMixin, luigi.WrapperTask):
+class LoadInternalReportingCourseCatalogToBigQuery(WarehouseMixin, BigQueryLoadDownstreamMixin, luigi.WrapperTask):
 
-    dataset_id = luigi.Parameter()
-    credentials = luigi.Parameter()
     date = luigi.DateParameter()
 
     def requires(self):
         kwargs = {
             'date': self.date,
-            'warehouse_path': self.warehouse_path,
-            'overwrite': self.overwrite,
             'dataset_id': self.dataset_id,
             'credentials': self.credentials,
+            'max_bad_records': self.max_bad_records,
+            'overwrite': self.overwrite,
+            'warehouse_path': self.warehouse_path,
         }
         yield LoadInternalReportingCourseToBigQuery(**kwargs)
         yield LoadInternalReportingCourseSeatToBigQuery(**kwargs)
@@ -173,8 +129,6 @@ class LoadInternalReportingCourseCatalogToBigQuery(WarehouseMixin, OverwriteOutp
 
 class LoadUserCourseSummaryToBigQuery(WarehouseMixin, BigQueryLoadTask):
 
-    date = luigi.DateParameter()
-
     @property
     def insert_source_task(self):
         return ExternalURL(url=self.hive_partition_path('course_enrollment_summary', self.date))
@@ -185,23 +139,10 @@ class LoadUserCourseSummaryToBigQuery(WarehouseMixin, BigQueryLoadTask):
 
     @property
     def schema(self):
-        return [
-            bigquery.SchemaField('course_id', 'STRING', mode='REQUIRED'),
-            bigquery.SchemaField('user_id', 'INTEGER', mode='REQUIRED'),
-            bigquery.SchemaField('current_enrollment_mode', 'STRING', mode='REQUIRED'),
-            bigquery.SchemaField('current_enrollment_is_active', 'STRING', mode='REQUIRED'),
-            bigquery.SchemaField('first_enrollment_mode', 'STRING'),
-            bigquery.SchemaField('first_enrollment_time', 'DATETIME'),
-            bigquery.SchemaField('last_unenrollment_time', 'DATETIME'),
-            bigquery.SchemaField('first_verified_enrollment_time', 'DATETIME'),
-            bigquery.SchemaField('first_credit_enrollment_time', 'DATETIME'),
-            bigquery.SchemaField('end_time', 'DATETIME', mode='REQUIRED'),
-        ]
+        return EnrollmentSummaryRecord.get_bigquery_schema()
 
 
 class LoadInternalReportingUserActivityToBigQuery(WarehouseMixin, BigQueryLoadTask):
-
-    date = luigi.DateParameter()
 
     def __init__(self, *args, **kwargs):
         super(LoadInternalReportingUserActivityToBigQuery, self).__init__(*args, **kwargs)
@@ -232,6 +173,7 @@ class LoadInternalReportingUserActivityToBigQuery(WarehouseMixin, BigQueryLoadTa
 
     @property
     def schema(self):
+        # Defined in load_internal_reporting_user_activity, but not in a Record.
         return [
             bigquery.SchemaField('user_id', 'INTEGER', mode='REQUIRED'),
             bigquery.SchemaField('course_id', 'STRING', mode='REQUIRED'),
@@ -242,8 +184,6 @@ class LoadInternalReportingUserActivityToBigQuery(WarehouseMixin, BigQueryLoadTa
 
 
 class LoadInternalReportingUserToBigQuery(WarehouseMixin, BigQueryLoadTask):
-
-    date = luigi.DateParameter()
 
     @property
     def partition(self):
@@ -260,6 +200,8 @@ class LoadInternalReportingUserToBigQuery(WarehouseMixin, BigQueryLoadTask):
 
     @property
     def schema(self):
+        # Defined in load_internal_reporting_user, but not in a Record.
+        # The names of fields here and Vertica is also different than in Hive, with 'user_' prepended to all but 'user_id'.
         return [
             bigquery.SchemaField('user_id', 'INTEGER'),
             bigquery.SchemaField('user_year_of_birth', 'INTEGER'),
@@ -273,7 +215,6 @@ class LoadInternalReportingUserToBigQuery(WarehouseMixin, BigQueryLoadTask):
 
 
 class DailyLoadSubjectsToBigQueryTask(WarehouseMixin, BigQueryLoadTask):
-    date = luigi.DateParameter()
 
     @property
     def insert_source_task(self):
@@ -288,6 +229,7 @@ class DailyLoadSubjectsToBigQueryTask(WarehouseMixin, BigQueryLoadTask):
 
     @property
     def schema(self):
+        # Defined in course_catalog, but not in a Record.
         return [
             bigquery.SchemaField('course_id', 'STRING'),
             bigquery.SchemaField('date', 'DATE'),
@@ -297,52 +239,34 @@ class DailyLoadSubjectsToBigQueryTask(WarehouseMixin, BigQueryLoadTask):
         ]
 
 
-class LoadWarehouseBigQueryTask(WarehouseMixin, luigi.WrapperTask):
+class LoadWarehouseBigQueryTask(BigQueryLoadDownstreamMixin, WarehouseMixin, luigi.WrapperTask):
 
     date = luigi.DateParameter()
-    dataset_id = luigi.Parameter()
-    credentials = luigi.Parameter()
-    overwrite = luigi.BooleanParameter(default=False, significant=False)
 
     def requires(self):
         kwargs = {
+            'date': self.date,
             'dataset_id': self.dataset_id,
             'credentials': self.credentials,
+            'max_bad_records': self.max_bad_records,
             'overwrite': self.overwrite,
             'warehouse_path': self.warehouse_path,
         }
 
-        yield LoadInternalReportingCertificatesToBigQuery(
-            date=self.date,
-            **kwargs
-        )
+        yield LoadInternalReportingCertificatesToBigQuery(**kwargs)
 
-        yield LoadInternalReportingCountryToBigQuery(
-            date=self.date,
-            **kwargs
-        )
+        yield LoadInternalReportingCountryToBigQuery(**kwargs)
 
-        yield LoadInternalReportingCourseCatalogToBigQuery(
-            date=self.date,
-            **kwargs
-        )
+        yield LoadInternalReportingCourseCatalogToBigQuery(**kwargs)
 
-        yield LoadUserCourseSummaryToBigQuery(
-            date=self.date,
-            **kwargs
-        )
+        yield LoadUserCourseSummaryToBigQuery(**kwargs)
 
-        yield LoadInternalReportingUserActivityToBigQuery(
-            date=self.date,
-            **kwargs
-        )
+        yield LoadInternalReportingUserActivityToBigQuery(**kwargs)
 
-        yield LoadInternalReportingUserToBigQuery(
-            date=self.date,
-            **kwargs
-        )
+        yield LoadInternalReportingUserToBigQuery(**kwargs)
 
-        yield DailyLoadSubjectsToBigQueryTask(
-            date=self.date,
-            **kwargs
-        )
+        yield DailyLoadSubjectsToBigQueryTask(**kwargs)
+
+    def complete(self):
+        # OverwriteOutputMixin changes the complete() method behavior, so we override it.
+        return all(r.complete() for r in luigi.task.flatten(self.requires()))

--- a/edx/analytics/tasks/warehouse/tests/test_load_internal_reporting_events.py
+++ b/edx/analytics/tasks/warehouse/tests/test_load_internal_reporting_events.py
@@ -1,30 +1,38 @@
 """Test processing of events for loading into Hive, etc."""
 
+import datetime
+import json
 import unittest
 
-from ddt import ddt, data
+import ciso8601
+from ddt import ddt, data, unpack
 import luigi
 
 from edx.analytics.tasks.common.tests.map_reduce_mixins import MapperTestMixin
+from edx.analytics.tasks.util import eventlog
+from edx.analytics.tasks.util.obfuscate_util import backslash_encode_value
 from edx.analytics.tasks.util.tests.opaque_key_mixins import InitializeOpaqueKeysMixin
 from edx.analytics.tasks.warehouse.load_internal_reporting_events import (
     EventRecord,
+    JsonEventRecord,
     TrackingEventRecordDataTask,
     SegmentEventRecordDataTask,
+    PerDateTrackingEventRecordDataTask,
+    PerDateSegmentEventRecordDataTask,
     VERSION,
 )
 
 
-@ddt
-class TrackingEventRecordTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMixin, unittest.TestCase):
-    """Base class for test analysis of detailed student engagement"""
+class BaseTrackingEventRecordTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMixin):
+    """Base class for test analysis of tracking log events."""
 
     DEFAULT_USER_ID = 10
     DEFAULT_TIMESTAMP = "2013-12-17T15:38:32.805444"
     DEFAULT_DATE = "2013-12-17"
+    EVENT_RECORD_TYPE = "unknown"
 
     def setUp(self):
-        super(TrackingEventRecordTaskMapTest, self).setUp()
+        super(BaseTrackingEventRecordTaskMapTest, self).setUp()
 
         self.initialize_ids()
         self.video_id = 'i4x-foo-bar-baz'
@@ -82,10 +90,17 @@ class TrackingEventRecordTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMixin,
         if not date:
             date = self.DEFAULT_DATE
         self.task = TrackingEventRecordDataTask(
-            date=luigi.DateParameter().parse(date),
+            interval=luigi.DateIntervalParameter().parse(date),
             output_root='/fake/output',
+            event_record_type=self.EVENT_RECORD_TYPE,
         )
         self.task.init_local()
+
+@ddt
+class TrackingEventRecordTaskMapTest(BaseTrackingEventRecordTaskMapTest, unittest.TestCase):
+    """Test class for emission of tracking log events in EventRecord format."""
+
+    EVENT_RECORD_TYPE = "EventRecord"
 
     @data(
         {'time': "2013-12-01T15:38:32.805444"},
@@ -120,11 +135,7 @@ class TrackingEventRecordTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMixin,
             'agent': 'blah, blah, blah',
         }
         expected_value = EventRecord(**expected_dict).to_separated_values()
-        self.assert_single_map_output(
-            event,
-            expected_key,
-            expected_value
-        )
+        self.assert_single_map_output(event, expected_key, expected_value)
 
     def test_play_video(self):
         template = self.event_templates['play_video']
@@ -162,16 +173,102 @@ class TrackingEventRecordTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMixin,
             'currenttime': '630.437320479',
         }
         expected_value = EventRecord(**expected_dict).to_separated_values()
-        self.assert_single_map_output(
-            event,
-            expected_key,
-            expected_value
-        )
-
+        self.assert_single_map_output(event, expected_key, expected_value)
 
 @ddt
-class SegmentEventRecordTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMixin, unittest.TestCase):
-    """Base class for test analysis of detailed student engagement"""
+class TrackingJsonEventRecordTaskMapTest(BaseTrackingEventRecordTaskMapTest, unittest.TestCase):
+    """Test class for emission of tracking log events in JsonEventRecord format."""
+
+    EVENT_RECORD_TYPE = "JsonEventRecord"
+
+    def get_raw_event(self, event_line):
+        event = eventlog.parse_json_event(event_line)
+        event_data = eventlog.get_event_data(event)
+        if event_data is not None:
+            event['event'] = event_data
+        dump = json.dumps(event, sort_keys=True)
+        encoded_dump = backslash_encode_value(dump)
+        return encoded_dump
+
+    def _get_event_record_from_mapper(self, kwargs):
+        """Returns an EventRecord constructed from mapper output."""
+        line = self.create_event_log_line(**kwargs)
+        mapper_output = tuple(self.task.mapper(line))
+        self.assertEquals(len(mapper_output), 1)
+        row = mapper_output[0]
+        self.assertEquals(len(row), 2)
+        _actual_key, actual_value = row
+        return JsonEventRecord.from_tsv(actual_value)
+
+    @data(
+        {'time': "2013-12-01T15:38:32.805444"},  # a good time, but lies outside the interval
+        {'event_type': None},
+        {'event': 'sdfasdf'},
+    )
+    def test_invalid_events(self, kwargs):
+        self.assert_no_map_output_for(self.create_event_log_line(**kwargs))
+
+    @data(
+        {'event_type': '/implicit/event/url'},
+    )
+    def test_implicit_events(self, kwargs):
+        event = self.create_event_log_line(**kwargs)
+        actual_record = self._get_event_record_from_mapper(kwargs)
+        url = getattr(actual_record, 'url')
+        self.assertEquals(url, kwargs['event_type'])
+        self.assertEquals(getattr(actual_record, 'event_type'), 'edx.server.request')
+
+    def test_problem_check(self):
+        template = self.event_templates['problem_check']
+        event = self.create_event_log_line(template=template)
+        expected_key = (self.DEFAULT_DATE, self.task.PROJECT_NAME)
+        expected_dict = {
+            'input_file': '',
+            'source': self.task.PROJECT_NAME,
+            'event_type': 'problem_check',
+            'emitter_type': 'server',
+            'timestamp': ciso8601.parse_datetime('2013-12-17T15:38:32.805444+00:00'),
+            'received_at': ciso8601.parse_datetime('2013-12-17T15:38:32.805444+00:00'),
+            'date': datetime.date(*[int(x) for x in self.DEFAULT_DATE.split('-')]),
+            'username': 'test_user',
+            'course_id': self.encoded_course_id,
+            'org_id': self.encoded_org_id,
+            'user_id': '10',
+            'raw_event': self.get_raw_event(event),
+        }
+        expected_value = JsonEventRecord(**expected_dict).to_separated_values()
+        self.assert_single_map_output(event, expected_key, expected_value)
+
+    def test_play_video(self):
+        template = self.event_templates['play_video']
+        event = self.create_event_log_line(template=template)
+        expected_key = (self.DEFAULT_DATE, self.task.PROJECT_NAME)
+        expected_dict = {
+            'input_file': '',
+            'source': self.task.PROJECT_NAME,
+            'event_type': 'play_video',
+            'emitter_type': 'browser',
+            'timestamp': ciso8601.parse_datetime('2013-12-17T15:38:32.805444+00:00'),
+            'received_at': ciso8601.parse_datetime('2013-12-17T15:38:32.805444+00:00'),
+            'date': datetime.date(*[int(x) for x in self.DEFAULT_DATE.split('-')]),
+            'username': 'test_user',
+            'course_id': self.encoded_course_id,
+            'org_id': self.encoded_org_id,
+            'user_id': '10',
+            'referrer': 'long meaningful url',
+            'agent_type': 'desktop',
+            'agent_device_name': 'Other',
+            'agent_os': 'Mac OS X',
+            'agent_browser': 'Safari',
+            'agent_touch_capable': False,
+            'raw_event': self.get_raw_event(event),
+        }
+        expected_value = JsonEventRecord(**expected_dict).to_separated_values()
+        self.assert_single_map_output(event, expected_key, expected_value)
+
+
+class BaseSegmentEventRecordTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMixin, unittest.TestCase):
+    """Base class for test analysis of segment events."""
 
     DEFAULT_USER_ID = 10
     DEFAULT_TIMESTAMP = "2013-12-17T15:38:32"
@@ -179,8 +276,10 @@ class SegmentEventRecordTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMixin, 
     DEFAULT_ANONYMOUS_ID = "abcdef12-3456-789a-bcde-f0123456789a"
     DEFAULT_PROJECT = "segment_test"
 
+    EVENT_RECORD_TYPE = "unknown"
+
     def setUp(self):
-        super(SegmentEventRecordTaskMapTest, self).setUp()
+        super(BaseSegmentEventRecordTaskMapTest, self).setUp()
 
         self.initialize_ids()
         self.event_templates = {
@@ -266,10 +365,18 @@ class SegmentEventRecordTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMixin, 
         if not date:
             date = self.DEFAULT_DATE
         self.task = SegmentEventRecordDataTask(
-            date=luigi.DateParameter().parse(date),
+            interval=luigi.DateIntervalParameter().parse(date),
             output_root='/fake/output',
+            event_record_type=self.EVENT_RECORD_TYPE,
         )
         self.task.init_local()
+
+
+@ddt
+class SegmentEventRecordTaskMapTest(BaseSegmentEventRecordTaskMapTest, unittest.TestCase):
+    """Test class for emission of segment log events in JsonEventRecord format."""
+
+    EVENT_RECORD_TYPE = "EventRecord"
 
     @data(
         {'receivedAt': "2013-12-01T15:38:32.805444Z"},
@@ -307,6 +414,20 @@ class SegmentEventRecordTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMixin, 
         actual_record = self._get_event_record_from_mapper(kwargs)
         timestamp = getattr(actual_record, 'timestamp')
         self.assertEquals(timestamp, None)
+
+    @data(
+        ({'receivedAt': "2013-12-17T15:38:32.805444Z", 'requestTime': "2014-12-18T15:38:32.805444Z"}, "2013-12-17T15:38:32.805444+00:00"),
+        ({'requestTime': "2014-12-01T15:38:32.805444Z"}, '2014-12-01T15:38:32.805444+00:00'), # default to requestTime
+        ({}, '2013-12-17T15:38:32.796000+00:00'), # default to timestamp
+    )
+    @unpack
+    def test_defaulting_arrival_timestamps(self, kwargs, expected_timestamp):
+        template = self.event_templates['android_screen']
+        del template['receivedAt']
+        line = self.create_event_log_line(template=template, **kwargs)
+        line_json = json.loads(line)
+        timestamp = self.task.get_event_arrival_time(line_json)
+        self.assertEquals(timestamp, expected_timestamp)
 
     def test_android_screen(self):
         template = self.event_templates['android_screen']
@@ -346,8 +467,126 @@ class SegmentEventRecordTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMixin, 
             'screen_height': '2560',
         }
         expected_value = EventRecord(**expected_dict).to_separated_values()
-        self.assert_single_map_output(
-            event,
-            expected_key,
-            expected_value
+        self.assert_single_map_output(event, expected_key, expected_value)
+
+
+@ddt
+class SegmentJsonEventRecordTaskMapTest(BaseSegmentEventRecordTaskMapTest, unittest.TestCase):
+    """Test class for emission of segment log events in JsonEventRecord format."""
+
+    EVENT_RECORD_TYPE = "JsonEventRecord"
+
+    def get_raw_event(self, event_line):
+        event = eventlog.parse_json_event(event_line)
+        dump = json.dumps(event, sort_keys=True)
+        encoded_dump = backslash_encode_value(dump)
+        return encoded_dump
+
+    @data(
+        {'receivedAt': "2013-12-01T15:38:32.805444Z"},
+        {'type': 'track', 'event': None},
+        {'type': 'track', 'event': '/implicit/event/url'},
+    )
+    def test_invalid_events(self, kwargs):
+        self.assert_no_map_output_for(self.create_event_log_line(**kwargs))
+
+    def _get_event_record_from_mapper(self, kwargs):
+        """Returns an EventRecord constructed from mapper output."""
+        line = self.create_event_log_line(**kwargs)
+        mapper_output = tuple(self.task.mapper(line))
+        self.assertEquals(len(mapper_output), 1)
+        row = mapper_output[0]
+        self.assertEquals(len(row), 2)
+        _actual_key, actual_value = row
+        return JsonEventRecord.from_tsv(actual_value)
+
+    @data(
+        {'sentAt': '2016-7-26T13:26:23-0500'},
+        {'sentAt': '2016-07-26T13:34:0026-0400'},
+        {'sentAt': '2016-0007-29T12:15:34+0530'},
+        {'sentAt': '2016-07-26 05:11:37 a.m. +0000'},
+    )
+    def test_funky_but_parsable_timestamps(self, kwargs):
+        actual_record = self._get_event_record_from_mapper(kwargs)
+        timestamp = getattr(actual_record, 'timestamp')
+        self.assertNotEquals(timestamp, None)
+
+    @data(
+        {'sentAt': '2016-07-26 05:11:37 a.m. +000A'},
+        # TODO: figure out why this no longer works!
+        # {'sentAt': '0300-01-01T00:00:00.000Z'},
+    )
+    def test_unparsable_timestamps(self, kwargs):
+        actual_record = self._get_event_record_from_mapper(kwargs)
+        timestamp = getattr(actual_record, 'timestamp')
+        self.assertEquals(timestamp, None)
+
+    @data(
+        {'properties': {'course_id': 'course-v1:FooX+1.23x+2013_Spring'}},
+        {'properties': {'courseid': 'course-v1:FooX+1.23x+2013_Spring'}},
+        {'properties': {'course': 'course-v1:FooX+1.23x+2013_Spring'}},
+        {'properties': {'label': 'course-v1:FooX+1.23x+2013_Spring'}},
+        {'properties': {'url': 'https://courses.edx.org/courses/course-v1:FooX+1.23x+2013_Spring'}},
+        {'properties': {'url': 'https://courses.edx.org/courses/FooX/1.23x/2013_Spring'}},
+        {'properties': {'url': 'https://courses.edx.org/verify_student/start-flow/course-v1:FooX+1.23x+2013_Spring/'}},
+        {'properties': {'url': 'https://courses.edx.org/course_modes/choose/course-v1:FooX+1.23x+2013_Spring/'}},
+    )
+    def test_course_ids(self, kwargs):
+        actual_record = self._get_event_record_from_mapper(kwargs)
+        course_id = getattr(actual_record, 'course_id')
+        self.assertNotEquals(course_id, None)
+        org_id = getattr(actual_record, 'org_id')
+        self.assertNotEquals(org_id, None)
+
+    def test_android_screen(self):
+        template = self.event_templates['android_screen']
+        event = self.create_event_log_line(template=template)
+        expected_key = (self.DEFAULT_DATE, self.DEFAULT_PROJECT)
+        expected_dict = {
+            'input_file': '',
+            'source': self.DEFAULT_PROJECT,
+            'event_type': 'screen',
+            'emitter_type': 'server',
+            'timestamp': ciso8601.parse_datetime('2013-12-17T15:38:32+00:00'),
+            'received_at': ciso8601.parse_datetime('2013-12-17T15:38:32.796000+00:00'),
+            'date': datetime.date(*[int(x) for x in self.DEFAULT_DATE.split('-')]),
+            'agent_type': 'tablet',
+            'agent_device_name': 'Samsung SM-N920A',
+            'agent_os': 'Android',
+            'agent_browser': 'Android',
+            'agent_touch_capable': True,
+            'anonymous_id': self.DEFAULT_ANONYMOUS_ID,
+            'category': 'screen',
+            'label': 'Launch',
+            'raw_event': self.get_raw_event(event),
+        }
+        expected_value = JsonEventRecord(**expected_dict).to_separated_values()
+        self.assert_single_map_output(event, expected_key, expected_value)
+
+
+class PerDateTrackingJsonEventRecordTaskMapTest(TrackingJsonEventRecordTaskMapTest):
+
+    def create_task(self, date=None):  # pylint: disable=arguments-differ
+        """Allow arguments to be passed to the task constructor."""
+        if not date:
+            date = self.DEFAULT_DATE
+        self.task = PerDateTrackingEventRecordDataTask(
+            date=luigi.DateParameter().parse(date),
+            output_root='/fake/output',
+            event_record_type=self.EVENT_RECORD_TYPE,
         )
+        self.task.init_local()
+
+
+class PerDateSegmentJsonEventRecordTaskMapTest(SegmentJsonEventRecordTaskMapTest):
+
+    def create_task(self, date=None):  # pylint: disable=arguments-differ
+        """Allow arguments to be passed to the task constructor."""
+        if not date:
+            date = self.DEFAULT_DATE
+        self.task = PerDateSegmentEventRecordDataTask(
+            date=luigi.DateParameter().parse(date),
+            output_root='/fake/output',
+            event_record_type=self.EVENT_RECORD_TYPE,
+        )
+        self.task.init_local()


### PR DESCRIPTION
This is the merging of what was in brian/load-json-events into master, so that it can coexist with outputting regular (non-JSON) events to Vertica.  

This includes an incremental improvement to the non-JSON events, fixing some early shortcomings by looking for user_id, username, and course_id values in additional places of Segment events.  The version number has been updated to 0.2.4, but no new columns are added so the data can coexist.  (In four months, it will be completely up-to-date.)

Unit tests pass, and regular events compare as expected.  Currently verifying JSON events and running the existing acceptance test.   BigQuery-related work will be done in a separate branch.