### PR TITLE
Added google spreadsheet loading workflow.

### DIFF
--- a/edx/analytics/tasks/warehouse/load_google_sheet_to_warehouse.py
+++ b/edx/analytics/tasks/warehouse/load_google_sheet_to_warehouse.py
@@ -1,0 +1,230 @@
+"""
+Tasks to load google spreadsheet data into the warehouse.
+
+The spreadsheet should have the following appearance if column_types_row=True:
+
+            A                 B          C        D
+  +----------------------+-----------+--------+-------+-------------+
+1 |      timestamp       | full_name | foo    | bar   | record_date |
+  +----------------------+-----------+--------+-------+-------------+
+2 |      datetime        | string    | float  | int   |    date     |
+  +----------------------+-----------+--------+-------+-------------+
+3 | 2019-06-13T10:36:20Z | Blah Blah | 123.45 | 12345 |  2019-06-13 |
+  +----------------------+-----------+--------+-------+-------------+
+4 | 2019-06-14T00:13:01Z | Blah Blah | 12.345 | 23456 |  2019-06-14 |
+  +----------------------+-----------+--------+-------+-------------+
+...
+
+Where the first row contains column titles, the second row contains column
+types, and the third row begins the data. If column_types_row=False, the
+second row is omitted, and the data begins on the second row, and types are
+assumed to be 'string'. Possible values include:
+    * integer/int
+    * string
+    * boolean
+    * float
+    * decimal
+    * date
+    * datetime
+
+The worksheet titles are used as table names in Vertica, they can be
+128 characters long, beginning with an upper/lower alphabet or underscore,
+subsequent characters can include upper/lower alphabets, underscores and digits.
+"""
+import datetime
+import json
+import logging
+
+import luigi
+from google.auth.transport.requests import AuthorizedSession
+from google.oauth2 import service_account
+from gspread import client
+
+from edx.analytics.tasks.common.vertica_load import VerticaCopyTask, VerticaCopyTaskMixin
+from edx.analytics.tasks.util.hive import HivePartition, WarehouseMixin
+from edx.analytics.tasks.util.overwrite import OverwriteOutputMixin
+from edx.analytics.tasks.util.url import ExternalURL, get_target_from_url, url_path_join
+
+log = logging.getLogger(__name__)
+
+
+# Provides a mapping between the simple types provided by the spreadsheet author in a second header row, and the types
+# as they should be loaded into Vertica.
+DATA_TYPE_MAPPING = {
+    'integer': 'INT',
+    'int': 'INT',
+    'string': 'VARCHAR(500)',
+    'boolean': 'BOOLEAN',
+    'float': 'FLOAT',
+    'decimal': 'DECIMAL(12,2)',
+    'date': 'DATE',
+    'datetime': 'DATETIME',
+}
+
+def create_google_spreadsheet_client(credentials_target):
+    with credentials_target.open('r') as credentials_file:
+        json_creds = json.load(credentials_file)
+        credentials = service_account.Credentials.from_service_account_info(
+            json_creds,
+            scopes=['https://www.googleapis.com/auth/drive.readonly']
+        )
+
+    authed_session = AuthorizedSession(credentials)
+    return client.Client(None, authed_session)
+
+
+class PullWorksheetMixin(OverwriteOutputMixin):
+    date = luigi.DateParameter(default=datetime.datetime.utcnow().date())
+    google_credentials = luigi.Parameter(description='Path to the external access credentials file.')
+    # spreadsheet key/id is a 44 characters alphanumeric including hyphen and underscore extracted from the URL.
+    spreadsheet_key = luigi.Parameter(description='Google sheets key.')
+    worksheet_name = luigi.Parameter(description='Worksheet name.', default=None)
+    column_types_row = luigi.BoolParameter(default=False, description='Whether there is a row with column types.')
+
+
+class PullWorksheetDataTask(PullWorksheetMixin, WarehouseMixin, luigi.Task):
+    """
+    Task to read data from a google worksheet and write to a tsv file.
+    """
+
+    def requires(self):
+        return {
+            'credentials': ExternalURL(url=self.google_credentials),
+        }
+
+    def run(self):
+        self.remove_output_on_overwrite()
+        credentials_target = self.input()['credentials']
+        gs = create_google_spreadsheet_client(credentials_target)
+        sheet = gs.open_by_key(self.spreadsheet_key)
+        worksheet = sheet.worksheet(self.worksheet_name)
+        all_values = worksheet.get_all_values()
+        # Remove the header/column names.
+        self.header = [v.strip() for v in all_values.pop(0)]
+        if self.column_types_row:
+            self.types = [v.strip() for v in all_values.pop(0)]
+        else:
+            self.types = ['string'] * len(self.header)
+
+        with self.output().open('w') as output_file:
+            for value in all_values:
+                output_file.write('\t'.join([v.encode('utf-8') for v in value]))
+                output_file.write('\n')
+
+    @property
+    def columns(self):
+        return self.header
+
+    @property
+    def column_types(self):
+        return self.types
+
+    def output(self):
+        partition_path_spec = HivePartition('dt', self.date).path_spec
+
+        output_worksheet_name = self.worksheet_name
+        output_url = url_path_join(self.warehouse_path, 'google_sheets', self.spreadsheet_key,
+                                   output_worksheet_name, partition_path_spec, '{}.tsv'.format(output_worksheet_name))
+        return get_target_from_url(output_url)
+
+
+class LoadWorksheetToWarehouse(PullWorksheetMixin, VerticaCopyTask):
+    """
+    Task to load data from a google sheet into the Vertica data warehouse.
+    """
+
+    @property
+    def copy_null_sequence(self):
+        """
+        The null sequence in the data to be copied. Empty string is Vertica's default.
+        """
+        return "''"
+
+    def create_table(self, connection):
+        # Drop the table in case of overwrite
+        if self.overwrite:
+            connection.cursor().execute("DROP TABLE IF EXISTS {schema}.{table}".format(
+                                        schema=self.schema, table=self.table))
+        super(LoadWorksheetToWarehouse, self).create_table(connection)
+
+    def init_copy(self, connection):
+        # We have already dropped the table, so we do away with the delete here.
+        self.attempted_removal = True
+
+    @property
+    def insert_source_task(self):
+        return PullWorksheetDataTask(
+            date=self.date,
+            google_credentials=self.google_credentials,
+            spreadsheet_key=self.spreadsheet_key,
+            worksheet_name=self.worksheet_name,
+            column_types_row=self.column_types_row,
+            overwrite=self.overwrite,
+        )
+
+    @property
+    def table(self):
+        return self.worksheet_name
+
+    @property
+    def auto_primary_key(self):
+        return None
+
+    @property
+    def default_columns(self):
+        return None
+
+    @property
+    def columns(self):
+        columns = self.insert_source_task.columns
+        column_types = self.insert_source_task.column_types
+        mapped_types = [DATA_TYPE_MAPPING.get(column_type) for column_type in column_types]
+        return zip(columns, mapped_types)
+
+
+class LoadGoogleSpreadsheetsToWarehouseWorkflow(luigi.WrapperTask):
+    """
+    Provides entry point for loading a google spreadsheet into the warehouse.
+    All worksheets within the spreadsheet are loaded as separate tables.
+    """
+
+    spreadsheets_config = luigi.DictParameter(
+        config_path={'section': 'google-spreadsheets', 'name': 'config'},
+        description='A dictionary containing spreadsheets config where a key is the spreadsheet key/id extracted from '
+                    'spreadsheet url, value is a dictionary containing atleast schema key/value pair which specifies '
+                    'the vertica schema for the spreadsheet tables. Can also specify column_types_row key where the '
+                    'value is either true or false specifying whether the worksheets in the spreadsheet contain a '
+                    'column types row as a second header row.'
+    )
+    google_credentials = luigi.Parameter(
+        description='Path to the external access credentials file.'
+    )
+    overwrite = luigi.BoolParameter(
+        default=False,
+        description='Whether or not to overwrite S3 outputs and the warehouse tables.',
+        significant=False
+    )
+    date = luigi.DateParameter(
+        default=datetime.datetime.utcnow().date()
+    )
+
+    def requires(self):
+        credentials_target = ExternalURL(url=self.google_credentials).output()
+        gs = create_google_spreadsheet_client(credentials_target)
+        for spreadsheet_key, config in self.spreadsheets_config.items():
+            schema = config['schema']
+            column_types_row = config.get('column_types_row', False)
+
+            spreadsheet = gs.open_by_key(spreadsheet_key)
+            worksheets = spreadsheet.worksheets()
+
+            for worksheet in worksheets:
+                yield LoadWorksheetToWarehouse(
+                    date=self.date,
+                    schema=schema,
+                    google_credentials=self.google_credentials,
+                    spreadsheet_key=spreadsheet_key,
+                    worksheet_name=worksheet.title,
+                    column_types_row=column_types_row,
+                    overwrite=self.overwrite,
+                )

--- a/requirements/default.in
+++ b/requirements/default.in
@@ -13,6 +13,7 @@ filechunkio==1.8	# MIT
 google-cloud-bigquery==0.27.0
 google-api-python-client==1.7.7
 graphitesend==0.10.0    # Apache
+gspread==3.1.0    # MIT
 html5lib==1.0b3 	# MIT
 isoweek==1.3.3		# BSD
 numpy==1.11.3 		# BSD

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -11,19 +11,19 @@
 ansible==1.4.5
 argparse==1.2.1
 asn1crypto==0.24.0
-azure-common==1.1.18      # via azure-storage-blob, azure-storage-common, snowflake-connector-python
+azure-common==1.1.21      # via azure-storage-blob, azure-storage-common, snowflake-connector-python
 azure-nspkg==3.0.2        # via azure-common, azure-storage-nspkg
-azure-storage-blob==1.5.0  # via snowflake-connector-python
-azure-storage-common==1.4.0  # via azure-storage-blob
+azure-storage-blob==2.0.1  # via snowflake-connector-python
+azure-storage-common==2.0.0  # via azure-storage-blob
 azure-storage-nspkg==3.1.0  # via azure-storage-common
 backports-abc==0.5        # via tornado
 bcrypt==3.1.6
 boto3==1.4.8
 boto==2.48.0
 botocore==1.8.50          # via boto3, s3transfer, snowflake-connector-python
-cachetools==3.1.0         # via google-auth
+cachetools==3.1.1         # via google-auth
 certifi==2019.3.9         # via requests, snowflake-connector-python, tornado
-cffi==1.12.2
+cffi==1.12.3
 chardet==3.0.4            # via requests
 ciso8601==1.0.3
 cryptography==2.6.1
@@ -43,32 +43,33 @@ google-auth==1.6.3        # via google-api-python-client, google-auth-httplib2, 
 google-cloud-bigquery==0.27.0
 google-cloud-core==0.27.1  # via google-cloud-bigquery
 google-resumable-media==0.3.2  # via google-cloud-bigquery
-googleapis-common-protos==1.5.9  # via google-cloud-core
+googleapis-common-protos==1.6.0  # via google-cloud-core
 graphitesend==0.10.0
+gspread==3.1.0
 html5lib==1.0b3
-httplib2==0.12.1
+httplib2==0.12.3
 idna==2.6                 # via requests, snowflake-connector-python
 ijson==2.3                # via snowflake-connector-python
 ipaddress==1.0.22
 isoweek==1.3.3
-jinja2==2.8.1
+jinja2==2.10.1
 jmespath==0.9.4           # via boto3, botocore
 lockfile==0.12.2          # via python-daemon
 markupsafe==1.1.1
 numpy==1.11.3
 paramiko==2.4.2
 paypalrestsdk==1.9.0
-pbr==5.1.3                # via stevedore
-protobuf==3.7.1           # via google-cloud-core, googleapis-common-protos
+pbr==5.2.1                # via stevedore
+protobuf==3.8.0           # via google-cloud-core, googleapis-common-protos
 psycopg2==2.6.2
-pyasn1-modules==0.2.4     # via google-auth, snowflake-connector-python
+pyasn1-modules==0.2.5     # via google-auth, snowflake-connector-python
 pyasn1==0.4.5
 pycparser==2.19
 pycrypto==2.6.1
-pycryptodomex==3.8.0      # via snowflake-connector-python
+pycryptodomex==3.8.2      # via snowflake-connector-python
 pygeoip==0.3.2
 pyjwt==1.7.1              # via snowflake-connector-python
-pymongo==3.7.2            # via edx-opaque-keys
+pymongo==3.8.0            # via edx-opaque-keys
 pynacl==1.3.0
 pyopenssl==19.0.0         # via paypalrestsdk, snowflake-connector-python
 python-cjson==1.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,7 @@ edx.analytics.tasks =
     test-vertica-sqoop = edx.analytics.tasks.common.vertica_export:VerticaSchemaToBigQueryTask
     load-ga-permissions = edx.analytics.tasks.warehouse.load_ga_permissions:LoadGoogleAnalyticsPermissionsWorkflow
     load-vertica-schema-snowflake = edx.analytics.tasks.warehouse.load_vertica_schema_to_snowflake:VerticaSchemaToSnowflakeTask
+    load-google-sheet-warehouse = edx.analytics.tasks.warehouse.load_google_sheet_to_warehouse:LoadGoogleSpreadsheetsToWarehouseWorkflow
 
     # financial:
     cybersource = edx.analytics.tasks.warehouse.financial.cybersource:DailyPullFromCybersourceTask


### PR DESCRIPTION
Added tasks to load data from a single google sheet to vertica. Expects a sheet key and worksheet name as parameters. Uses gspread which leverages Sheets API v4.

#### Speadsheet and Worksheet
We can fetch the spreadsheet using complete url, key(part of the url) or the Title. The google sheet needs to be shared with the service account email that is being used in order for it to be able to access. 

A spreadsheet can have multiple worksheets, we can access it through name or index. Currently, the task only pulls a single worksheet out of a spreadsheet into a vertica table named according to the worksheet name. 

#### Table name and schema
The task expects the first row of the worksheet to be the header with a skip_rows parameter to skip rows leading to the header if any.
Worksheet name is used as the table name in vertica. As a safety net, all characters which are not lower/upper alphabets or digits are replaced with underscore.

There seems to be no straightforward way of inferring column types. Pandas has a convert_objects method but it infers something like 5565105529276667903236 as a numpy float, does not infer datetime unless we pass in the column indexes which hold datetime values. 

We could manually analyze one row and deduce column types, but it won't work for edge cases where
the column in the first row has an int, and rest of the rows also include floats. 

Currently, everything is stored as a VARCHAR.

#### Format considerations
* Worksheet should be properly structured, including a header.  
* The worksheet name should only include characters that are allowed in a table name.
* Column names should be properly defined, only allowable characters. 
* It might make sense to include a data type along side the column name to help with sql schema.
