### PR TITLE
Don't require org_id in d_course.

### DIFF
--- a/edx/analytics/tasks/warehouse/load_internal_reporting_course_catalog.py
+++ b/edx/analytics/tasks/warehouse/load_internal_reporting_course_catalog.py
@@ -587,7 +587,7 @@ class CourseRecord(Record):
     pacing_type = StringField(nullable=True, length=255)
     level_type = StringField(nullable=True, length=255)
     availability = StringField(nullable=True, length=255)
-    org_id = StringField(nullable=False, length=255)
+    org_id = StringField(nullable=True, length=255)
     partner_short_code = StringField(nullable=True, length=8)
     marketing_url = StringField(nullable=True, length=1024)
     min_effort = IntegerField(nullable=True)


### PR DESCRIPTION
This is motivated by a bogus course on our stage server causing this to break, but in fact there is no real reason to fail if the org_id is not available.   Better that it just go through as None.
