### PR TITLE
Generate the Hive Table but not Table Data

### DIFF
--- a/edx/analytics/tasks/insights/enrollments.py
+++ b/edx/analytics/tasks/insights/enrollments.py
@@ -565,6 +565,8 @@ class CourseEnrollmentPartitionTask(CourseEnrollmentDownstreamMixin, HivePartiti
 class ExternalCourseEnrollmentPartitionTask(CourseEnrollmentPartitionTask):
 
     def requires(self):
+        yield self.hive_table_task
+
         yield ExternalURL(
             url=url_path_join(self.warehouse_path, 'course_enrollment', self.partition.path_spec) + '/'
         )


### PR DESCRIPTION
Reverting this back to using the prior functionality of generating a hive table but not generating the associated data. Our recent release had squashed the hive table generation and caused the overnight failures of module-engagement.  