### PR TITLE
ENT-978 Add user country code and last activity date in enterprise en…

### DIFF
--- a/edx/analytics/tasks/tests/acceptance/fixtures/input/enterprise/auth_userprofile.sql
+++ b/edx/analytics/tasks/tests/acceptance/fixtures/input/enterprise/auth_userprofile.sql
@@ -1,0 +1,43 @@
+--
+-- Table structure for table `auth_user`
+--
+
+DROP TABLE IF EXISTS `auth_userprofile`;
+CREATE TABLE `auth_userprofile` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `meta` longtext NOT NULL,
+  `courseware` varchar(255) NOT NULL,
+  `language` varchar(255) NOT NULL,
+  `location` varchar(255) NOT NULL,
+  `year_of_birth` int(11) DEFAULT NULL,
+  `gender` varchar(6) DEFAULT NULL,
+  `level_of_education` varchar(6) DEFAULT NULL,
+  `mailing_address` longtext,
+  `city` longtext,
+  `country` varchar(2) DEFAULT NULL,
+  `goals` longtext,
+  `allow_certificate` tinyint(1) NOT NULL,
+  `bio` varchar(3000) DEFAULT NULL,
+  `profile_image_uploaded_at` datetime(6) DEFAULT NULL,
+  `user_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `user_id` (`user_id`),
+  KEY `auth_userprofile_b068931c` (`name`),
+  KEY `auth_userprofile_8512ae7d` (`language`),
+  KEY `auth_userprofile_d5189de0` (`location`),
+  KEY `auth_userprofile_8939d49d` (`year_of_birth`),
+  KEY `auth_userprofile_cc90f191` (`gender`),
+  KEY `auth_userprofile_a895faa8` (`level_of_education`),
+  CONSTRAINT `auth_userprofile_user_id_62634b27_fk` FOREIGN KEY (`user_id`) REFERENCES `auth_user` (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8;
+
+
+--
+-- Dumping data for table `auth_userprofile`
+--
+INSERT INTO `auth_userprofile` VALUES
+    (5, 'Test User', '', 'course.xml', '', '', 1989, 'm', '', '', '', 'US', '', 1, NULL, NULL, 11),
+    (6, 'Test User2', '', 'course.xml', '', '', 1989, 'f', '', '', '', 'US', '', 1, NULL, NULL, 12),
+    (7, 'Test User3', '', 'course.xml', '', '', 1989, 'm', '', '', '', 'US', '', 1, NULL, NULL, 13),
+    (8, 'Test User4', '', 'course.xml', '', '', 1989, 'f', '', '', '', 'US', '', 1, NULL, NULL, 14);

--- a/edx/analytics/tasks/tests/acceptance/fixtures/input/user_activity_by_user
+++ b/edx/analytics/tasks/tests/acceptance/fixtures/input/user_activity_by_user
@@ -1,0 +1,4 @@
+11	course-v1:edX+Testing102x+1T2017	2015-09-09	ACTIVE	4
+12	course-v1:edX+Testing102x+1T2017	2015-09-09	ACTIVE	1
+13	course-v1:edX+Open_DemoX+edx_demo_course2	2015-09-09	ACTIVE	3
+14	course-v1:edX+Testing102x+1T2017	2015-09-09	ACTIVE	7

--- a/edx/analytics/tasks/tests/acceptance/test_enterprise_enrollments.py
+++ b/edx/analytics/tasks/tests/acceptance/test_enterprise_enrollments.py
@@ -40,6 +40,15 @@ class EnterpriseEnrollmentAcceptanceTest(AcceptanceTestCase):
             os.path.join(self.data_dir, 'input', 'programs.json'),
             url_path_join(self.warehouse_path, 'discovery_api_raw', 'dt=' + self.DATE, 'programs.json')
         )
+        self.upload_file(
+            os.path.join(self.data_dir, 'input', 'user_activity_by_user'),
+            url_path_join(
+                self.warehouse_path,
+                'user_activity_by_user',
+                'dt=' + self.DATE,
+                'user_activity_by_user_' + self.DATE
+            )
+        )
 
     def prepare_database(self):
         sql_fixture_base_url = url_path_join(self.data_dir, 'input', 'enterprise')
@@ -66,37 +75,40 @@ class EnterpriseEnrollmentAcceptanceTest(AcceptanceTestCase):
              datetime.datetime(2016, 3, 22, 20, 59, 12), 'verified', 1, '', 0, None, 'ron', 1,
              'All about acceptance testing!', datetime.datetime(2016, 6, 1, 0, 0), datetime.datetime(2016, 9, 1, 0, 0),
              'self_paced', 'Self Paced', 3, 5, datetime.datetime(2015, 2, 12, 23, 14, 35), 'test2@example.com',
-             'test_user2', 'edX+Open_DemoX'],
+             'test_user2', 'edX+Open_DemoX', 'US', None],
 
             ['03fc6c3a33d84580842576922275ca6f', '2nd Enterprise', 13, 3, 'course-v1:edX+Open_DemoX+edx_demo_course2',
              datetime.datetime(2016, 3, 22, 21, 2, 9), 'no-id-professional', 1, '', 0, None, 'hermione', 1,
              'All about acceptance testing!', datetime.datetime(2016, 6, 1, 0, 0), datetime.datetime(2016, 9, 1, 0, 0),
              'self_paced', 'Self Paced', 3, 5, datetime.datetime(2015, 2, 12, 23, 14, 35), 'test3@example.com',
-             'test_user3', 'edX+Open_DemoX'],
+             'test_user3', 'edX+Open_DemoX', 'US', datetime.date(2015, 9, 9)],
 
             ['0381d3cb033846d48a5cb1475b589d7f', 'Enterprise 1', 11, 1, 'course-v1:edX+Open_DemoX+edx_demo_course2',
              datetime.datetime(2016, 3, 22, 20, 56, 9), 'verified', 1, '', 0, None, 'harry', 1,
              'All about acceptance testing!', datetime.datetime(2016, 6, 1, 0, 0), datetime.datetime(2016, 9, 1, 0, 0),
              'self_paced', 'Self Paced', 3, 5, datetime.datetime(2015, 2, 12, 23, 14, 35), 'test@example.com',
-             'test_user', 'edX+Open_DemoX'],
+             'test_user', 'edX+Open_DemoX', 'US', None],
 
             ['0381d3cb033846d48a5cb1475b589d7f', 'Enterprise 1', 12, 2, 'course-v1:edX+Testing102x+1T2017',
              datetime.datetime(2016, 3, 22, 21, 4, 8), 'no-id-professional', 1, 'Pass', 1,
              datetime.datetime(2017, 5, 9, 16, 27, 34), 'ron', 1, 'All about acceptance testing Part 3!',
              datetime.datetime(2016, 12, 1, 0, 0), datetime.datetime(2017, 2, 1, 0, 0), 'instructor_paced', '9', 2, 5,
-             datetime.datetime(2015, 2, 12, 23, 14, 35), 'test2@example.com', 'test_user2', 'edX+Testing102'],
+             datetime.datetime(2015, 2, 12, 23, 14, 35), 'test2@example.com', 'test_user2', 'edX+Testing102',
+             'US', datetime.date(2015, 9, 9)],
 
             ['0381d3cb033846d48a5cb1475b589d7f', 'Enterprise 1', 11, 1, 'course-v1:edX+Testing102x+1T2017',
              datetime.datetime(2016, 3, 22, 21, 8, 8), 'credit', 0, '', 0, None, 'harry', 1,
              'All about acceptance testing Part 3!', datetime.datetime(2016, 12, 1, 0, 0),
              datetime.datetime(2017, 2, 1, 0, 0), 'instructor_paced', '9', 2, 5,
-             datetime.datetime(2015, 2, 12, 23, 14, 35), 'test@example.com', 'test_user', 'edX+Testing102'],
+             datetime.datetime(2015, 2, 12, 23, 14, 35), 'test@example.com', 'test_user', 'edX+Testing102',
+             'US', datetime.date(2015, 9, 9)],
 
             ['0381d3cb033846d48a5cb1475b589d7f', 'Enterprise 1', 11, 1, 'edX/Open_DemoX/edx_demo_course',
              datetime.datetime(2014, 6, 27, 16, 2, 38), 'verified', 1, 'Pass', 1,
              datetime.datetime(2017, 5, 9, 16, 27, 35), 'harry', 1, 'All about acceptance testing!',
              datetime.datetime(2016, 9, 1, 0, 0), datetime.datetime(2016, 12, 1, 0, 0), 'instructor_paced', '13', 2, 4,
-             datetime.datetime(2015, 2, 12, 23, 14, 35), 'test@example.com', 'test_user', 'edX+Open_DemoX'],
+             datetime.datetime(2015, 2, 12, 23, 14, 35), 'test@example.com', 'test_user', 'edX+Open_DemoX',
+             'US', None],
         ]
 
         return [tuple(row) for row in expected]
@@ -107,7 +119,8 @@ class EnterpriseEnrollmentAcceptanceTest(AcceptanceTestCase):
                    'enrollment_created_timestamp', 'user_current_enrollment_mode', 'consent_granted', 'letter_grade',
                    'has_passed', 'passed_timestamp', 'enterprise_sso_uid', 'enterprise_site_id', 'course_title',
                    'course_start', 'course_end', 'course_pacing_type', 'course_duration_weeks', 'course_min_effort',
-                   'course_max_effort', 'user_account_creation_timestamp', 'user_email', 'user_username', 'course_key']
+                   'course_max_effort', 'user_account_creation_timestamp', 'user_email', 'user_username', 'course_key',
+                   'user_country_code', 'last_activity_date']
         with self.export_db.cursor() as cursor:
             cursor.execute(
                 '''


### PR DESCRIPTION
…rollment hive table

* Add fields `user_country_code` and `last_activity_date` in `EnterpriseEnrollmentRecord` table.
* Update `insert_query`to populate above fields during `EnterpriseEnrollmentDataTask`

Remaining Task:
* Cannot add/populate field `country_name` as we are using django-countries which provide method for getting country name against the provided country code. We cannot do this with such ease in SQL. One way we can try is using manual dump for countries along with code and name.