### PR TITLE
When writing to S3, don't validate the bucket.

### DIFF
--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -4,7 +4,7 @@
 http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-1.2.2.zip  	# GPL v2 with FOSS License Exception
 
 # Putting these here rather than in default.in allows us to avoid using editable mode that pip-compile requires.
-git+https://github.com/edx/luigi.git@5472d77309b4600de9e8c246935d17972d0a6c9f#egg=luigi # Apache License 2.0
+git+https://github.com/edx/luigi.git@eb45bcc52243de11b2b16a81229ac584fe1e601b#egg=luigi # Apache License 2.0
 
 git+https://github.com/edx/pyinstrument.git@a35ff76df4c3d5ff9a2876d859303e33d895e78f#egg=pyinstrument     # BSD
 


### PR DESCRIPTION
If Boto is passed "validate=True", it will require an additional
permission to be present when asked to list all of the keys in the
bucket.  We want to minimize the set of required permissions so we get a
reference to the bucket without validating that it exists.  It should
only require PutObject and PutObjectAcl permissions in order to write to
the target bucket.

This is particularly the case with answer-distribution, which writes out
to a bucket that is used by LMS for course downloads.

It was awkward to maintain this change in the pipeline code, so the change
was instead made in the edx/luigi fork.    See the change here:

https://github.com/edx/luigi/commit/eb45bcc52243de11b2b16a81229ac584fe1e601b
