### PR TITLE
Fix pip version before uninstall.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 .PHONY:	requirements test test-requirements .tox upgrade
 
 uninstall:
+	pip install -r requirements/pip.txt
 	while pip uninstall -y edx.analytics.tasks; do true; done
 	python setup.py clean
 
@@ -9,7 +10,6 @@ install: requirements uninstall
 	python setup.py install --force
 
 bootstrap: uninstall
-	pip install -r requirements/pip.txt
 	pip install -r requirements/base.txt --no-cache-dir
 	python setup.py install --force
 


### PR DESCRIPTION
Newer version of pip returns 0 when calling ```pip uninstall -y edx.analytics.tasks``` when requirements are not already installed(We call make bootstrap from analytics-configuration when starting a job on jenkins). This results in an infinite loop when we call ```while pip uninstall -y edx.analytics.tasks; do true; done```. The new Jenkins box comes with pip 18.x. 

This ensures we install our pip version before uninstalling. 