### PR TITLE
Doc generation requires a single requirements file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	pip-compile --upgrade -o requirements/default.txt requirements/default.in requirements/base.in
 	pip-compile --upgrade -o requirements/docs.txt requirements/docs.in requirements/default.in requirements/base.in
 	pip-compile --upgrade -o requirements/test.txt requirements/test.in requirements/default.in requirements/base.in
+	echo "-r extra.txt" >> requirements/docs.txt
 
 test-docker:
 	docker run -v `(pwd)`:/edx/app/analytics-pipeline -it edxops/analytics-pipeline:latest make develop-local test-local
@@ -89,7 +90,6 @@ coverage: test coverage-local
 docs-requirements:
 	pip install -U -r requirements/pre.txt
 	pip install -U -r requirements/docs.txt --no-cache-dir --upgrade-strategy only-if-needed
-	pip install -U -r requirements/extra.txt --no-cache-dir --upgrade-strategy only-if-needed
 	python setup.py install --force
 
 docs-local:

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -77,3 +77,4 @@ user-agents==0.3.2
 vertica-python==0.6.11
 wheel==0.30.0
 yarn-api-client==0.2.3
+-r extra.txt


### PR DESCRIPTION
We currently have makefile targets for installing requirements for doc, but these are not actually used by our readthedocs configuration. Instead, it is configured to load only requirements/docs.txt. Before work done to use pip-compile to build dependencies, the docs.txt file included default.txt, which in turn included base.txt, so the build worked. The pip-compile work separated these, and so recent builds are failing because they are not finding Luigi. 

Addressing DE-524.