### PR TITLE
Renames TimestampPartitionMixin.date to TimestampPartitionMixin.datetime

### DIFF
--- a/config/devstack.cfg
+++ b/config/devstack.cfg
@@ -112,14 +112,15 @@ report_fields = [
 report_output_root = /edx/src/problem-response-reports/
 
 [edx-rest-api]
-# Create using:
+# Create OAuth2 client (url doesn't matter):
 # ./manage.py lms --settings=devstack create_oauth2_client  \
-#   http://localhost:9999  # URL doesn't matter \
+#   http://localhost:9999
 #   http://localhost:9999/complete/edx-oidc/  \
 #   confidential \
 #   --client_name "Analytics Pipeline" \
 #   --client_id oauth_id \
 #   --client_secret oauth_secret \
+#   --user <staff_username> \
 #   --trusted
 client_id = oauth_id
 client_secret = oauth_secret

--- a/edx/analytics/tasks/insights/course_blocks.py
+++ b/edx/analytics/tasks/insights/course_blocks.py
@@ -61,7 +61,7 @@ class CourseBlocksDownstreamMixin(TimestampPartitionMixin, WarehouseMixin, Overw
     partition_format = luigi.Parameter(
         config_path={'section': 'course-blocks', 'name': 'partition_format'},
         default='%Y-%m-%d',
-        description='Format string for the course blocks table partition\'s `date` parameter. '
+        description='Format string for the course blocks table partition\'s `datetime` parameter. '
                     'Must result in a filename-safe string, or your partitions will fail to be created.\n'
                     'The default value of "%Y-%m-%d" changes daily, and so causes a new course partition to to be '
                     'created once a day.  For example, use "%Y-%m-%dT%H" to update hourly, though beware of load on '
@@ -89,7 +89,7 @@ class PullCourseBlocksApiData(CourseBlocksDownstreamMixin, luigi.Task):
 
     def requires(self):
         return CourseListApiDataTask(
-            date=self.date,
+            datetime=self.datetime,
             output_root=self.input_root,
             overwrite=self.overwrite,
         )
@@ -185,7 +185,7 @@ class CourseBlocksApiDataTask(CourseBlocksDownstreamMixin, MapReduceJobTask):
 
     def requires(self):
         return PullCourseBlocksApiData(
-            date=self.date,
+            datetime=self.datetime,
             input_root=self.input_root,
             overwrite=self.overwrite,
         )
@@ -321,7 +321,7 @@ class CourseBlocksApiDataTask(CourseBlocksDownstreamMixin, MapReduceJobTask):
 
 
 class CourseBlocksTableTask(BareHiveTableTask):
-    """Hive table containing the sorted course block data, partitioned on formatted date."""
+    """Hive table containing the sorted course block data, partitioned on formatted datetime."""
 
     @property
     def partition_by(self):
@@ -359,7 +359,7 @@ class CourseBlocksPartitionTask(CourseBlocksDownstreamMixin, MapReduceJobTaskMix
     @property
     def data_task(self):
         return CourseBlocksApiDataTask(
-            date=self.date,
+            datetime=self.datetime,
             input_root=self.input_root,
             output_root=self.output_root,
             overwrite=self.overwrite,

--- a/edx/analytics/tasks/insights/problem_response.py
+++ b/edx/analytics/tasks/insights/problem_response.py
@@ -91,7 +91,7 @@ class ProblemResponseTableMixin(TimestampPartitionMixin,
         config_path={'section': 'problem-response', 'name': 'partition_format'},
         default='%Y-%m-%d',
         description='Datetime format string for the table partition, which is applied to the configured '
-                    '`date` parameter.  Must result in a filename-safe string, or your partitions will '
+                    '`datetime` parameter.  Must result in a filename-safe string, or your partitions will '
                     'fail to be created.  It results in a combined partition containing: \n'
                     '* {course_id}: a filename-safe version of the configured course_id\n'
                     '* datetime format string:  Adjust this portion to update the data more or less frequently.\n'
@@ -424,7 +424,7 @@ class ProblemResponseLocationPartitionTask(ProblemResponseTableMixin, HivePartit
     sort_idx=0, and will be sorted in an indeterminate order.
 
     The resulting records are sorted by course_id, course_blocks.sort_idx, and first_attempt_date, and
-    partitioned by formatted date.
+    partitioned by formatted datetime.
     """
     path_delimiter = luigi.Parameter(
         config_path={'section': 'course-blocks', 'name': 'path_delimiter'},
@@ -493,12 +493,12 @@ class ProblemResponseLocationPartitionTask(ProblemResponseTableMixin, HivePartit
             input_format=self.input_format,
         )
         self.course_list_partition = CourseListPartitionTask(
-            date=self.date,
+            datetime=self.datetime,
             **kwargs
         )
         self.course_blocks_partition = CourseBlocksPartitionTask(
             input_root=self.course_list_partition.output_root,
-            date=self.date,
+            datetime=self.datetime,
             **kwargs
         )
         self.problem_response_partition = LatestProblemResponsePartitionTask(
@@ -506,7 +506,7 @@ class ProblemResponseLocationPartitionTask(ProblemResponseTableMixin, HivePartit
             interval=self.interval,
             interval_start=self.interval_start,
             interval_end=self.interval_end,
-            date=self.date,
+            datetime=self.datetime,
             source=self.source,
             pattern=self.pattern,
             overwrite=self.overwrite,
@@ -596,7 +596,7 @@ class ProblemResponseReportTask(ProblemResponseDataMixin,
         Use the raw data from the problem response location partition as input
         """
         return ProblemResponseLocationPartitionTask(
-            date=self.date,
+            datetime=self.datetime,
             partition_format=self.partition_format,
             interval=self.interval,
             interval_start=self.interval_start,
@@ -722,7 +722,7 @@ class ProblemResponseReportWorkflow(ProblemResponseTableMixin,
         """
         yield ProblemResponseReportTask(
             # ProblemResponseTableMixin
-            date=self.date,
+            datetime=self.datetime,
             partition_format=self.partition_format,
             interval=self.interval,
             interval_start=self.interval_start,

--- a/edx/analytics/tasks/insights/tests/test_problem_response.py
+++ b/edx/analytics/tasks/insights/tests/test_problem_response.py
@@ -15,8 +15,7 @@ from ddt import data, ddt, unpack
 
 from edx.analytics.tasks.common.tests.map_reduce_mixins import MapperTestMixin, ReducerTestMixin
 from edx.analytics.tasks.insights.problem_response import (
-    LatestProblemResponseDataTask, LatestProblemResponsePartitionTask, LatestProblemResponseTableTask,
-    ProblemResponseRecord, ProblemResponseReportTask
+    LatestProblemResponseDataTask, LatestProblemResponseTableTask, ProblemResponseRecord, ProblemResponseReportTask
 )
 from edx.analytics.tasks.util.record import DateTimeField
 from edx.analytics.tasks.util.tests.opaque_key_mixins import InitializeLegacyKeysMixin, InitializeOpaqueKeysMixin
@@ -586,48 +585,3 @@ class ProblemResponseReportTaskReducerTest(ReducerTestMixin, ProblemResponseRepo
         record = test_record_class(list_field=['a', 'b'])
         self.assertEquals(self.task._record_to_string_dict(record),  # pylint: disable=protected-access
                           dict(list_field="['a', 'b']"))
-
-
-class LatestProblemResponsePartitionTaskTest(ProblemResponseTestMixin, TestCase):
-    """Tests the LatestProblemResponsePartitionTask's formatted partition value."""
-
-    task_class = LatestProblemResponsePartitionTask
-
-    timestamp = datetime.utcnow()
-
-    # Only testing to a minute's precision due to issues with interval string parsing, as noted
-    # in partition_format parameter description.
-    partition_format = '%Y%m%dT%H%M'
-
-    def create_task(self, **kwargs):
-        """Create the task"""
-        self.task = self.task_class(
-            warehouse_path=self.output_dir,
-            date=self.timestamp,
-            **kwargs
-        )
-
-    def assert_partition_value(self):
-        """Ensure that datetimes are not filtered down to dates alone, when determining partition value."""
-        expected_partition_value = self.timestamp.strftime(self.partition_format)
-        self.assertEquals(self.task.partition_value, expected_partition_value)
-
-    def test_partition_value_with_start_end(self):
-        self.create_task(
-            interval_start=datetime.strptime('2013-05-30', '%Y-%m-%d'),
-            interval_end=self.timestamp,
-            partition_format=self.partition_format,
-        )
-        self.assert_partition_value()
-
-    def test_partition_value_with_no_interval(self):
-        # interval = luigi.date_interval.Custom.parse('2013-05-30-{}'.format(self.timestamp.isoformat()))
-        # TODO: fix this test to actually check what it's supposed to.
-        # The interval calculated using Custom.parse has always been None for strings with more than just a date range,
-        # so the task below has always used default values.
-        interval = None
-        self.create_task(
-            interval=interval,
-            partition_format=self.partition_format,
-        )
-        self.assert_partition_value()

--- a/edx/analytics/tasks/tests/acceptance/test_course_blocks.py
+++ b/edx/analytics/tasks/tests/acceptance/test_course_blocks.py
@@ -56,12 +56,12 @@ class CourseBlocksPartitionTaskAcceptanceTest(AcceptanceTestCase):
 
     def validate_partition_task(self):
         """Run the CourseBlocksPartitionTask and test its output."""
-        date = self.DATE.strftime('%Y-%m-%dT%H%M%S')
+        date_time = self.DATE.strftime('%Y-%m-%dT%H%M%S')
         input_root = url_path_join(self.warehouse_path, 'course_list', self.partition)
 
         self.task.launch([
             'CourseBlocksPartitionTask',
-            '--date', date,
+            '--datetime', date_time,
             '--input-root', input_root,
             '--n-reduce-tasks', str(self.NUM_REDUCERS),
         ])

--- a/edx/analytics/tasks/tests/acceptance/test_course_list.py
+++ b/edx/analytics/tasks/tests/acceptance/test_course_list.py
@@ -31,10 +31,10 @@ class CourseListPartitionTaskAcceptanceTest(AcceptanceTestCase):
 
     def test_partition_task(self):
         """Run the CourseListPartitionTask and test its output."""
-        date = self.DATE.strftime('%Y-%m-%dT%H%M%S')
+        date_time = self.DATE.strftime('%Y-%m-%dT%H%M%S')
         self.task.launch([
             'CourseListPartitionTask',
-            '--date', date,
+            '--datetime', date_time,
             '--n-reduce-tasks', str(self.NUM_REDUCERS),
         ])
 

--- a/edx/analytics/tasks/tests/acceptance/test_problem_response.py
+++ b/edx/analytics/tasks/tests/acceptance/test_problem_response.py
@@ -66,7 +66,7 @@ class ProblemResponseReportWorkflowAcceptanceTest(AcceptanceTestCase):
     def validate_problem_response_report(self):
         """Run the ProblemResponseReportWorkflow task and test the output."""
         marker_path = url_path_join(self.test_out, 'marker-{}'.format(str(time.time())))
-        report_date = self.DATE.strftime('%Y-%m-%dT%H%M%S')
+        report_datetime = self.DATE.strftime('%Y-%m-%dT%H%M%S')
 
         # The test tracking.log file contains problem_check events for 2016-09-06, 09-07, and 09-08.
         # However, to test the interval parameter propagation, we deliberately exclude all but the 2016-09-07 events.
@@ -80,7 +80,7 @@ class ProblemResponseReportWorkflowAcceptanceTest(AcceptanceTestCase):
             'ProblemResponseReportWorkflow',
             '--interval-start', interval_start,
             '--interval-end', interval_end,
-            '--date', report_date,
+            '--datetime', report_datetime,
             '--marker', marker_path,
             '--n-reduce-tasks', str(self.NUM_REDUCERS),
         ])


### PR DESCRIPTION
... to better reflect that parameter's type, as per https://github.com/edx/edx-analytics-pipeline/pull/472#issuecomment-360722500

**JIRA tickets**: [OSPR-2230](https://openedx.atlassian.net/browse/OSPR-2230)

**Discussions**: https://github.com/edx/edx-analytics-pipeline/pull/472

**Merge deadline**: Please merge before Hawthorn is cut.

**Testing instructions**:

Unit and acceptance testing should be sufficient here, but to test manually:

1. Set up [analytics devstack](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/installation/analytics/install_analytics.html)
1. Add a course with problem units, enrol some learners, and submit answers to the problems.
  (Wait 1 min for tracking logs to be copied to hdfs so pipeline can read them.)
1. Create an OAuth2 client for the analytics pipeline as per [these updated instructions](https://github.com/open-craft/edx-analytics-pipeline/blob/68ffb306db0004014d2dda8b82e3ab7c83db1863/config/devstack.cfg#L115-L124).
1. Ensure that the configured [`report_output_root `](https://github.com/edx/edx-analytics-pipeline/blob/master/config/devstack.cfg#L112) directory exists, and is writable by the `hadoop` user.
1. Run the Problem Response report as the `hadoop` user:
   ```bash
   sudo su hadoop
   cd /edx/app/analytics_pipeline/analytics_pipeline
   source ../venvs/analytics_pipeline/bin/activate
   export LUIGI_CONFIG_PATH="$PWD/config/devstack.cfg"
   export TOMORROW=`date --date="tomorrow" +%Y-%m-%d`
   export DATETIME=`date --date="yesterday" +%Y-%m-%dT%H%M%S`
   launch-task ProblemResponseReportWorkflow \
       --local-scheduler \
       --marker hdfs://localhost:9000/reports/marker`date +%s` \
       --interval-end "$TOMORROW" \
       --datetime "$DATETIME" \
       --overwrite \
       --n-reduce-tasks 2
   ```
1. Ensure that the problem response report is written to your configured [`report_output_root `](https://github.com/edx/edx-analytics-pipeline/blob/master/config/devstack.cfg#L112), and that it contains your problem responses.
1. Ensure that the created partition uses yesterday's date (default `partition_format` is [`%Y-%m-%d`](https://github.com/edx/edx-analytics-pipeline/blob/4d9d9ae7abf803996a0b45ea64976f54fa4e0dbe/edx/analytics/tasks/insights/problem_response.py#L90)), e.g.
   ```bash
   hdfs dfs -ls /edx-analytics-pipeline/warehouse/course_blocks /edx-analytics-pipeline/warehouse/course_list /edx-analytics-pipeline/warehouse/problem_response_latest
   ```
**Author notes and concerns**:

1. Lots of warnings emitted during tests -- are these a concern?
    ```
   /edx/app/analytics_pipeline/venvs/analytics_pipeline/local/lib/python2.7/site-packages/luigi/parameter.py:261: 
   UserWarning: Parameter "effective_user" with value "None" is not of type string.
   ```
1. Questions addressed from https://github.com/edx/edx-analytics-pipeline/pull/472: 
   > I changed the definition of TimestampPartitionMixin.date from luigi.DateParameter to 
   > luigi.DateSecondParameter. This requires the date of a job to always be specified to the minute. 

   No worries there -- we don't override the `date` (or now `datetime`) parameters when calling these tasks, though we do override the `interval_end` to tomorrow at `00:00:00`, to allow log records from today to be processed immediately.

   Note that the `datetime` must be specified to the minute, but the `partition_format` can still be set to whatever suits -- daily, hourly, minute-ly (is this even a word?).

   > I'm not sure if the interval or interval_end need to also support datetimes. It turns out that 
   > luigi.date_interval.Custom never did support this, but 
   > ProblemResponseTableMixin.interval_end is still a luigi.DateParameter, so it now only holds the date.

   The `interval` parameters only affect the tracking log data intervals, not the partition, so it's ok to leave these as simple Dates.

**Reviewers**
- [ ] OpenCraft TBD
- [ ] @edx/analytics -- CC @brianhw 