### PR TITLE
Don't require org_id in program_course.

### DIFF
--- a/edx/analytics/tasks/warehouse/load_internal_reporting_course_catalog.py
+++ b/edx/analytics/tasks/warehouse/load_internal_reporting_course_catalog.py
@@ -360,7 +360,7 @@ class ProgramCourseRecord(Record):
     catalog_course = StringField(nullable=False, length=255)
     catalog_course_title = StringField(nullable=True, length=255, normalize_whitespace=True)
     course_id = StringField(nullable=False, length=255)
-    org_id = StringField(nullable=False, length=255)
+    org_id = StringField(nullable=True, length=255)
     partner_short_code = StringField(nullable=True, length=8)
     program_slot_number = IntegerField(nullable=True)
 


### PR DESCRIPTION
This is motivated by a bogus course on our stage server causing this to break in the enrollment workflow, but in fact there is no real reason to fail if the org_id is not available. Better that it just go through as None.

