### PR TITLE
Added Dockerfile to aid local development

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,3 @@
-# .coveragerc for edx-analytics-platform
 [run]
 data_file = .coverage
 source = edx/analytics

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,46 @@ language: python
 python:
   - "2.7"
 
+sudo: required
+
+services:
+  - docker
+
 cache: pip
 
-addons:
-  apt:
-    packages:
-      - libblas-dev
-      - liblapack-dev
-      - libatlas-base-dev
+env:
+  global:
+    - secure: NLqmm18NpV3JRwD4CaugXm5cMWgxjdOA88xRFocmmVrduv0QT9JxBZFGebLYmFQOoKNJ23hz6g3EHe1aWfhLYnr1iUYerrwIriSI1wzuqbXJBRN6gO2n3YW+IfG83OLMZkOIMswT8MEdT3JPWVJL3bsocjHp8bYhRCt1KTCMJjY=
+    - secure: aG8l39jaLFWXB5CEOOAR9mJTT3GnqxCl/oFM/7NvTZCBoSWIPIztpFhSAkRE9xSIiKUKXakZcL5H349NLC28jdlHPVsNAaKKt2YNhB6MjmePihp3RPwZGn8c/SjslwY7DPVUKMdWsI7AVNJBH8ab30OPxKwXFAMOiJJza206CYQ=
+
+# Do NOT install Python requirements.
+# Doing so is a waste of time since they won't be used.
+install: true
 
 before_install:
-  - export BOTO_CONFIG=/dev/null
+  # Confirm Docker version and login credentials
+  - docker --version
+  - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+
+  # Upgrade Docker
+  - sudo apt-get -y update
+  - sudo apt-get -y install -o Dpkg::Options::="--force-confnew" docker-ce
+  - docker --version
+
+  # Build the image
+  - make docker-build
+
+  # Ensure we have a place to store coverage output
+  - mkdir -p coverage
 
 script:
-  - make test
+  - make test-docker
+  - make coverage-docker
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - pip install --upgrade codecov
+  - codecov
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
+    docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+    docker push edxops/analytics-pipeline:latest;
+    fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# docker build -t edxops/analytics-pipeline .
+
+FROM edxops/python:2.7
+ENV BOTO_CONFIG /dev/null
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        libatlas-base-dev \
+        libblas-dev \
+        liblapack-dev \
+        libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /edx/app/analytics-pipeline/requirements
+COPY Makefile /edx/app/analytics-pipeline
+COPY requirements /edx/app/analytics-pipeline/requirements
+
+WORKDIR /edx/app/analytics-pipeline
+
+RUN make test-requirements
+
+VOLUME /edx/app/analytics-pipeline

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,12 @@ develop-local: uninstall
 	python setup.py develop
 	python setup.py install_data
 
+docker-build:
+	docker build -t edxops/analytics-pipeline:latest .
+
+docker-shell:
+	docker run -v `(pwd)`:/edx/app/analytics-pipeline -it edxops/analytics-pipeline:latest bash
+
 system-requirements:
 ifeq (,$(wildcard /usr/bin/yum))
 	# This is not great, we can't use these libraries on slave nodes using this method.
@@ -35,6 +41,9 @@ requirements:
 test-requirements: requirements
 	pip install -U -r requirements/test.txt --no-cache-dir
 
+test-docker:
+	docker run -v `(pwd)`:/edx/app/analytics-pipeline -it edxops/analytics-pipeline:latest make develop-local test-local
+
 test-local:
 	# TODO: when we have better coverage, modify this to actually fail when coverage is too low.
 	rm -rf .coverage
@@ -50,6 +59,9 @@ test-acceptance-local:
 
 test-acceptance-local-all:
 	REMOTE_TASK=$(shell which remote-task) LUIGI_CONFIG_PATH='config/test.cfg' ACCEPTANCE_TEST_CONFIG="/var/tmp/acceptance.json" python -m coverage run --rcfile=./.coveragerc -m nose --nocapture --with-xunit -A acceptance -v
+
+coverage-docker:
+	docker run -v `(pwd)`:/edx/app/analytics-pipeline -it edxops/analytics-pipeline:latest coverage xml
 
 coverage-local: test-local
 	python -m coverage html

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ test-requirements: requirements
 test-local:
 	# TODO: when we have better coverage, modify this to actually fail when coverage is too low.
 	rm -rf .coverage
-	LUIGI_CONFIG_PATH='config/test.cfg' python -m coverage run --rcfile=./.coveragerc -m nose --with-xunit --xunit-file=unittests.xml -A 'not acceptance' -s
+	LUIGI_CONFIG_PATH='config/test.cfg' python -m coverage run --rcfile=./.coveragerc -m nose --with-xunit --xunit-file=unittests.xml -A 'not acceptance'
 
 test: test-requirements develop test-local
 


### PR DESCRIPTION
A Dockerfile is now included so that developers can use a Docker image/container for local testing. Travis now builds the Docker image and runs tests on the container. The image is pushed to Docker Hub for successful master builds.

LEARNER-1745