### PR TITLE
Passing source parameter from workflow entry point.

### DIFF
--- a/edx/analytics/tasks/warehouse/event_type_dist.py
+++ b/edx/analytics/tasks/warehouse/event_type_dist.py
@@ -5,7 +5,7 @@ import logging
 import luigi.task
 
 from edx.analytics.tasks.common.mapreduce import MapReduceJobTask
-from edx.analytics.tasks.common.pathutil import EventLogSelectionMixin
+from edx.analytics.tasks.common.pathutil import EventLogSelectionDownstreamMixin, EventLogSelectionMixin
 from edx.analytics.tasks.common.vertica_load import VerticaCopyTask
 from edx.analytics.tasks.util.obfuscate_util import backslash_encode_value
 from edx.analytics.tasks.util.url import ExternalURL, get_target_from_url, url_path_join
@@ -70,10 +70,9 @@ class EventTypeDistributionTask(EventLogSelectionMixin, MapReduceJobTask):
         return get_target_from_url(url_path_join(self.output_root, 'event_type_distribution/'))
 
 
-class PushToVerticaEventTypeDistributionTask(VerticaCopyTask):
+class PushToVerticaEventTypeDistributionTask(EventLogSelectionDownstreamMixin, VerticaCopyTask):
     """Push the event type distribution task data to Vertica."""
     output_root = luigi.Parameter()
-    interval = luigi.DateIntervalParameter()
     n_reduce_tasks = luigi.Parameter()
     events_list_file_path = luigi.Parameter(default=None)
 
@@ -98,5 +97,6 @@ class PushToVerticaEventTypeDistributionTask(VerticaCopyTask):
             output_root=self.output_root,
             interval=self.interval,
             n_reduce_tasks=self.n_reduce_tasks,
-            events_list_file_path=self.events_list_file_path
+            events_list_file_path=self.events_list_file_path,
+            source=self.source,
         )

--- a/edx/analytics/tasks/warehouse/lms_courseware_link_clicked.py
+++ b/edx/analytics/tasks/warehouse/lms_courseware_link_clicked.py
@@ -7,7 +7,7 @@ from urlparse import urlparse
 import luigi.task
 
 from edx.analytics.tasks.common.mapreduce import MapReduceJobTask
-from edx.analytics.tasks.common.pathutil import EventLogSelectionMixin
+from edx.analytics.tasks.common.pathutil import EventLogSelectionDownstreamMixin, EventLogSelectionMixin
 from edx.analytics.tasks.common.vertica_load import VerticaCopyTask
 from edx.analytics.tasks.util import eventlog
 from edx.analytics.tasks.util.url import get_target_from_url, url_path_join
@@ -107,10 +107,9 @@ class LMSCoursewareLinkClickedTask(EventLogSelectionMixin, MapReduceJobTask):
         super(LMSCoursewareLinkClickedTask, self).run()
 
 
-class PushToVerticaLMSCoursewareLinkClickedTask(VerticaCopyTask):
+class PushToVerticaLMSCoursewareLinkClickedTask(EventLogSelectionDownstreamMixin, VerticaCopyTask):
     """Push the LMS courseware link clicked task data to Vertica."""
     output_root = luigi.Parameter()
-    interval = luigi.DateIntervalParameter()
     n_reduce_tasks = luigi.Parameter()
 
     @property
@@ -131,7 +130,8 @@ class PushToVerticaLMSCoursewareLinkClickedTask(VerticaCopyTask):
         return LMSCoursewareLinkClickedTask(
             output_root=self.output_root,
             interval=self.interval,
-            n_reduce_tasks=self.n_reduce_tasks
+            n_reduce_tasks=self.n_reduce_tasks,
+            source=self.source,
         )
 
     @property


### PR DESCRIPTION
I'm thinking for event loading tasks we can leverage the command line passing. Segment and tracking event loading tasks both have a source parameter. So it would be easier to just pass --TrackingEventRecordDataTask-source to the task in jenkins. 