### PR TITLE
Bump boto to latest version due to AWS EMR SSL/TLS update.

### DIFF
--- a/edx/analytics/tasks/util/tests/test_aws_elasticsearch_connection.py
+++ b/edx/analytics/tasks/util/tests/test_aws_elasticsearch_connection.py
@@ -36,7 +36,7 @@ class AwsElasticsearchConnectionTests(TestCase):
         self.assertTrue('my_access_key' in auth_header)
 
     def test_timeout(self):
-        def fake_connection(_address):
+        def fake_connection(_address, timeout=None):
             """Fail immediately with a socket timeout."""
             raise socket.timeout('fake error')
         socket.create_connection = fake_connection

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,10 +1,10 @@
 # These packages are required for bootstrapping.
 
 ansible==1.4.5 --no-binary ansible         # GPL v3 License
-boto==2.22.1            # MIT
-ecdsa==0.13 		# MIT
-Jinja2==2.8.1		# BSD
-pycrypto==2.6.1 	# public domain
+boto==2.48.0        # MIT
+ecdsa==0.13         # MIT
+Jinja2==2.8.1       # BSD
+pycrypto==2.6.1     # public domain
 
 # The following are dependencies pulled in by the above,
 # but are pinned here.


### PR DESCRIPTION
According to an email from AWS:

> Amazon EMR is in the process of updating the SSL/TLS certificates it uses to secure communications with customers, with the changes scheduled to be made on December 3, 2017 4:00 PM PST. 

and, the important part for us:

> If you are using a version of the Python AWS SDK or CLI released before February 5, 2015, you must upgrade.

This PR bumps our use of `boto` to the latest version in preparation for this change.
