### PR TITLE
Allow empty inserts for ModuleEngagementSummaryMetricRangesMysqlTask

### DIFF
--- a/edx/analytics/tasks/insights/module_engagement.py
+++ b/edx/analytics/tasks/insights/module_engagement.py
@@ -766,6 +766,10 @@ class ModuleEngagementSummaryMetricRangesMysqlTask(ModuleEngagementDownstreamMix
                     'want.',
         significant=False
     )
+    allow_empty_insert = luigi.BooleanParameter(
+        default=False,
+        config_path={'section': 'module-engagement', 'name': 'allow_empty_insert'},
+    )
 
     @property
     def table(self):


### PR DESCRIPTION
Sites with periods of low learner activity may sometimes have no learner summary data to record.

This change allows empty inserts to be configured for `ModuleEngagementSummaryMetricRangesMysqlTask`, as is already present for [`ModuleEngagementMysqlTask`](https://github.com/open-craft/edx-analytics-pipeline/blob/f86f2175282900b36e357eb12b2bcd2d714695e6/edx/analytics/tasks/insights/module_engagement.py#L267).

**JIRA Issue**

[OSPR-2008](https://openedx.atlassian.net/browse/OSPR-2008)

**Reviewers**
- [ ] @UmanShahzad 
- [x] @brianhw 