### PR TITLE
Escape event_type strings before output.

### DIFF
--- a/edx/analytics/tasks/warehouse/event_type_dist.py
+++ b/edx/analytics/tasks/warehouse/event_type_dist.py
@@ -7,6 +7,7 @@ import luigi.task
 from edx.analytics.tasks.common.mapreduce import MapReduceJobTask
 from edx.analytics.tasks.common.pathutil import EventLogSelectionMixin
 from edx.analytics.tasks.common.vertica_load import VerticaCopyTask
+from edx.analytics.tasks.util.obfuscate_util import backslash_encode_value
 from edx.analytics.tasks.util.url import ExternalURL, get_target_from_url, url_path_join
 
 log = logging.getLogger(__name__)
@@ -57,6 +58,9 @@ class EventTypeDistributionTask(EventLogSelectionMixin, MapReduceJobTask):
             exported = True
         else:
             event_category = 'unknown'
+        # Make sure that event_type doesn't have embedded newlines and such, but do so
+        # after checking that it's not None.
+        event_type = backslash_encode_value(unicode(event_type))
         yield (event_date, event_category, event_type, event_source, exported), 1
 
     def reducer(self, key, values):


### PR DESCRIPTION
Some event_type values are coming in with lots of garbage, and for the most part we tolerate this.  However, if the event_type contains a newline, it breaks our event-type-dist job.   Our regular event-loading is not affected, because it performs an encoding on all string values.   So we do the same here.