### PR TITLE
upgrade jinja2

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,7 +6,7 @@
 ansible==1.4.5          # GPL v3 License
 boto==2.48.0            # MIT
 ecdsa==0.13 		# MIT
-Jinja2==2.8.1		# BSD
+Jinja2		        # BSD
 pycrypto==2.6.1 	# public domain
 wheel==0.30.0
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,13 +10,13 @@ ansible==1.4.5
 asn1crypto==0.24.0        # via cryptography
 bcrypt==3.1.6             # via paramiko
 boto==2.48.0
-cffi==1.12.2              # via bcrypt, cryptography, pynacl
+cffi==1.12.3              # via bcrypt, cryptography, pynacl
 cryptography==2.6.1       # via paramiko
 ecdsa==0.13
 enum34==1.1.6             # via cryptography
-httplib2==0.12.1          # via ansible
+httplib2==0.12.3          # via ansible
 ipaddress==1.0.22         # via cryptography
-jinja2==2.8.1
+jinja2==2.10.1
 markupsafe==1.1.1         # via jinja2
 paramiko==2.4.2           # via ansible
 pyasn1==0.4.5             # via paramiko

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.0                # via pip-tools
-pip-tools==3.5.0
+pip-tools==3.7.0
 six==1.10.0


### PR DESCRIPTION
### PROD-210

### Description
This PR updates the jinja2 version to 2.10.1 using `make upgrade`. See PROD-210 for more information regarding the update

Make sure that the following steps are done before merging:

  - [ ] If you have a migration please contact data engineering team before merging.
  - [ ] Before merging run full acceptance tests suite and provide URL for the acceptance tests run.
  - [ ] A member of data engineering team has approved the pull request.
  
