### PR TITLE
Use Luigi return codes.

### DIFF
--- a/config/devstack.cfg
+++ b/config/devstack.cfg
@@ -1,3 +1,13 @@
+[retcode]
+# The following return codes are the recommended exit codes for Luigi.
+# They are in increasing level of severity (for most applications).
+already_running = 10
+missing_data = 20
+not_run = 25
+task_failed = 30
+scheduling_error = 35
+unhandled_exception = 40
+
 [hive]
 release = apache
 version = 1.0

--- a/config/local.cfg
+++ b/config/local.cfg
@@ -10,10 +10,6 @@ source = /tmp/antasks/input/
 [manifest]
 path = /tmp/antasks/manifest/
 
-[enrollment-reports]
-src = /tmp/antasks/input/
-destination = /tmp/enrollment-reports/
-
 [problem-response]
 report_output_root = /tmp/problem-response-reports/
 

--- a/config/test.cfg
+++ b/config/test.cfg
@@ -1,5 +1,15 @@
 # Safe defaults that can be used by unit and acceptance tests.
 
+[retcode]
+# The following return codes are the recommended exit codes for Luigi.
+# They are in increasing level of severity (for most applications).
+already_running = 10
+missing_data = 20
+not_run = 25
+task_failed = 30
+scheduling_error = 35
+unhandled_exception = 40
+
 [hive]
 release = apache
 version = 1.0

--- a/edx/analytics/tasks/launchers/local.py
+++ b/edx/analytics/tasks/launchers/local.py
@@ -24,9 +24,11 @@ import idna
 import luigi
 import luigi.configuration
 import luigi.contrib.hadoop
+import luigi.retcodes
 import opaque_keys
 import pyinstrument
 import requests
+import six
 import stevedore
 import urllib3
 
@@ -87,11 +89,11 @@ def main():
     # - filechunkio is used for multipart uploads of large files to s3.
     # - opaque_keys is used to interpret serialized course_ids
     #   - opaque_keys extensions:  ccx_keys
-    #   - dependencies of opaque_keys:  bson, stevedore
+    #   - dependencies of opaque_keys:  bson, stevedore, six
     # - requests has several dependencies:
     #   - chardet, urllib3, certifi, idna
     luigi.contrib.hadoop.attach(edx.analytics.tasks)
-    luigi.contrib.hadoop.attach(boto, cjson, filechunkio, opaque_keys, bson, stevedore, ciso8601, chardet, urllib3, certifi, idna, requests)
+    luigi.contrib.hadoop.attach(boto, cjson, filechunkio, opaque_keys, bson, stevedore, six, ciso8601, chardet, urllib3, certifi, idna, requests)
 
     if configuration.getboolean('ccx', 'enabled', default=False):
         import ccx_keys
@@ -102,7 +104,7 @@ def main():
     # Launch Luigi using the default builder
 
     with profile_if_necessary(os.getenv('WORKFLOW_PROFILER', ''), os.getenv('WORKFLOW_PROFILER_PATH', '')):
-        luigi.run(cmdline_args)
+        luigi.retcodes.run_with_retcodes(cmdline_args)
 
 
 def get_cleaned_command_line_args():


### PR DESCRIPTION
Modify launch-task to fail if any error conditions are encountered.   Use the return code
values recommended by Luigi documentation.

Also add six, since it is also needed on remote clusters.  For AWS, six is already installed by default, but it is not always present for non-AWS open source users. 
