### PR TITLE
Correcting coerced timestamp columns so that they do not use the default name

### DIFF
--- a/edx/analytics/tasks/common/sqoop.py
+++ b/edx/analytics/tasks/common/sqoop.py
@@ -327,7 +327,10 @@ class SqoopImportFromVertica(SqoopImportTask):
         column_list = []
         for column in self.columns:
             if column in self.timezone_adjusted_column_list:
-                column_list.append('"{}" AT TIME ZONE \'UTC\''.format(column))
+                column_list.append('"{source_column}" AT TIME ZONE \'UTC\' AS "{exported_column_name}"'.format(
+                    source_column=column,
+                    exported_column_name=column
+                ))
             else:
                 column_list.append('"{}"'.format(column))
 


### PR DESCRIPTION
The production runs of vertica-to-bigquery-schema-copy-business-intelligence have been failing because duplicate field names are present due to a timestamp coercion process we are using in Sqoop.  This fixes the issue identified here: https://openedx.atlassian.net/browse/DE-763

Testing is being done on the production dataset here: http://scheduler.analytics.edx.org/view/Warehouse/job/vertica-to-bigquery-schema-copy-business-intelligence/6/ . 

I will update with the status when the job is complete and the code is ready for review.