### PR TITLE
Pin some google-related packages.

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -40,12 +40,18 @@ git+https://github.com/edx/pyinstrument.git@a35ff76df4c3d5ff9a2876d859303e33d895
 botocore==1.5.95
 distlib==0.2.2
 docutils==0.14
+google-auth==1.2.0
+google-cloud-core==0.27.1
+google-resumable-media==0.3.1
+googleapis-common-protos==1.5.3
 future==0.16.0
 futures==3.1.1
 jmespath==0.9.3
 pbr==3.1.1
+protobuf==3.4.0
 pymongo==3.5.1
 pyOpenSSL==17.2.0
+pyasn1-modules==0.1.5
 s3transfer==0.1.11
 
 


### PR DESCRIPTION
Some newer releases of google packages seem to be breaking existing imports, so pin them to their previous versions for now. 