### PR TITLE
Only build travis push on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: python
 python:
   - "2.7"
 
+branches:
+  only:
+    - master
+
 sudo: required
 
 services:


### PR DESCRIPTION
Analytics Pipeline Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] If you have a migration please contact data engineering team before merging.
  - [ ] Before merging run full acceptance tests suite and provide URL for the acceptance tests run.
  - [ ] A member of data engineering team has approved the pull request.
  
I've been working on adding some automation for creating and testing openedx releases, which creates branches in a number of IDA's, and (if desired) deletes them at the end of the tests. For now, the job is in the beginning stages, and just creates a branch, and later deletes it.

The problem is, the branch gets deleted so quickly, that travis gets kicked off, but quickly fails when the branch can't be found. To make matters worse, since the branch doesn't include any new commits, travis gets run (and fails) on the same commit as the tip of the master branch, which overwrites whatever status it previously had to failing (example: link to failing travis build).

This change fixes that, by following a travis pattern we currently already use in other repos, like these: (configuration repo, devstack repo). This will limit builds to being triggered either by a pull request, or a push to master.

So when any non-master branch gets created or pushed, travis will not be triggered (unless there is an open pull request for that branch).