### PR TITLE
Add missing backslash for null ascii.

### DIFF
--- a/edx/analytics/tasks/warehouse/load_internal_reporting_events.py
+++ b/edx/analytics/tasks/warehouse/load_internal_reporting_events.py
@@ -650,7 +650,7 @@ class BaseEventRecordDataTask(EventRecordDataDownstreamMixin, MultiOutputMapRedu
             else:
                 value = backslash_encode_value(unicode(obj))
                 if '\x00' in value:
-                    value = value.replace('\x00', '\0')
+                    value = value.replace('\x00', '\\0')
                 # Avoid validation errors later due to length by truncating here.
                 field_length = event_record_field.length
                 value_length = len(value)

--- a/edx/analytics/tasks/warehouse/tests/test_load_internal_reporting_events.py
+++ b/edx/analytics/tasks/warehouse/tests/test_load_internal_reporting_events.py
@@ -346,7 +346,7 @@ class BaseSegmentEventRecordTaskMapTest(InitializeOpaqueKeysMixin, MapperTestMix
                         "app_name": "edx.mobileapp.android",
                     },
                     "category": "screen",
-                    "label": "Launch",
+                    "label": "Launch\x00",
                 },
                 "writeKey": "dummy_write_key",
                 "projectId": self.DEFAULT_PROJECT,
@@ -453,7 +453,7 @@ class SegmentEventRecordTaskMapTest(BaseSegmentEventRecordTaskMapTest, unittest.
             'channel': 'server',
             'anonymous_id': self.DEFAULT_ANONYMOUS_ID,
             'category': 'screen',
-            'label': 'Launch',
+            'label': 'Launch\\0',
             'locale': 'en-US',
             'timezone': 'America/New_York',
             'app_name': 'edX',
@@ -557,7 +557,7 @@ class SegmentJsonEventRecordTaskMapTest(BaseSegmentEventRecordTaskMapTest, unitt
             'agent_touch_capable': True,
             'anonymous_id': self.DEFAULT_ANONYMOUS_ID,
             'category': 'screen',
-            'label': 'Launch',
+            'label': 'Launch\\0',
             'raw_event': self.get_raw_event(event),
         }
         expected_value = JsonEventRecord(**expected_dict).to_separated_values()


### PR DESCRIPTION
Some events for project hqawk62tyf contain a '\x00' character at the end of the 'label' property, which is not accepted by BigQuery.  These seem to appear only on 'edx.bi.search-results.query.submitted' events, and I'm guessing that the 'label' contains the search string.

This PR makes a fix (or rather, fixes a fix), so that such characters are escaped as '\0' (which is expressed in code as '\\0').  

This was tested on 6/14/2017 data, though the issue arises for 5/1, 4/29, 4/28 and 4/3 (among others).