### PR TITLE
Allows `make bootstrap` to be run on an empty virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,14 @@
 
 uninstall:
 	pip install -r requirements/pip.txt
-	while pip uninstall -y edx.analytics.tasks; do true; done
+	pip uninstall -y edx.analytics.tasks
 	python setup.py clean
 
 install: requirements uninstall
 	python setup.py install --force
 
-bootstrap: uninstall
+bootstrap:
+	-make uninstall
 	pip install -r requirements/base.txt --no-cache-dir
 	python setup.py install --force
 

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,13 @@
 
 uninstall:
 	pip install -r requirements/pip.txt
-	pip uninstall -y edx.analytics.tasks
+	-pip uninstall -y edx.analytics.tasks
 	python setup.py clean
 
 install: requirements uninstall
 	python setup.py install --force
 
-bootstrap:
-	-make uninstall
+bootstrap: uninstall
 	pip install -r requirements/base.txt --no-cache-dir
 	python setup.py install --force
 


### PR DESCRIPTION
When running [`run-automated-task.sh`](https://github.com/edx/edx-analytics-configuration/blob/master/automation/run-automated-task.sh) for the first time on a new virtualenv, the script loops infinitely [on this line](https://github.com/edx/edx-analytics-configuration/blob/8acbb14cf886be9588c085759d7e2e70c99b6d33/automation/run-automated-task.sh#L34) while failing to uninstall the analytics pipeline.

This change allows `make bootstrap` to run successfully on an empty virtualenv.

**JIRA tickets**: [OSPR-2946](https://openedx.atlassian.net/browse/OSPR-2946), BB-273

**Testing instructions**:

To verify the issue, use the `master` branch, and run these steps.

1. Create and activate a new virtualenv.
1. Run `make bootstrap` (or `make develop-local`).
1. Note the following infinite loop:
   ```
   (analytics-pipeline) edx-analytics-pipeline$ make bootstrap
   while pip uninstall -y edx.analytics.tasks; do true; done
   Skipping edx.analytics.tasks as it is not installed.
   Skipping edx.analytics.tasks as it is not installed.
   Skipping edx.analytics.tasks as it is not installed.
   Skipping edx.analytics.tasks as it is not installed.
   ...
   ```

To verify this fix, run the above steps using the branch from this PR, and note that the pipeline installs successfully.

**Author Notes & Concerns**

1. This is not a new issue; we've worked around it in the past by manually running `make install` on the new virtualenv for new deployments.
  However, this fix removes a manual step, so would be a welcome change.

**Reviewers**
- [ ] @lgp171188 
- [ ] @brianhw ?

Analytics Pipeline Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] If you have a migration please contact data engineering team before merging.
  - [ ] Before merging run full acceptance tests suite and provide URL for the acceptance tests run.
  - [ ] A member of data engineering team has approved the pull request.
  
