### PR TITLE
Update boto version.

### DIFF
--- a/edx/analytics/tasks/common/pathutil.py
+++ b/edx/analytics/tasks/common/pathutil.py
@@ -21,7 +21,7 @@ import luigi.task
 from luigi.date_interval import DateInterval
 
 from edx.analytics.tasks.util import eventlog
-from edx.analytics.tasks.util.s3_util import generate_s3_sources, get_s3_bucket_key_names
+from edx.analytics.tasks.util.s3_util import generate_s3_sources, get_s3_bucket_key_names, ScalableS3Client
 from edx.analytics.tasks.util.url import ExternalURL, UncheckedExternalURL, url_path_join, get_target_from_url
 
 
@@ -62,7 +62,7 @@ class PathSetTask(luigi.Task):
             if src.startswith('s3'):
                 # connect lazily as needed:
                 if self.s3_conn is None:
-                    self.s3_conn = boto.connect_s3()
+                    self.s3_conn = ScalableS3Client().s3
                 for _bucket, _root, path in generate_s3_sources(self.s3_conn, src, self.include, self.include_zero_length):
                     source = url_path_join(src, path)
                     yield ExternalURL(source)
@@ -193,7 +193,7 @@ class PathSelectionByDateIntervalTask(EventLogSelectionDownstreamMixin, luigi.Wr
 
     def _get_s3_urls(self, source):
         """Recursively list all files inside the source URL directory."""
-        s3_conn = boto.connect_s3()
+        s3_conn = ScalableS3Client().s3
         bucket_name, root = get_s3_bucket_key_names(source)
         bucket = s3_conn.get_bucket(bucket_name)
         for key_metadata in bucket.list(root):

--- a/edx/analytics/tasks/common/tests/test_pathutil.py
+++ b/edx/analytics/tasks/common/tests/test_pathutil.py
@@ -60,7 +60,7 @@ class PathSelectionByDateIntervalTaskTest(unittest.TestCase):
     COMPLETE_SOURCE_PATHS = COMPLETE_SOURCE_PATHS_1 + COMPLETE_SOURCE_PATHS_2
     SOURCE = [SOURCE_1, SOURCE_2]
 
-    @patch('edx.analytics.tasks.common.pathutil.boto.connect_s3')
+    @patch('edx.analytics.tasks.util.s3_util.connect_s3')
     def test_requires(self, connect_s3_mock):
         s3_conn_mock = connect_s3_mock.return_value
         bucket_mock = s3_conn_mock.get_bucket.return_value

--- a/edx/analytics/tasks/tests/acceptance/__init__.py
+++ b/edx/analytics/tasks/tests/acceptance/__init__.py
@@ -7,14 +7,13 @@ import shutil
 import unittest
 import csv
 
-from luigi.s3 import S3Client
 import pandas
 from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 from edx.analytics.tasks.common.pathutil import PathSetTask
 from edx.analytics.tasks.tests.acceptance.services import fs, db, task, hive, vertica, elasticsearch_service
+from edx.analytics.tasks.util.s3_util import ScalableS3Client
 from edx.analytics.tasks.util.url import url_path_join, get_target_from_url
-
 
 log = logging.getLogger(__name__)
 
@@ -25,7 +24,7 @@ def when_s3_available(function):
     s3_available = getattr(when_s3_available, 's3_available', None)
     if s3_available is None:
         try:
-            connection = boto.connect_s3()
+            connection = ScalableS3Client().s3
             # ^ The above line will not error out if AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
             # are set, so it can't be used to check if we have a valid connection to S3. Instead:
             connection.get_all_buckets()
@@ -135,7 +134,7 @@ class AcceptanceTestCase(unittest.TestCase):
 
     def setUp(self):
         try:
-            self.s3_client = S3Client()
+            self.s3_client = ScalableS3Client()
         except Exception:
             self.s3_client = None
 

--- a/edx/analytics/tasks/tests/acceptance/test_database_export.py
+++ b/edx/analytics/tasks/tests/acceptance/test_database_export.py
@@ -12,12 +12,12 @@ import tempfile
 import textwrap
 import urlparse
 
-import boto
 import gnupg
 
 from edx.analytics.tasks.tests.acceptance import AcceptanceTestCase, when_exporter_available
 from edx.analytics.tasks.tests.acceptance.services import shell
 from edx.analytics.tasks.util.opaque_key_util import get_filename_safe_course_id, get_org_id_for_course
+from edx.analytics.tasks.util.s3_util import ScalableS3Client
 from edx.analytics.tasks.util.url import url_path_join
 
 
@@ -192,7 +192,7 @@ class ExportAcceptanceTest(AcceptanceTestCase):
 
         """
         today = datetime.datetime.utcnow().strftime('%Y-%m-%d')
-        bucket = boto.connect_s3().get_bucket(self.config.get('exporter_output_bucket'))
+        bucket = ScalableS3Client().s3.get_bucket(self.config.get('exporter_output_bucket'))
         export_id = '{org}-{date}'.format(org=org_id, date=today)
         filename = export_id + '.zip'
         key = bucket.lookup(self.output_prefix + filename)

--- a/edx/analytics/tasks/util/tests/test_aws_elasticsearch_connection.py
+++ b/edx/analytics/tasks/util/tests/test_aws_elasticsearch_connection.py
@@ -36,7 +36,7 @@ class AwsElasticsearchConnectionTests(TestCase):
         self.assertTrue('my_access_key' in auth_header)
 
     def test_timeout(self):
-        def fake_connection(_address):
+        def fake_connection(_address, _timeout):
             """Fail immediately with a socket timeout."""
             raise socket.timeout('fake error')
         socket.create_connection = fake_connection

--- a/edx/analytics/tasks/util/tests/test_s3_util.py
+++ b/edx/analytics/tasks/util/tests/test_s3_util.py
@@ -103,7 +103,7 @@ class ScalableS3ClientTestCase(TestCase):
     """Tests for ScalableS3Client class."""
 
     def setUp(self):
-        patcher = patch('luigi.s3.boto')
+        patcher = patch('edx.analytics.tasks.util.s3_util.connect_s3')
         patcher.start()
         self.addCleanup(patcher.stop)
 

--- a/edx/analytics/tasks/util/tests/test_url.py
+++ b/edx/analytics/tasks/util/tests/test_url.py
@@ -32,7 +32,7 @@ class TargetFromUrlTestCase(TestCase):
             self.assertIsInstance(target, luigi.LocalTarget)
             self.assertEquals(target.path, path)
 
-    @patch('luigi.s3.boto')
+    @patch('edx.analytics.tasks.util.s3_util.connect_s3')
     def test_s3_https_scheme(self, _mock_boto):
         test_url = 's3+https://foo/bar'
         target = url.get_target_from_url(test_url)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 # These packages are required for bootstrapping.
 
 ansible==1.4.5 --no-binary ansible         # GPL v3 License
-boto==2.22.1            # MIT
+boto==2.48.0            # MIT
 ecdsa==0.13 		# MIT
 Jinja2==2.8.1		# BSD
 pycrypto==2.6.1 	# public domain


### PR DESCRIPTION
Add host argument to s3_connect.  Update unit test patches to match.

Host argument is now required by boto.  Latest version of boto provides a
hook to read from a .boto file, and there is a way for remote-task
to set such a file up and then read from it.  However, it's not
clear how to get the .boto file to the task instances in a multi-instance
cluster so that the file would be read by boto when reducers open
their own streams to output to an S3 file.