### PR TITLE
ENT-1021 Fix data discrepancy for enterprise enrollment table

### DIFF
--- a/edx/analytics/tasks/enterprise/enterprise_enrollments.py
+++ b/edx/analytics/tasks/enterprise/enterprise_enrollments.py
@@ -141,13 +141,13 @@ class EnterpriseEnrollmentDataTask(
                     AND enterprise_user.user_id = enrollment.user_id
             JOIN auth_user auth_user
                     ON enterprise_user.user_id = auth_user.id
-            JOIN consent_datasharingconsent consent
+            LEFT JOIN consent_datasharingconsent consent
                     ON auth_user.username =  consent.username
                     AND enterprise_course_enrollment.course_id = consent.course_id
-            JOIN grades_persistentcoursegrade grades
+            LEFT JOIN grades_persistentcoursegrade grades
                     ON enterprise_user.user_id = grades.user_id
                     AND enterprise_course_enrollment.course_id = grades.course_id
-            JOIN (
+            LEFT JOIN (
                     SELECT
                         user_id,
                         provider,


### PR DESCRIPTION
The vertica version of the table had many more rows than the one in the result store,
and after investigating, it seems we were filtering out rows because of some joins
that should have been left joins.