### PR TITLE
Translation of MySQL's LONGBLOB to Vertica's LONG VARBINARY.  

### DIFF
--- a/edx/analytics/tasks/warehouse/load_internal_reporting_database.py
+++ b/edx/analytics/tasks/warehouse/load_internal_reporting_database.py
@@ -70,6 +70,8 @@ class LoadMysqlToVerticaTableTask(MysqlToVerticaTaskMixin, VerticaCopyTask):
                     field_type = field_type.rsplit('(')[0]
                 elif field_type == 'longtext':
                     field_type = 'LONG VARCHAR'
+                elif field_type == 'longblob':
+                    field_type = 'LONG VARBINARY'
                 elif field_type == 'double':
                     field_type = 'DOUBLE PRECISION'
 


### PR DESCRIPTION
Data loss is possible here, LONGBLOB's storage space is considerably larger than Vertica's LONG VARBINARY.  However this was the best option.