### PR TITLE
Update pep8 to pycodestyle.

### DIFF
--- a/.pycodestyle
+++ b/.pycodestyle
@@ -1,3 +1,3 @@
-[pep8]
+[pycodestyle]
 ignore=E501
 max_line_length=119

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ coverage-local: test-local
 	diff-cover coverage.xml --html-report diff_cover.html
 
 	# Compute pep8 quality
-	diff-quality --violations=pep8 --html-report diff_quality_pep8.html
-	pep8 edx > pep8.report || echo "Not pep8 clean"
+	diff-quality --violations=pycodestyle --html-report diff_quality_pep8.html
+	pycodestyle --config=.pycodestyle edx > pep8.report || echo "Not pep8 clean"
 
 	# Compute pylint quality
 	pylint -f parseable edx --msg-template "{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}" > pylint.report || echo "Not pylint clean"

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@ httpretty==0.8.14
 mock==2.0.0
 nose-ignore-docstring==0.2
 nose==1.3.7
-pep8==1.7.0
+pycodestyle==2.3.1
 pylint==1.6.4
 
 # dependencies pulled in by the above, that


### PR DESCRIPTION
The pep8 package was renamed to pycodestyle.  See https://github.com/PyCQA/pycodestyle for more pointers.  