### PR TITLE
Copy mysql database to bigquery dataset

### DIFF
--- a/edx/analytics/tasks/warehouse/load_internal_reporting_database.py
+++ b/edx/analytics/tasks/warehouse/load_internal_reporting_database.py
@@ -7,16 +7,24 @@ import re
 
 import luigi
 
+from edx.analytics.tasks.common.bigquery_load import BigQueryLoadDownstreamMixin, BigQueryLoadTask, BigQueryTarget
 from edx.analytics.tasks.common.mysql_load import get_mysql_query_results
 from edx.analytics.tasks.common.sqoop import SqoopImportFromMysql
 from edx.analytics.tasks.common.vertica_load import SchemaManagementTask, VerticaCopyTask
 from edx.analytics.tasks.util.hive import HivePartition, WarehouseMixin
 from edx.analytics.tasks.util.url import ExternalURL, url_path_join
 
+try:
+    from google.cloud.bigquery import SchemaField
+    bigquery_available = True  # pylint: disable=invalid-name
+except ImportError:
+    bigquery_available = False  # pylint: disable=invalid-name
+
+
 log = logging.getLogger(__name__)
 
 
-class MysqlToVerticaTaskMixin(WarehouseMixin):
+class MysqlToWarehouseTaskMixin(WarehouseMixin):
     """
     Parameters for importing a mysql database into the warehouse.
     """
@@ -30,7 +38,7 @@ class MysqlToVerticaTaskMixin(WarehouseMixin):
     )
 
 
-class LoadMysqlToVerticaTableTask(MysqlToVerticaTaskMixin, VerticaCopyTask):
+class LoadMysqlToVerticaTableTask(MysqlToWarehouseTaskMixin, VerticaCopyTask):
     """
     Task to import a table from mysql into vertica.
     """
@@ -188,7 +196,7 @@ class PostImportDatabaseTask(SchemaManagementTask):
         )
 
 
-class ImportMysqlToVerticaTask(MysqlToVerticaTaskMixin, luigi.WrapperTask):
+class ImportMysqlToVerticaTask(MysqlToWarehouseTaskMixin, luigi.WrapperTask):
     """Provides entry point for importing a mysql database into Vertica."""
 
     schema = luigi.Parameter(
@@ -267,3 +275,267 @@ class ImportMysqlToVerticaTask(MysqlToVerticaTaskMixin, luigi.WrapperTask):
 
     def complete(self):
         return self.is_complete
+
+
+# Accepted types for standard tables are 'STRING', 'INT64', 'FLOAT64', 'BOOL', 'TIMESTAMP', 'BYTES', 'DATE', 'TIME', 'DATETIME'.
+MYSQL_TO_BIGQUERY_TYPE_MAP = {
+    # STRING -- BQ assumes input is utf8.
+    # Loading will fail if the string data being loaded is not utf8, or contains ASCII 0.
+    'char': 'STRING',  # includes 'NCHAR'.
+    'varchar': 'STRING',  # includes 'NVARCHAR'.
+    'text': 'STRING',
+    'tinytext': 'STRING',
+    'mediumtext': 'STRING',
+    'longtext': 'STRING',
+    'enum': 'STRING',
+    # BIT is actually output by Sqoop as a Hex number.  Requires conversion on BigQuery side from Hex string to number,
+    # by prepending '0x' to the string and safe-casting to INT64.
+    'bit': 'STRING',
+    # BOOL
+    'tinyint(1)': 'BOOL',  # includes "BOOL" and "BOOLEAN".
+    # INT64
+    'tinyint': 'INT64',
+    'smallint': 'INT64',
+    'mediumint': 'INT64',
+    'int': 'INT64',  # includes 'INTEGER'.
+    'bigint': 'INT64',
+    'year': 'INT64',
+    # FLOAT64
+    'decimal': 'FLOAT64',  # includes 'DEC', 'DECIMAL', 'NUMERIC', 'FIXED'.
+    'float': 'FLOAT64',
+    'double': 'FLOAT64',  # includes 'DOUBLE', 'DOUBLE PRECISION', 'REAL'.
+    # BYTES
+    # Sqoop outputs these as two character hex-codes separated by a space.  BigQuery reads these in and displays them as
+    # the corresponding hex values without the space separation.  This doesn't seem like the desired behavior, but the
+    # problem probably lies with Sqoop.  At present, LMS has only two columns that are longblobs, and they are passwords
+    # in a table that is excluded.
+    'binary': 'BYTES',
+    'varbinary': 'BYTES',
+    'tinyblob': 'BYTES',
+    'blob': 'BYTES',
+    'mediumblob': 'BYTES',
+    'longblob': 'BYTES',
+    # DATE
+    'date': 'DATE',
+    # TIME
+    'time': 'TIME',
+    # DATETIME
+    'datetime': 'DATETIME',
+    # TIMESTAMP -- like DATETIME, but with timezone
+    'timestamp': 'TIMESTAMP',
+}
+
+
+class MysqlToBigQueryTaskMixin(MysqlToWarehouseTaskMixin):
+    """
+    Parameters for importing a mysql database into BigQuery.
+    """
+
+    exclude_field = luigi.ListParameter(
+        default=(),
+        description='List of regular expression patterns for matching "tablename.fieldname" fields that should not be output.',
+    )
+    date = luigi.DateParameter(
+        default=datetime.datetime.utcnow().date(),
+    )
+    # Don't use the same source for BigQuery loads as was used for Vertica loads, until their formats match.
+    warehouse_subdirectory = luigi.Parameter(
+        default='import_mysql_to_bq',
+        description='Subdirectory under warehouse_path to store intermediate data.'
+    )
+
+
+class LoadMysqlToBigQueryTableTask(MysqlToBigQueryTaskMixin, BigQueryLoadTask):
+    """
+    Task to import a table from MySQL into BigQuery.
+    """
+
+    table_name = luigi.Parameter(
+        description='The name of the table.',
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(LoadMysqlToBigQueryTableTask, self).__init__(*args, **kwargs)
+        # Get schema for BigQuery and also Mysql columns that are excluded from that schema.
+        self.table_schema = []
+        self.deleted_fields = []
+
+    def should_exclude_field(self, field_name):
+        """Determines whether to exclude an individual field during the import, matching against 'table.field'."""
+        full_name = "{}.{}".format(self.table_name, field_name)
+        if any(re.match(pattern, full_name) for pattern in self.exclude_field):
+            return True
+        return False
+
+    def get_bigquery_schema(self):
+        """Transforms mysql table schema into a vertica compliant schema."""
+
+        if not self.table_schema:
+            results = get_mysql_query_results(self.db_credentials, self.database, 'describe {}'.format(self.table_name))
+            for result in results:
+                field_name = result[0].strip()
+                field_type = result[1].strip()
+                field_null = result[2].strip()
+
+                # Strip off size information from any type except booleans.
+                if field_type != 'tinyint(1)':
+                    field_type = field_type.rsplit('(')[0]
+
+                bigquery_type = MYSQL_TO_BIGQUERY_TYPE_MAP.get(field_type)
+                mode = 'REQUIRED' if field_null == 'NO' else 'NULLABLE'
+                description = ''
+
+                if self.should_exclude_field(field_name):
+                    self.deleted_fields.append(field_name)
+                else:
+                    self.table_schema.append(SchemaField(field_name, bigquery_type, description=description, mode=mode))
+
+        return self.table_schema
+
+    @property
+    def field_delimiter(self):
+        """The delimiter in the data to be copied."""
+        # Select a delimiter string that will not occur in field values.
+        return '\x01'
+
+    @property
+    def null_marker(self):
+        """The null sequence in the data to be copied."""
+        # Using "NULL" doesn't work, because there are values in several tables
+        # in non-nullable fields that store the string value "NULL" (or "Null" or "null").
+        # As with the field delimiter, we must use something here that we don't expect to
+        # appear in a field value.  (This was an arbitrary but hopefully still readable choice.)
+        # Note that this option only works if "direct" mode is disabled, otherwise it will be ignored
+        # and "NULL" will always be output.
+        return 'NNULLL'
+
+    @property
+    def quote_character(self):
+        # BigQuery does not handle escaping of quotes.  It hews to a narrower standard for CSV
+        # input, which expects quote characters to be doubled as a way of escaping them.
+        # We therefore have to avoid escaping quotes by selecting delimiters and null markers
+        # so they won't appear in field values at all.
+        return ''
+
+    @property
+    def insert_source_task(self):
+        # Make sure yet again that columns have been calculated.
+        columns = [field.name for field in self.schema]
+
+        partition_path_spec = HivePartition('dt', self.date.isoformat()).path_spec
+        destination = url_path_join(
+            self.warehouse_path,
+            self.warehouse_subdirectory,
+            self.database,
+            self.table_name,
+            partition_path_spec
+        ) + '/'
+        return SqoopImportFromMysql(
+            table_name=self.table_name,
+            credentials=self.db_credentials,
+            database=self.database,
+            destination=destination,
+            overwrite=self.overwrite,
+            mysql_delimiters=False,
+            fields_terminated_by=self.field_delimiter,
+            null_string=self.null_marker,
+            delimiter_replacement=' ',
+            direct=False,
+            columns=columns,
+        )
+
+    @property
+    def table(self):
+        return self.table_name
+
+    @property
+    def schema(self):
+        return self.get_bigquery_schema()
+
+    @property
+    def table_description(self):
+        optional = ''
+        if self.deleted_fields:
+            optional = '  Fields not included in the copy: {}'.format(', '.join(self.deleted_fields))
+        return "Copy of '{}' table from '{}' MySQL database on {}.{}".format(self.table_name, self.database, self.date.isoformat(), optional)
+
+    @property
+    def table_friendly_name(self):
+        return '{} from {}'.format(self.table_name, self.database)
+
+
+class ImportMysqlDatabaseToBigQueryDatasetTask(MysqlToBigQueryTaskMixin, BigQueryLoadDownstreamMixin, luigi.WrapperTask):
+    """
+    Provides entry point for importing a mysql database into BigQuery as a single dataset.
+
+    It is assumed that there is one database written to each dataset.
+    """
+
+    exclude = luigi.ListParameter(
+        default=(),
+        description='List of regular expressions matching database table names that should not be imported from MySQL to BigQuery.'
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(ImportMysqlDatabaseToBigQueryDatasetTask, self).__init__(*args, **kwargs)
+        self.table_list = []
+        self.is_complete = False
+        self.required_tasks = None
+
+        # If we are overwriting the database output, then delete the entire marker table.
+        # That way, any future activity on it should only consist of inserts, rather than any deletes
+        # of existing marker entries.  There are quotas on deletes and upserts on a table, of no more
+        # than 96 per day.   This allows us to work around hitting those limits.
+        # Note that we have to do this early, before scheduling begins, so that no entries are present
+        # when scheduling occurs (so everything gets properly scheduled).
+        if self.overwrite:
+            # First, create a BigQueryTarget object, so we can connect to BigQuery.  This is only
+            # for the purpose of deleting the marker table, so use dummy values.
+            credentials_target = ExternalURL(url=self.credentials).output()
+            target = BigQueryTarget(
+                credentials_target=credentials_target,
+                dataset_id=self.dataset_id,
+                table="dummy_table",
+                update_id="dummy_id",
+            )
+            # Now ask it to delete the marker table completely.
+            target.delete_marker_table()
+
+    def should_exclude_table(self, table_name):
+        """Determines whether to exclude a table during the import."""
+        if any(re.match(pattern, table_name) for pattern in self.exclude):
+            return True
+        return False
+
+    def requires(self):
+        if not self.table_list:
+            results = get_mysql_query_results(self.db_credentials, self.database, 'show tables')
+            unfiltered_table_list = [result[0].strip() for result in results]
+            self.table_list = [table_name for table_name in unfiltered_table_list if not self.should_exclude_table(table_name)]
+        if self.required_tasks is None:
+            self.required_tasks = []
+            for table_name in self.table_list:
+                self.required_tasks.append(
+                    LoadMysqlToBigQueryTableTask(
+                        db_credentials=self.db_credentials,
+                        database=self.database,
+                        warehouse_path=self.warehouse_path,
+                        warehouse_subdirectory=self.warehouse_subdirectory,
+                        table_name=table_name,
+                        overwrite=self.overwrite,
+                        date=self.date,
+                        dataset_id=self.dataset_id,
+                        credentials=self.credentials,
+                        max_bad_records=self.max_bad_records,
+                        skip_clear_marker=self.overwrite,
+                        exclude_field=self.exclude_field,
+                    )
+                )
+        return self.required_tasks
+
+    def output(self):
+        return [task.output() for task in self.requires()]
+
+    def complete(self):
+        # OverwriteOutputMixin changes the complete() method behavior, so we override it.
+        return all(r.complete() for r in luigi.task.flatten(self.requires()))

--- a/edx/analytics/tasks/warehouse/tests/test_internal_reporting_database.py
+++ b/edx/analytics/tasks/warehouse/tests/test_internal_reporting_database.py
@@ -7,7 +7,8 @@ from ddt import data, ddt, unpack
 from mock import patch
 
 from edx.analytics.tasks.warehouse.load_internal_reporting_database import (
-    ImportMysqlToVerticaTask, LoadMysqlToVerticaTableTask
+    ImportMysqlDatabaseToBigQueryDatasetTask, ImportMysqlToVerticaTask, LoadMysqlToBigQueryTableTask,
+    LoadMysqlToVerticaTableTask
 )
 
 
@@ -74,3 +75,79 @@ class LoadMysqlToVerticaTableTaskTest(TestCase):
         ]
 
         self.assertEqual(task.vertica_compliant_schema(), expected_schema)
+
+
+@ddt
+class ImportMysqlToBigQueryTaskTest(TestCase):
+    """Test for ImportMysqlDatabaseToBigQueryDatasetTask."""
+
+    def setUp(self):
+        self.task = ImportMysqlDatabaseToBigQueryDatasetTask(
+            exclude=('auth_user$', 'courseware_studentmodule*', 'oauth*'),
+            dataset_id='dummy',
+            credentials='dummy',
+        )
+
+    @data(
+        ('auth_user', True),
+        ('auth_userprofile', False),
+        ('courseware_studentmodule', True),
+        ('courseware_studentmodulehistory', True),
+        ('oauth2_accesstoken', True),
+        ('oauth_provider_token', True),
+    )
+    @unpack
+    def test_should_exclude_table(self, table, expected):
+        actual = self.task.should_exclude_table(table)
+        self.assertEqual(actual, expected)
+
+
+class LoadMysqlToBigQueryTableTaskTest(TestCase):
+    """Test for LoadMysqlToBigQueryTableTask."""
+
+    @patch('edx.analytics.tasks.warehouse.load_internal_reporting_database.get_mysql_query_results')
+    def test_table_schema(self, mysql_query_results_mock):
+        desc_table = [
+            ('id', 'int(11)', 'NO', 'PRI', None, 'auto_increment'),
+            ('name', 'varchar(255)', 'NO', 'MUL', None, ''),
+            ('meta', 'longtext', 'NO', '', None, ''),
+            ('width', 'smallint(6)', 'YES', 'MUL', None, ''),
+            ('test_tiny', 'tinyint(4)', 'YES', 'MUL', None, ''),
+            ('allow_certificate', 'tinyint(1)', 'NO', '', None, ''),
+            ('user_id', 'bigint(20) unsigned', 'NO', '', None, ''),
+            ('profile_image_uploaded_at', 'datetime', 'YES', '', None, ''),
+            ('change_date', 'datetime(6)', 'YES', '', None, ''),
+            ('total_amount', 'double', 'NO', '', None, ''),
+            ('expiration_date', 'date', 'YES', '', None, ''),
+            ('ip_address', 'char(39)', 'YES', '', None, ''),
+            ('unit_cost', 'decimal(30,2)', 'NO', '', None, '')
+        ]
+        mysql_query_results_mock.return_value = desc_table
+
+        task = LoadMysqlToBigQueryTableTask(
+            table_name='test_table',
+            dataset_id='dummy',
+            credentials='dummy',
+        )
+
+        expected_schemas = [
+            {'name': 'id', 'type': 'int64', 'mode': 'required'},
+            {'name': 'name', 'type': 'string', 'mode': 'required'},
+            {'name': 'meta', 'type': 'string', 'mode': 'required'},
+            {'name': 'width', 'type': 'int64', 'mode': 'nullable'},
+            {'name': 'test_tiny', 'type': 'int64', 'mode': 'nullable'},
+            {'name': 'allow_certificate', 'type': 'bool', 'mode': 'required'},
+            {'name': 'user_id', 'type': 'int64', 'mode': 'required'},
+            {'name': 'profile_image_uploaded_at', 'type': 'datetime', 'mode': 'nullable'},
+            {'name': 'change_date', 'type': 'datetime', 'mode': 'nullable'},
+            {'name': 'total_amount', 'type': 'float64', 'mode': 'required'},
+            {'name': 'expiration_date', 'type': 'date', 'mode': 'nullable'},
+            {'name': 'ip_address', 'type': 'string', 'mode': 'nullable'},
+            {'name': 'unit_cost', 'type': 'float64', 'mode': 'required'},
+        ]
+
+        schema = task.schema
+        # schema_list = [(field.name, field.field_type, field.mode) for field in task.schema]
+        actual_schemas = [field.to_api_repr() for field in task.schema]
+        for actual_schema, expected_schema in zip(actual_schemas, expected_schemas):
+            self.assertDictEqual(actual_schema, expected_schema)


### PR DESCRIPTION

Some of the features:
* Special handling of the marker table on overwrite was required due to quotas by BigQuery on table modifications.  To get around the quotas, the marker table is deleted in its entirety, and appended after that.
* Direct mode was not used in Sqoop calls because the null strings needed to be overridden, and direct mode prevents that.  Null strings needed to be redefined because the default value of "NULL" appears in field values for fields that are defined to be not nullable.
* Per-table filtering was left in as is done for copying mysql databases to Vertica.
* Per-column filtering was added to avoid columns that contain ASCII 0 characters.  BigQuery returns errors when loading such values.   This should not have a sizeable performance effect, as we already had to disable direct mode. 
* This moved away from using dynamic dependencies, as it seemed this was putting more load on repeatedly checking whether tables had already been loaded.  It seemed that at times those checks that had earlier been successful started being unsuccessful, resulting in a particular table being loaded multiple times.  This is much less likely to happen with regular requirements.
* The easiest way to handle not loading metadata files (like _metadata and _SUCCESS) was to delete them after synchronizing directories to Google Storage but before loading into BigQuery.   This could have been done differently.

This finally works on copying lms, ecommerce, discovery, and credentials databases to BigQuery.  Jenkins jobs have currently been set up to run these daily.  
