### PR TITLE
Skip long usernames in module engagement tasks.

### DIFF
--- a/edx/analytics/tasks/insights/module_engagement.py
+++ b/edx/analytics/tasks/insights/module_engagement.py
@@ -122,6 +122,12 @@ class ModuleEngagementDataTask(EventLogSelectionMixin, OverwriteOutputMixin, Map
         username = event.get('username', '').strip()
         if not username:
             return
+        if len(username) > 30:
+            # User retirement process generates usernames containing 54
+            # characters, at the time of writing.  It's unusual that an event
+            # would be emitted with a retired username, but the least we can do
+            # is skip these events.
+            return
 
         event_type = event.get('event_type')
         if event_type is None:


### PR DESCRIPTION
This was created in response to retired usernames ending up in tracking
logs and breaking the module-engagement jobs.

Analytics Pipeline Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] If you have a migration please contact data engineering team before merging.
  - [ ] Before merging run full acceptance tests suite and provide URL for the acceptance tests run.
  - [ ] A member of data engineering team has approved the pull request.
  
