### PR TITLE
ENT-1232 Change field type of unenrollment_timestamp to datetime

### DIFF
--- a/edx/analytics/tasks/enterprise/enterprise_enrollments.py
+++ b/edx/analytics/tasks/enterprise/enterprise_enrollments.py
@@ -70,7 +70,7 @@ class EnterpriseEnrollmentRecord(Record):
     current_grade = FloatField(description='')
     course_price = FloatField(description='')
     discount_price = FloatField(description='')
-    unenrollment_timestamp = DateField(description='')
+    unenrollment_timestamp = DateTimeField(description='')
 
 
 class EnterpriseEnrollmentHiveTableTask(BareHiveTableTask):

--- a/edx/analytics/tasks/tests/acceptance/fixtures/input/course_enrollment_summary
+++ b/edx/analytics/tasks/tests/acceptance/fixtures/input/course_enrollment_summary
@@ -1,2 +1,2 @@
-course-v1:edX+Testing102x+1T2017	12	no-id-professional	True	no-id-professional	2016-09-09 00:00:00	2016-09-08 00:00:00	2016-09-09 00:00:00	2016-09-09 00:00:00	2016-09-09 00:00:00
-course-v1:edX+Open_DemoX+edx_demo_course2	13	no-id-professional	True	no-id-professional	2016-03-09 00:00:00	2016-09-08 00:00:00	2016-09-09 00:00:00	2016-03-09 00:00:00	2016-10-10 00:00:00
+course-v1:edX+Testing102x+1T2017	12	no-id-professional	True	no-id-professional	2016-09-09 00:00:00	2016-09-10 00:30:05	2016-09-09 00:00:00	2016-09-09 00:00:00	2016-09-09 00:00:00
+course-v1:edX+Open_DemoX+edx_demo_course2	13	no-id-professional	True	no-id-professional	2016-03-09 00:00:00	2016-09-08 01:02:00	2016-09-09 00:00:00	2016-03-09 00:00:00	2016-10-10 00:00:00

--- a/edx/analytics/tasks/tests/acceptance/test_enterprise_enrollments.py
+++ b/edx/analytics/tasks/tests/acceptance/test_enterprise_enrollments.py
@@ -93,7 +93,7 @@ class EnterpriseEnrollmentAcceptanceTest(AcceptanceTestCase):
              'All about acceptance testing!', datetime.datetime(2016, 6, 1, 0, 0), datetime.datetime(2016, 9, 1, 0, 0),
              'self_paced', 'Self Paced', 3, 5, datetime.datetime(2015, 2, 12, 23, 14, 35), 'test3@example.com',
              'test_user3', 'edX+Open_DemoX', 'US', datetime.date(2015, 9, 9), 'ENT - No restrictions',
-             'ZSJHRVLCNTT6XFCJ', None, 0.03, 100.00, 20.00, datetime.date(2016, 9, 8)],
+             'ZSJHRVLCNTT6XFCJ', None, 0.03, 100.00, 20.00, datetime.datetime(2016, 9, 8, 1, 2, 0)],
 
             ['0381d3cb033846d48a5cb1475b589d7f', 'Enterprise 1', 11, 1, 'course-v1:edX+Open_DemoX+edx_demo_course2',
              datetime.datetime(2016, 3, 22, 20, 56, 9), 'verified', 1, '', 0, None, 'harry', 1,
@@ -108,7 +108,7 @@ class EnterpriseEnrollmentAcceptanceTest(AcceptanceTestCase):
              datetime.datetime(2016, 12, 1, 0, 0), datetime.datetime(2017, 2, 1, 0, 0), 'instructor_paced', '9', 2, 5,
              datetime.datetime(2015, 2, 12, 23, 14, 35), 'test2@example.com', 'test_user2', 'edX+Testing102',
              'US', datetime.date(2015, 9, 9), 'ENT - Discount', 'CQHVBDLY35WSJRZ4', None, 0.98, 100.00, 60.00,
-             datetime.date(2016, 9, 8)],
+             datetime.datetime(2016, 9, 10, 0, 30, 5)],
 
             ['0381d3cb033846d48a5cb1475b589d7f', 'Enterprise 1', 11, 1, 'course-v1:edX+Testing102x+1T2017',
              datetime.datetime(2016, 3, 22, 21, 8, 8), 'credit', 0, '', 0, None, 'harry', 1,


### PR DESCRIPTION
**Jira ticket:** [ENT-1232](https://openedx.atlassian.net/browse/ENT-1232)

**Description:** Change data type of newly introduced field "unenrollment_timestamp" to type `datetime` from type `date` in the `EnterpriseEnrollmentRecord` table to make it consistent with other timestamp values and to resolve the issue on the `edx-analytics-data-api` side.

**Background:** Previously we introduced new field "unenrollment_timestamp" with type "date" in analytics-pipeline PR (https://github.com/edx/edx-analytics-pipeline/pull/534).

But there was a mismatch between the data type for "unenrollment_timestamp" in analytics-pipeline (type = date) and the data type in enterprise-data (type = datatime) PR (https://github.com/edx/edx-enterprise-data/pull/76). Due to which we started to get following exception while accessing the enrollments data api "/enterprise/api/v0/enterprise/9004fea4-1063-41fe-8ff1-ee46617da52d/enrollments/"
```bash
exceptions:AttributeError: 'datetime.date' object has no attribute 'tzinfo'
```

**Related analytics-pipeline PR:** https://github.com/edx/edx-analytics-pipeline/pull/534
**Related edx-enterprise-data PR:** https://github.com/edx/edx-enterprise-data/pull/76
---

Make sure that the following steps are done before merging:

  - [ ] If you have a migration please contact data engineering team before merging.
  - [ ] Before merging run full acceptance tests suite and provide URL for the acceptance tests run.
  - [ ] A member of data engineering team has approved the pull request.
  
