### PR TITLE
Add docker analyticstack guides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,3 +120,17 @@ docker-test-acceptance-local:
 
 docker-test-acceptance-local-all:
 	LAUNCH_TASK=$(shell which launch-task) REMOTE_TASK=$(shell which remote-task) LUIGI_CONFIG_PATH='config/docker_test.cfg' ACCEPTANCE_TEST_CONFIG="/edx/etc/edx-analytics-pipeline/acceptance.json" python -m coverage run --rcfile=./.coveragerc -m nose --nocapture --with-xunit -A acceptance -v
+
+generate-spark-egg-files:
+	# edx-opaque-keys egg
+	mkdir -p /var/tmp/edx_egg_files/
+	curl -fSL https://files.pythonhosted.org/packages/63/86/d4bf9c7e7a720125b0572c43dda002f72be2cc66313be601cd7b6cccb2ad/edx-opaque-keys-0.4.tar.gz -o /var/tmp/edx-opaque-keys.tar.gz
+	cd /var/tmp/ && mkdir -p /var/tmp/edx-opaque-keys/ && tar --strip-components=1 -xzf /var/tmp/edx-opaque-keys.tar.gz -C /var/tmp/edx-opaque-keys/
+	cd /var/tmp/edx-opaque-keys && python setup.py bdist_egg
+	cp /var/tmp/edx-opaque-keys/dist/edx_opaque_keys-0.4-py2.7.egg /var/tmp/edx_egg_files/edx_opaque_keys.egg
+
+	# edx-ccx-keys agg
+	curl -fSL https://files.pythonhosted.org/packages/a4/03/444d30a3859e36ef2273ae6254c011e1fb3a02f4e3dba16008ecf0b4bdb3/edx-ccx-keys-0.2.1.tar.gz -o /var/tmp/edx-ccx-keys.tar.gz
+	cd /var/tmp/ && mkdir -p /var/tmp/edx-ccx-keys/  && tar --strip-components=1 -xzf /var/tmp/edx-ccx-keys.tar.gz -C /var/tmp/edx-ccx-keys/
+	cd /var/tmp/edx-ccx-keys && python setup.py bdist_egg
+	cp /var/tmp/edx-ccx-keys/dist/edx_ccx_keys-0.2.1-py2.7.egg  /var/tmp/edx_egg_files/edx_ccx_keys.egg

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,6 +13,9 @@ This guide provides information about the edX data pipeline.
 
    running_tasks.rst
    faq.rst	     
+   running_acceptance_tests_in_docker.rst
+   running_spark_tasks.rst
+   troubleshooting_docker_analyticstack.rst
 
 The following documentation is generated dynamically from comments in the code. There is detailed documentation for every Luigi task.
 

--- a/docs/source/running_acceptance_tests_in_docker.rst
+++ b/docs/source/running_acceptance_tests_in_docker.rst
@@ -1,0 +1,45 @@
+..  _running_acceptance_tests_in_docker:
+
+Running Acceptance Tests in Docker Analyticstack
+================================================
+
+For docker analyticstack setup, follow instructions under **Getting Started on Analytics** section in `Devstack`_ repository.
+
+Pre-requisites
+--------------
+
+* Access analytics pipeline shell:
+
+   ::
+
+       make analytics-pipeline-shell
+
+* Before running the user-location workflows, a geolocation Maxmind data file must be downloaded. This file can be in
+  HDFS or S3, for example, and should be pointed to by the `geolocation_data` setting in the `geolocation` section of your
+  configuration file. To use the default location used by acceptance tests, execute the following:
+
+   ::
+
+       curl -fSL http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz -o /var/tmp/GeoIP.dat.gz
+       cd /var/tmp/ && gunzip /var/tmp/GeoIP.dat.gz
+       mv GeoIP.dat geo.dat
+       hdfs dfs -put geo.dat /edx-analytics-pipeline/
+
+Running Acceptance Tests
+------------------------
+
+* To run the full test suite, execute the following command in the shell:
+
+  ::
+
+      make docker-test-acceptance-local-all
+
+* To run individual tests, execute the following:
+
+  ::
+
+      make docker-test-acceptance-local ONLY_TESTS=edx.analytics.tasks.tests.acceptance.<test_script_file>    # e.g.
+      make docker-test-acceptance-local ONLY_TESTS=edx.analytics.tasks.tests.acceptance.test_user_activity
+
+
+.. _Devstack: https://github.com/edx/devstack/tree/master/README.rst#getting-started-on-analytics

--- a/docs/source/running_spark_tasks.rst
+++ b/docs/source/running_spark_tasks.rst
@@ -1,0 +1,31 @@
+..  _running_spark_tasks:
+
+Running Spark Tasks in Docker Analyticstack
+===========================================
+
+Pre-requisites
+--------------
+
+* Access analytics pipeline shell:
+
+   ::
+
+       make analytics-pipeline-shell
+
+* Generate egg files
+
+  If you plan to run Spark workflows that use imports that in turn require the use of a plugin mechanism,
+  it is necessary to store those imports locally as egg files. These imports are then identified in the
+  configuration file in the `spark` section. Opaque keys is one of these imports, and the two egg files
+  used by Spark can be made as follows.
+
+   ::
+
+       make generate-spark-egg-files
+
+Task
+~~~~
+
+::
+
+    launch-task UserActivityTaskSpark --local-scheduler --interval 2017-03-16

--- a/docs/source/troubleshooting_docker_analyticstack.rst
+++ b/docs/source/troubleshooting_docker_analyticstack.rst
@@ -1,0 +1,26 @@
+..  _troubleshooting_docker_analyticstack:
+
+Troubleshooting Docker Analyticstack
+====================================
+
+* Make sure there are no errors during provision command. If there are errors, **do not rerun the provision command without first cleaning up after the failures.**
+* For cleanup, there are 2 options.
+
+  - Reset containers ( this will remove all containers and volumes )
+
+     ::
+
+         make destroy
+
+  - Manual cleanup
+
+     ::
+
+         make mysql-shell
+         mysql
+         DROP DATABASE reports
+         DROP DATABASE edx_hive_metastore
+         DROP DATABASE edxapp           # Only drop if provisioning failed while loading the LMS schema.
+         DROP DATABASE edxapp_csmh      # Only drop if provisioning failed while loading the LMS schema.
+         # exit mysql shell
+         make down


### PR DESCRIPTION
This PR adds supporting documents for docker analyticstack.

Relevant [devstack PR](https://github.com/edx/devstack/pull/308).