### PR TITLE
Add support for BigQuery event loading

### DIFF
--- a/edx/analytics/tasks/common/bigquery_load.py
+++ b/edx/analytics/tasks/common/bigquery_load.py
@@ -317,9 +317,3 @@ class BigQueryLoadTask(BigQueryLoadDownstreamMixin, luigi.Task):
             return True
         else:
             return False
-
-
-class BigQueryLoadDailyPartitionTask(BigQueryLoadTask):
-    """Like BigQueryLoadTask, but loads only a date partition into a table, not the entire table."""
-
-

--- a/edx/analytics/tasks/util/record.py
+++ b/edx/analytics/tasks/util/record.py
@@ -5,7 +5,11 @@ import re
 import datetime
 import itertools
 
-from google.cloud.bigquery import SchemaField
+try:
+    from google.cloud.bigquery import SchemaField
+    bigquery_available = True  # pylint: disable=invalid-name
+except ImportError:
+    bigquery_available = False  # pylint: disable=invalid-name
 
 
 DEFAULT_NULL_VALUE = '\\N'  # This is the default string used by Hive to represent a NULL value.
@@ -365,6 +369,9 @@ class Record(object):
 
         Returns: A list of BigQuery SchemaField objects.
         """
+        if not bigquery_available:
+            raise ImportError('Bigquery library not available')
+
         schema = []
         for field_name, field_obj in cls.get_fields().items():
             mode = 'NULLABLE' if field_obj.nullable else 'REQUIRED'

--- a/edx/analytics/tasks/warehouse/load_internal_reporting_events.py
+++ b/edx/analytics/tasks/warehouse/load_internal_reporting_events.py
@@ -649,6 +649,8 @@ class BaseEventRecordDataTask(EventRecordDataDownstreamMixin, MultiOutputMapRedu
                 value = None
             else:
                 value = backslash_encode_value(unicode(obj))
+                if '\x00' in value:
+                    value = value.replace('\x00', '\0')
                 # Avoid validation errors later due to length by truncating here.
                 field_length = event_record_field.length
                 value_length = len(value)

--- a/edx/analytics/tasks/warehouse/load_internal_reporting_events.py
+++ b/edx/analytics/tasks/warehouse/load_internal_reporting_events.py
@@ -1287,6 +1287,10 @@ class SegmentEventRecordDataTask(SegmentEventLogSelectionMixin, BaseEventRecordD
 class BulkEventRecordIntervalTask(EventRecordDownstreamMixin, luigi.WrapperTask):
     """Compute event information over a range of dates and insert the results into Hive."""
 
+    interval = luigi.DateIntervalParameter(
+        description='The range of dates for which to create event records.',
+    )
+
     def requires(self):
         kwargs = {
             'output_root': self.warehouse_path,

--- a/edx/analytics/tasks/warehouse/load_warehouse_bigquery.py
+++ b/edx/analytics/tasks/warehouse/load_warehouse_bigquery.py
@@ -105,19 +105,18 @@ class LoadInternalReportingProgramCourseToBigQuery(WarehouseMixin, BigQueryLoadT
         return ProgramCourseRecord.get_bigquery_schema()
 
 
-class LoadInternalReportingCourseCatalogToBigQuery(WarehouseMixin, OverwriteOutputMixin, luigi.WrapperTask):
+class LoadInternalReportingCourseCatalogToBigQuery(WarehouseMixin, BigQueryLoadDownstreamMixin, luigi.WrapperTask):
 
-    dataset_id = luigi.Parameter()
-    credentials = luigi.Parameter()
     date = luigi.DateParameter()
 
     def requires(self):
         kwargs = {
             'date': self.date,
-            'warehouse_path': self.warehouse_path,
-            'overwrite': self.overwrite,
             'dataset_id': self.dataset_id,
             'credentials': self.credentials,
+            'max_bad_records': self.max_bad_records,
+            'overwrite': self.overwrite,
+            'warehouse_path': self.warehouse_path,
         }
         yield LoadInternalReportingCourseToBigQuery(**kwargs)
         yield LoadInternalReportingCourseSeatToBigQuery(**kwargs)

--- a/edx/analytics/tasks/warehouse/tests/test_load_internal_reporting_events.py
+++ b/edx/analytics/tasks/warehouse/tests/test_load_internal_reporting_events.py
@@ -16,6 +16,8 @@ from edx.analytics.tasks.warehouse.load_internal_reporting_events import (
     JsonEventRecord,
     TrackingEventRecordDataTask,
     SegmentEventRecordDataTask,
+    PerDateTrackingEventRecordDataTask,
+    PerDateSegmentEventRecordDataTask,
     VERSION,
 )
 
@@ -87,7 +89,7 @@ class BaseTrackingEventRecordTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMi
         if not date:
             date = self.DEFAULT_DATE
         self.task = TrackingEventRecordDataTask(
-            date=luigi.DateParameter().parse(date),
+            interval=luigi.DateIntervalParameter().parse(date),
             output_root='/fake/output',
             event_record_type=self.EVENT_RECORD_TYPE,
         )
@@ -391,7 +393,7 @@ class BaseSegmentEventRecordTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMix
         if not date:
             date = self.DEFAULT_DATE
         self.task = SegmentEventRecordDataTask(
-            date=luigi.DateParameter().parse(date),
+            interval=luigi.DateIntervalParameter().parse(date),
             output_root='/fake/output',
             event_record_type=self.EVENT_RECORD_TYPE,
         )
@@ -591,3 +593,31 @@ class SegmentJsonEventRecordTaskMapTest(BaseSegmentEventRecordTaskMapTest, unitt
         }
         expected_value = JsonEventRecord(**expected_dict).to_separated_values()
         self.assert_single_map_output(event, expected_key, expected_value)
+
+
+class PerDateTrackingJsonEventRecordTaskMapTest(TrackingJsonEventRecordTaskMapTest):
+
+    def create_task(self, date=None):  # pylint: disable=arguments-differ
+        """Allow arguments to be passed to the task constructor."""
+        if not date:
+            date = self.DEFAULT_DATE
+        self.task = PerDateTrackingEventRecordDataTask(
+            date=luigi.DateParameter().parse(date),
+            output_root='/fake/output',
+            event_record_type=self.EVENT_RECORD_TYPE,
+        )
+        self.task.init_local()
+
+
+class PerDateSegmentJsonEventRecordTaskMapTest(SegmentJsonEventRecordTaskMapTest):
+
+    def create_task(self, date=None):  # pylint: disable=arguments-differ
+        """Allow arguments to be passed to the task constructor."""
+        if not date:
+            date = self.DEFAULT_DATE
+        self.task = PerDateSegmentEventRecordDataTask(
+            date=luigi.DateParameter().parse(date),
+            output_root='/fake/output',
+            event_record_type=self.EVENT_RECORD_TYPE,
+        )
+        self.task.init_local()

--- a/edx/analytics/tasks/warehouse/tests/test_load_internal_reporting_events.py
+++ b/edx/analytics/tasks/warehouse/tests/test_load_internal_reporting_events.py
@@ -1,5 +1,6 @@
 """Test processing of events for loading into Hive, etc."""
 
+import datetime
 import json
 import unittest
 
@@ -227,7 +228,7 @@ class TrackingJsonEventRecordTaskMapTest(BaseTrackingEventRecordTaskMapTest, uni
             # 'event_category': 'unknown',
             'timestamp': ciso8601.parse_datetime('2013-12-17T15:38:32.805444+00:00'),
             'received_at': ciso8601.parse_datetime('2013-12-17T15:38:32.805444+00:00'),
-            'date': self.DEFAULT_DATE,
+            'date': datetime.date(*[int(x) for x in self.DEFAULT_DATE.split('-')]),
             # 'host': 'test_host',
             # 'ip': '127.0.0.1',
             'username': 'test_user',
@@ -260,7 +261,7 @@ class TrackingJsonEventRecordTaskMapTest(BaseTrackingEventRecordTaskMapTest, uni
             # 'event_category': 'unknown',
             'timestamp': ciso8601.parse_datetime('2013-12-17T15:38:32.805444+00:00'),
             'received_at': ciso8601.parse_datetime('2013-12-17T15:38:32.805444+00:00'),
-            'date': self.DEFAULT_DATE,
+            'date': datetime.date(*[int(x) for x in self.DEFAULT_DATE.split('-')]),
             # 'host': 'test_host',
             # 'ip': '127.0.0.1',
             'username': 'test_user',
@@ -562,7 +563,7 @@ class SegmentJsonEventRecordTaskMapTest(BaseSegmentEventRecordTaskMapTest, unitt
             # 'event_category': 'screen',
             'timestamp': ciso8601.parse_datetime('2013-12-17T15:38:32+00:00'),
             'received_at': ciso8601.parse_datetime('2013-12-17T15:38:32.796000+00:00'),
-            'date': self.DEFAULT_DATE,
+            'date': datetime.date(*[int(x) for x in self.DEFAULT_DATE.split('-')]),
             # 'agent': 'Dalvik/2.1.0 (Linux; U; Android 5.1.1; SAMSUNG-SM-N920A Build/LMY47X)',
             'agent_type': 'tablet',
             'agent_device_name': 'Samsung SM-N920A',


### PR DESCRIPTION
Involves refactoring existing loading code into partition-based and non-partition-based tasks. 

Regular warehouse loading continues to use non-partition-based tasks.   The event loading uses partition-based tasks, for which overwrite is at the partition level rather than the table level. 