### PR TITLE
Refactor Vertica exports

### DIFF
--- a/edx/analytics/tasks/common/vertica_export.py
+++ b/edx/analytics/tasks/common/vertica_export.py
@@ -122,7 +122,7 @@ class VerticaTableToS3Mixin(VerticaTableFromS3Mixin):
     )
 
 
-class LoadVerticaTableFromS3Mixin(WarehouseMixin):
+class VerticaExportMixin(WarehouseMixin):
 
     vertica_warehouse_name = luigi.Parameter(
         default='warehouse',
@@ -137,7 +137,7 @@ class LoadVerticaTableFromS3Mixin(WarehouseMixin):
     )
 
 
-class VerticaTableExportMixin(LoadVerticaTableFromS3Mixin):
+class VerticaTableExportMixin(VerticaExportMixin):
     """A set of parameters and methods used by classes that dump or load a Vertica table."""
 
     date = luigi.DateParameter(
@@ -184,7 +184,7 @@ class VerticaTableExportMixin(LoadVerticaTableFromS3Mixin):
         return url
 
 
-class VerticaSchemaExportMixin(LoadVerticaTableFromS3Mixin):
+class VerticaSchemaExportMixin(VerticaExportMixin):
     """A set of parameters and methods used by classes that dump or load a Vertica schema."""
 
     date = luigi.DateParameter(

--- a/edx/analytics/tasks/common/vertica_export.py
+++ b/edx/analytics/tasks/common/vertica_export.py
@@ -30,7 +30,7 @@ except ImportError:
 # Define default values to be used by Sqoop when exporting tables from Vertica, whether for loading in
 # BigQuery or Snowflake (or some other database).
 
-VERTICA_EXPORT_DEFAULT_FIELD_DELIMITER = r'\x01'
+VERTICA_EXPORT_DEFAULT_FIELD_DELIMITER = u'\x01'
 
 VERTICA_EXPORT_DEFAULT_NULL_MARKER = 'NNULLL'
 

--- a/edx/analytics/tasks/common/vertica_export.py
+++ b/edx/analytics/tasks/common/vertica_export.py
@@ -239,7 +239,7 @@ class ExportVerticaTableToS3Task(VerticaTableExportMixin, VerticaTableToS3Mixin,
     def requires(self):
         if self._required_tasks is None:
             self._required_tasks = {
-                'credentials': ExternalURL(url=self.credentials),
+                'credentials': ExternalURL(url=self.vertica_credentials),
                 'sqoop_dump_vertica_table_task': self.sqoop_dump_vertica_table_task,
             }
         return self._required_tasks

--- a/edx/analytics/tasks/common/vertica_export.py
+++ b/edx/analytics/tasks/common/vertica_export.py
@@ -305,7 +305,7 @@ class ExportVerticaSchemaToS3Task(VerticaSchemaExportMixin, VerticaTableToS3Mixi
         yield ExternalURL(url=self.vertica_credentials)
 
         for table_name in self.get_table_list_for_schema():
-            yield VerticaTableToS3Task(
+            yield ExportVerticaTableToS3Task(
                 date=self.date,
                 overwrite=self.overwrite,
                 table_name=table_name,

--- a/edx/analytics/tasks/common/vertica_export.py
+++ b/edx/analytics/tasks/common/vertica_export.py
@@ -313,7 +313,6 @@ class ExportVerticaSchemaToS3Task(VerticaSchemaExportMixin, VerticaTableToS3Mixi
                 vertica_schema_name=self.vertica_schema_name,
                 vertica_warehouse_name=self.vertica_warehouse_name,
                 vertica_credentials=self.vertica_credentials,
-                exclude=self.exclude,
                 sqoop_null_string=self.sqoop_null_string,
                 sqoop_fields_terminated_by=self.sqoop_fields_terminated_by,
                 sqoop_delimiter_replacement=self.sqoop_delimiter_replacement,

--- a/edx/analytics/tasks/common/vertica_export.py
+++ b/edx/analytics/tasks/common/vertica_export.py
@@ -1,5 +1,5 @@
 """
-Supports exporting data from Vertica.
+Supports exporting data from Vertica to S3, for loading into other databases.
 """
 import datetime
 import json
@@ -7,9 +7,7 @@ import logging
 import re
 
 import luigi
-from google.cloud import bigquery
 
-from edx.analytics.tasks.common.bigquery_load import BigQueryLoadTask
 from edx.analytics.tasks.common.sqoop import SqoopImportFromVertica
 from edx.analytics.tasks.util.decorators import workflow_entry_point
 from edx.analytics.tasks.util.hive import HivePartition, WarehouseMixin
@@ -30,38 +28,13 @@ except ImportError:
 
 
 # Define default values to be used by Sqoop when exporting tables from Vertica, whether for loading in
-# BigQuery or Snowflake.
+# BigQuery or Snowflake (or some other database).
 
 VERTICA_EXPORT_DEFAULT_FIELD_DELIMITER = r'\x01'
 
 VERTICA_EXPORT_DEFAULT_NULL_MARKER = 'NNULLL'
 
 VERTICA_EXPORT_DEFAULT_DELIMITER_REPLACEMENT = ' '
-
-VERTICA_TO_BIGQUERY_FIELD_MAPPING = {
-    'boolean': 'bool',
-    'integer': 'int64',
-    'int': 'int64',
-    'bigint': 'int64',
-    'varbinary': 'bytes',
-    'long varbinary': 'bytes',
-    'binary': 'bytes',
-    'char': 'string',
-    'varchar': 'string',
-    'long varchar': 'string',
-    'money': 'float64',
-    'numeric': 'float64',
-    'float': 'float64',
-    'date': 'date',
-    'time': 'time',
-    # Due to an error with the Vertica JDBC client time zone information is stripped prior to extracting.  All
-    # timestamptz and timetz values are coerced to UTC (manually in the case of timestamptz).
-    'timetz': 'time',
-    'timestamptz': 'datetime',
-    'timestamp': 'datetime'
-}
-
-# (Note that Vertica-to-Snowflake mappings are found in warehouse/load_vertica_schema_to_snowflake.py.)
 
 
 def get_vertica_results(credentials, query):
@@ -128,7 +101,7 @@ class VerticaTableFromS3Mixin(object):
         description='A string replacement value for any (null) values encountered by Sqoop when exporting from Vertica.'
     )
     sqoop_fields_terminated_by = luigi.Parameter(
-        default=VERTICA_EXPORT_DEFAULT_FIELD_TERMINATOR,
+        default=VERTICA_EXPORT_DEFAULT_FIELD_DELIMITER,
         description='The field delimiter used by Sqoop.'
     )
 
@@ -149,7 +122,7 @@ class VerticaTableToS3Mixin(VerticaTableFromS3Mixin):
     )
 
 
-class LoadVerticaTableFromS3Mixin(object):
+class LoadVerticaTableFromS3Mixin(WarehouseMixin):
 
     vertica_warehouse_name = luigi.Parameter(
         default='warehouse',
@@ -164,25 +137,83 @@ class LoadVerticaTableFromS3Mixin(object):
     )
 
 
-class VerticaSchemaExportMixin(LoadVerticaTableFromS3Mixin):
+class VerticaTableExportMixin(LoadVerticaTableFromS3Mixin):
+    """A set of parameters and methods used by classes that dump or load a Vertica table."""
 
+    date = luigi.DateParameter(
+        default=datetime.datetime.utcnow().date(),
+        description='Current run date.  This parameter is used to isolate intermediate datasets.'
+    )
+    table_name = luigi.Parameter(
+        description='The Vertica table being dumped to S3.'
+    )
+    intermediate_warehouse_path = luigi.Parameter(
+        description='A path specifying the S3 root for storing dumps from Vertica.',
+        default=None,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(VerticaTableExportMixin, self).__init__(*args, **kwargs)
+        # If no explicit value is passed in, use the same default that schema-level classes would have used.
+        if self.intermediate_warehouse_path is None:
+            self.intermediate_warehouse_path = url_path_join(self.warehouse_path, 'import/vertica/sqoop/')
+        self.vertica_source_table_schema = None
+
+    @property
+    def vertica_table_schema(self):
+        """The schema of the Vertica table."""
+        if self.vertica_source_table_schema is None:
+            self.vertica_source_table_schema = get_vertica_table_schema(
+                self.vertica_credentials, self.vertica_schema_name, self.table_name
+            )
+        return self.vertica_source_table_schema
+
+    @property
+    def s3_location_for_table(self):
+        """
+        Returns the URL for the location of S3 data for the given table and schema.
+
+        This logic is shared by classes that dump data to S3 and those that load data from S3, so they agree.
+        """
+        partition_path_spec = HivePartition('dt', self.date).path_spec
+        url = url_path_join(self.intermediate_warehouse_path,
+                            self.vertica_warehouse_name,
+                            self.vertica_schema_name,
+                            self.table_name,
+                            partition_path_spec) + '/'
+        return url
+
+
+class VerticaSchemaExportMixin(LoadVerticaTableFromS3Mixin):
+    """A set of parameters and methods used by classes that dump or load a Vertica schema."""
+
+    date = luigi.DateParameter(
+        default=datetime.datetime.utcnow().date(),
+        description='Current run date.  This parameter is used to isolate intermediate datasets.'
+    )
     exclude = luigi.ListParameter(
         default=[],
         description='The Vertica tables that are to be excluded from exporting.'
     )
 
-    # Cache list for tables in schema, to reduce repeated calls to Vertica.
-    _table_names_list = None
+    def __init__(self, *args, **kwargs):
+        super(VerticaSchemaExportMixin, self).__init__(*args, **kwargs)
+        self._table_names_list = None
+
+    @property
+    def intermediate_warehouse_path(self):
+        """Define root URL under which data should be written to or read from in S3."""
+        return url_path_join(self.warehouse_path, 'import/vertica/sqoop/')
 
     def should_exclude_table(self, table_name):
-        """
-        Determines whether to exclude a table during the import.
-        """
+        """Determine whether to exclude a table during the import, based on regex matching agains specified patterns."""
         if any(re.match(pattern, table_name) for pattern in self.exclude):  # pylint: disable=not-an-iterable
             return True
         return False
 
     def get_table_list_for_schema(self):
+        """Returns a list of tables in the specified Vertica schema, applying all exclude patterns."""
+        # Cache list for tables in schema, to reduce repeated calls to Vertica.
         if not self._table_names_list:
             query = "SELECT table_name FROM all_tables WHERE schema_name='{schema_name}' AND table_type='TABLE' " \
                     "".format(schema_name=self.vertica_schema_name)
@@ -192,7 +223,7 @@ class VerticaSchemaExportMixin(LoadVerticaTableFromS3Mixin):
         return self._table_names_list
 
 
-class VerticaTableToS3Task(VerticaTableToS3Mixin, OverwriteOutputMixin, luigi.Task):
+class ExportVerticaTableToS3Task(VerticaTableExportMixin, VerticaTableToS3Mixin, OverwriteOutputMixin, luigi.Task):
     """
     Export a table from Vertica to S3 using sqoop.
 
@@ -200,89 +231,64 @@ class VerticaTableToS3Task(VerticaTableToS3Mixin, OverwriteOutputMixin, luigi.Ta
     LoadVerticaToS3TableTask the caller must know the Vertica schema and table name. The columns are automatically
     discovered at run time.
     """
-    date = luigi.DateParameter(
-        description='A URL location of the data warehouse.'
-    )
-    intermediate_warehouse_path = luigi.Parameter(
-        description='A dictionary specifying the S3-centric configuration.'
-    )
-    column_list = luigi.ListParameter(
-        description='The column names being extracted from this table.'
-    )
-    warehouse_name = luigi.Parameter(
-        description='The Vertica warehouse that houses the schema being copied.'
-    )
-    schema_name = luigi.Parameter(
-        description='The Vertica schema being copied. '
-    )
-    credentials = luigi.Parameter(
-        description='Path to the external Vertica access credentials file.',
-    )
-    table_name = luigi.Parameter(
-        description='The Vertica table being copied.'
-    )
-    timestamptz_column_list = luigi.ListParameter(
-        default=[],
-        description='The list of columns being copied that are of type timestamptz.  This is necessary because of a '
-                    'bug in the time zone processing of the Vertica JDBC client.  Note timetz fields are automatically'
-                    'converted to UTC.'
-    )
-
     def __init__(self, *args, **kwargs):
         super(VerticaTableToS3Task, self).__init__(*args, **kwargs)
-        self.required_tasks = None
-        self.vertica_source_table_schema = None
+        self._required_tasks = None
+        self._sqoop_dump_vertica_table_task = None
 
     def requires(self):
-        if self.required_tasks is None:
-            self.required_tasks = {
+        if self._required_tasks is None:
+            self._required_tasks = {
                 'credentials': ExternalURL(url=self.credentials),
-                'insert_source': self.insert_source_task,
+                'sqoop_dump_vertica_table_task': self.sqoop_dump_vertica_table_task,
             }
-        return self.required_tasks
+        return self._required_tasks
 
     def complete(self):
-        return self.insert_source_task.complete()
-
-    def s3_output_path(self):
-        partition_path_spec = HivePartition('dt', self.date).path_spec
-        target_url = url_path_join(self.intermediate_warehouse_path,
-                                   self.warehouse_name,
-                                   self.schema_name,
-                                   self.table_name,
-                                   partition_path_spec) + '/'
-        return target_url
+        return self.sqoop_dump_vertica_table_task.complete()
 
     def output(self):
-        return get_target_from_url(self.s3_output_path())
+        return get_target_from_url(self.s3_location_for_table)
 
     @property
-    def insert_source_task(self):
+    def sqoop_dump_vertica_table_task(self):
         """The sqoop command that manages the data transfer from the source datasource."""
-        if len(self.column_list) <= 0:
-            raise RuntimeError('Error Sqoop copy of {schema}.{table} found no viable columns!'.
-                               format(schema=self.schema_name,
-                                      table=self.table))
+        # Only calculate this once, since it's used in required() and complete() methods.
+        if self._sqoop_dump_vertica_table_task is None:
+            # We not only need the list of column names, but we also
+            # need the list of columns being copied that are of type
+            # timestamptz.  This is necessary because of a bug in the
+            # time zone processing of the Vertica JDBC client.  Note
+            # timetz fields are automatically converted to UTC.
+            column_list = []
+            timestamptz_column_list = []
+            for field_name, vertica_field_type, _ in self.vertica_table_schema:
+                column_list.append(field_name)
+                if vertica_field_type in ['timestamptz']:
+                    timestamptz_column_list.append(field_name)
 
-        target_url = self.s3_output_path()
+            if len(column_list) <= 0:
+                raise RuntimeError('Error Sqoop copy of {schema}.{table} found no viable columns!'.
+                                   format(schema=self.schema_name, table=self.table))
 
-        return SqoopImportFromVertica(
-            schema_name=self.schema_name,
-            table_name=self.table_name,
-            credentials=self.credentials,
-            database=self.warehouse_name,
-            columns=self.column_list,
-            destination=target_url,
-            overwrite=self.overwrite,
-            null_string=self.sqoop_null_string,
-            fields_terminated_by=self.sqoop_fields_terminated_by,
-            delimiter_replacement=self.sqoop_delimiter_replacement,
-            timezone_adjusted_column_list=self.timestamptz_column_list,
-        )
+            self._sqoop_dump_vertica_table_task = SqoopImportFromVertica(
+                schema_name=self.vertica_schema_name,
+                table_name=self.table_name,
+                credentials=self.vertica_credentials,
+                database=self.vertica_warehouse_name,
+                destination=self.s3_location_for_table,
+                overwrite=self.overwrite,
+                null_string=self.sqoop_null_string,
+                fields_terminated_by=self.sqoop_fields_terminated_by,
+                delimiter_replacement=self.sqoop_delimiter_replacement,
+                columns=column_list,
+                timezone_adjusted_column_list=timestamptz_column_list,
+            )
+        return self._sqoop_dump_vertica_table_task
 
 
 @workflow_entry_point
-class VerticaSchemaToS3Task(VerticaSchemaExportMixin, WarehouseMixin, luigi.WrapperTask):
+class ExportVerticaSchemaToS3Task(VerticaSchemaExportMixin, VerticaTableToS3Mixin, luigi.WrapperTask):
     """
     A task that copies all the tables in a Vertica schema to S3, so other jobs can load from there.
 
@@ -294,199 +300,21 @@ class VerticaSchemaToS3Task(VerticaSchemaExportMixin, WarehouseMixin, luigi.Wrap
         significant=False,
         description='Indicates if the target data sources should be removed prior to generating.'
     )
-    date = luigi.DateParameter(
-        default=datetime.datetime.utcnow().date(),
-        description='Current run date.  This parameter is used to isolate intermediate datasets.'
-    )
-
-    def __init__(self, *args, **kwargs):
-        super(VerticaSchemaToS3Task, self).__init__(*args, **kwargs)
 
     def requires(self):
         yield ExternalURL(url=self.vertica_credentials)
-
-        intermediate_warehouse_path = url_path_join(self.warehouse_path, 'import/vertica/sqoop/')
 
         for table_name in self.get_table_list_for_schema():
             yield VerticaTableToS3Task(
                 date=self.date,
                 overwrite=self.overwrite,
-                intermediate_warehouse_path=intermediate_warehouse_path,
                 table_name=table_name,
+                intermediate_warehouse_path=self.intermediate_warehouse_path,
                 vertica_schema_name=self.vertica_schema_name,
                 vertica_warehouse_name=self.vertica_warehouse_name,
                 vertica_credentials=self.vertica_credentials,
+                exclude=self.exclude,
                 sqoop_null_string=self.sqoop_null_string,
                 sqoop_fields_terminated_by=self.sqoop_fields_terminated_by,
                 sqoop_delimiter_replacement=self.sqoop_delimiter_replacement,
-                exclude=self.exclude,
             )
-
-
-class LoadVerticaTableToBigQuery(VerticaTableToS3Task, BigQueryLoadTask):
-    """Copies one table from Vertica through S3/GCP into BigQuery."""
-
-    intermediate_warehouse_path = luigi.Parameter(
-        description='The intermediate warehouse path used on S3 and GCP'
-    )
-    table_name = luigi.Parameter(
-        description='The Vertica table being copied.'
-    )
-    vertica_warehouse_name = luigi.Parameter(
-        default='warehouse', description='The Vertica warehouse that houses the schema being copied.'
-    )
-    vertica_schema_name = luigi.Parameter(
-        description='The Vertica schema being copied. '
-    )
-    vertica_credentials = luigi.Parameter(
-        description='Path to the external Vertica access credentials file.',
-    )
-    exclude = luigi.ListParameter(
-        description='The Vertica tables that are to be excluded from exporting.'
-    )
-
-    def __init__(self, *args, **kwargs):
-        super(LoadVerticaTableToBigQuery, self).__init__(*args, **kwargs)
-        self.vertica_source_table_schema = None
-        self.bigquery_compliant_schema = None
-        self.timestamptz_column_list = None
-
-    @property
-    def vertica_table_schema(self):
-        """The schema of the Vertica table."""
-        if self.vertica_source_table_schema is None:
-            self.vertica_source_table_schema = get_vertica_table_schema(self.vertica_credentials,
-                                                                        self.vertica_schema_name,
-                                                                        self.table_name)
-        return self.vertica_source_table_schema
-
-    @property
-    def table(self):
-        return self.table_name
-
-    @property
-    def table_description(self):
-        return "Copy of Vertica table {}.{} on {}".format(self.vertica_schema_name,
-                                                          self.table_name,
-                                                          self.date)
-
-    @property
-    def table_friendly_name(self):
-        return '{} from {}'.format(self.table_name, self.vertica_schema_name)
-
-    @property
-    def field_delimiter(self):
-        return VERTICA_EXPORT_DEFAULT_FIELD_DELIMITER
-
-    @property
-    def null_marker(self):
-        return VERTICA_EXPORT_DEFAULT_NULL_MARKER
-
-    @property
-    def delimiter_replacement(self):
-        return VERTICA_EXPORT_DEFAULT_DELIMITER_REPLACEMENT
-
-    @property
-    def schema(self):
-        """The BigQuery compliant schema."""
-        if self.bigquery_compliant_schema is None:
-            res = []
-            timestamp_list = []
-            for field_name, vertica_field_type, nullable in self.vertica_table_schema:
-                # column_name, data_type, is_nullable
-                if vertica_field_type in VERTICA_TO_BIGQUERY_FIELD_MAPPING:
-                    res.append(bigquery.SchemaField(field_name,
-                                                    VERTICA_TO_BIGQUERY_FIELD_MAPPING[vertica_field_type],
-                                                    mode='NULLABLE' if nullable else 'REQUIRED'))
-                    if vertica_field_type in ['timestamptz']:
-                        timestamp_list.append(field_name)
-                else:
-                    raise RuntimeError('Error for field {field}: Vertica type {type} does not have a mapping to '
-                                       'BigQuery'.format(field=field_name, type=vertica_field_type))
-            self.bigquery_compliant_schema = res
-            self.timestamptz_column_list = timestamp_list
-        return self.bigquery_compliant_schema
-
-    @property
-    def insert_source_task(self):
-        return VerticaTableToS3Task(
-            intermediate_warehouse_path=self.intermediate_warehouse_path,
-            date=self.date,
-            overwrite=self.overwrite,
-            sqoop_null_string=self.null_marker,
-            sqoop_fields_terminated_by=self.field_delimiter,
-            sqoop_delimiter_replacement=self.delimiter_replacement,
-            column_list=[field.name for field in self.schema],
-            warehouse_name=self.vertica_warehouse_name,
-            schema_name=self.vertica_schema_name,
-            credentials=self.vertica_credentials,
-            table_name=self.table_name,
-            timestamptz_column_list=self.timestamptz_column_list
-        )
-
-
-@workflow_entry_point
-class VerticaSchemaToBigQueryTask(VerticaSchemaExportMixin, luigi.WrapperTask):
-    """
-    A task that copies all the tables in a Vertica schema to BigQuery via S3.
-
-    Reads all tables in a schema and, if they are not listed in the `exclude` parameter, schedules a
-    LoadVerticaTableToBigQuery task for each table.
-    """
-    overwrite = luigi.BoolParameter(
-        default=False,
-        significant=False,
-        description='Indicates if the target data sources should be removed prior to generating.'
-    )
-    date = luigi.DateParameter(
-        default=datetime.datetime.utcnow().date(),
-        description='Current run date.  This parameter is used to isolate intermediate datasets.'
-    )
-    bigquery_dataset = luigi.Parameter(
-        default=None,
-        description='The target dataset that will hold the Vertica schema.'
-    )
-    max_bad_records = luigi.IntParameter(
-        default=0,
-        description="Number of bad records ignored by BigQuery before failing a load job."
-    )
-    gcp_credentials = luigi.Parameter(
-        description='Path to the external GCP/BigQuery access credentials file.',
-    )
-    s3_warehouse_path = luigi.Parameter(
-        config_path={'section': 'hive', 'name': 'warehouse_path'},
-        description='The warehouse path to store intermediate data on S3.'
-    )
-
-    def __init__(self, *args, **kwargs):
-        super(VerticaSchemaToBigQueryTask, self).__init__(*args, **kwargs)
-
-    def requires(self):
-        yield ExternalURL(url=self.vertica_credentials)
-        yield ExternalURL(url=self.gcp_credentials)
-
-        if self.bigquery_dataset is None:
-            self.bigquery_dataset = self.vertica_schema_name
-
-        intermediate_warehouse_path = url_path_join(self.s3_warehouse_path, 'import/vertica/sqoop/')
-
-        query = "SELECT table_name FROM all_tables WHERE schema_name='{schema_name}' AND table_type='TABLE' " \
-                "".format(schema_name=self.vertica_schema_name)
-        table_list = [row[0] for row in get_vertica_results(self.vertica_credentials, query)]
-
-        for table_name in table_list:
-            if not self.should_exclude_table(table_name):
-
-                yield LoadVerticaTableToBigQuery(
-                    date=self.date,
-                    overwrite=self.overwrite,
-                    intermediate_warehouse_path=intermediate_warehouse_path,
-                    dataset_id=self.bigquery_dataset,
-                    credentials=self.gcp_credentials,
-                    max_bad_records=self.max_bad_records,
-                    table_name=table_name,
-                    vertica_schema_name=self.vertica_schema_name,
-                    vertica_warehouse_name=self.vertica_warehouse_name,
-                    vertica_credentials=self.vertica_credentials,
-                    exclude=self.exclude,
-                )

--- a/edx/analytics/tasks/common/vertica_export.py
+++ b/edx/analytics/tasks/common/vertica_export.py
@@ -232,7 +232,7 @@ class ExportVerticaTableToS3Task(VerticaTableExportMixin, VerticaTableToS3Mixin,
     discovered at run time.
     """
     def __init__(self, *args, **kwargs):
-        super(VerticaTableToS3Task, self).__init__(*args, **kwargs)
+        super(ExportVerticaTableToS3Task, self).__init__(*args, **kwargs)
         self._required_tasks = None
         self._sqoop_dump_vertica_table_task = None
 

--- a/edx/analytics/tasks/warehouse/load_vertica_schema_to_bigquery.py
+++ b/edx/analytics/tasks/warehouse/load_vertica_schema_to_bigquery.py
@@ -1,6 +1,7 @@
 """
-Supports exporting data from Vertica to S3, for loading into other databases.
+Tasks to load a Vertica schema from S3 into BigQuery.
 """
+
 import logging
 
 import luigi
@@ -81,7 +82,7 @@ class LoadVerticaTableFromS3ToBigQueryTask(VerticaTableExportMixin, VerticaTable
             for field_name, vertica_field_type, nullable in self.vertica_table_schema:
                 # Above is analogous to "column_name, data_type, is_nullable" in Vertica.
                 # In BigQuery, strip off all sizes before remapping, because BigQuery doesn't want size information.
-                vertica_field_type = vertica_field_type.rsplit('(')[0]
+                vertica_field_type = vertica_field_type.split('(')[0]
                 if vertica_field_type in VERTICA_TO_BIGQUERY_FIELD_MAPPING:
                     res.append(
                         SchemaField(

--- a/edx/analytics/tasks/warehouse/load_vertica_schema_to_bigquery.py
+++ b/edx/analytics/tasks/warehouse/load_vertica_schema_to_bigquery.py
@@ -7,7 +7,7 @@ import luigi
 from google.cloud.bigquery import SchemaField
 
 from edx.analytics.tasks.common.bigquery_load import BigQueryLoadTask
-from edx.analytics.tasks.common.vertica_export import LoadVerticaTableFromS3Mixin, VerticaSchemaExportMixin, VerticaTableExportMixin
+from edx.analytics.tasks.common.vertica_export import VerticaSchemaExportMixin, VerticaTableExportMixin, VerticaTableFromS3Mixin
 from edx.analytics.tasks.util.decorators import workflow_entry_point
 from edx.analytics.tasks.util.url import ExternalURL
 

--- a/edx/analytics/tasks/warehouse/load_vertica_schema_to_bigquery.py
+++ b/edx/analytics/tasks/warehouse/load_vertica_schema_to_bigquery.py
@@ -39,7 +39,7 @@ VERTICA_TO_BIGQUERY_FIELD_MAPPING = {
 }
 
 
-class LoadVerticaTableFromS3ToBigQueryTask(VerticaTableExportMixin, LoadVerticaTableFromS3Mixin, BigQueryLoadTask):
+class LoadVerticaTableFromS3ToBigQueryTask(VerticaTableExportMixin, VerticaTableFromS3Mixin, BigQueryLoadTask):
     """Copies one table from S3 through GCP into BigQuery, after having been dumped from Vertica to S3."""
 
     def __init__(self, *args, **kwargs):

--- a/edx/analytics/tasks/warehouse/load_vertica_schema_to_bigquery.py
+++ b/edx/analytics/tasks/warehouse/load_vertica_schema_to_bigquery.py
@@ -42,7 +42,7 @@ class LoadVerticaTableFromS3ToBigQueryTask(VerticaTableExportMixin, LoadVerticaT
     """Copies one table from S3 through GCP into BigQuery, after having been dumped from Vertica to S3."""
 
     def __init__(self, *args, **kwargs):
-        super(LoadVerticaTableToBigQuery, self).__init__(*args, **kwargs)
+        super(LoadVerticaTableFromS3ToBigQueryTask, self).__init__(*args, **kwargs)
         self.bigquery_compliant_schema = None
         self.timestamptz_column_list = None
 

--- a/edx/analytics/tasks/warehouse/load_vertica_schema_to_bigquery.py
+++ b/edx/analytics/tasks/warehouse/load_vertica_schema_to_bigquery.py
@@ -135,7 +135,6 @@ class LoadVerticaSchemaFromS3ToBigQueryTask(VerticaSchemaExportMixin, luigi.Wrap
                 vertica_schema_name=self.vertica_schema_name,
                 vertica_warehouse_name=self.vertica_warehouse_name,
                 vertica_credentials=self.vertica_credentials,
-                exclude=self.exclude,
             )
 
 

--- a/edx/analytics/tasks/warehouse/load_vertica_schema_to_bigquery.py
+++ b/edx/analytics/tasks/warehouse/load_vertica_schema_to_bigquery.py
@@ -1,0 +1,141 @@
+"""
+Supports exporting data from Vertica to S3, for loading into other databases.
+"""
+import logging
+
+import luigi
+
+from edx.analytics.tasks.common.bigquery_load import BigQueryLoadTask
+from edx.analytics.tasks.common.vertica_export import LoadVerticaTableFromS3Mixin, VerticaSchemaExportMixin, VerticaTableExportMixin
+from edx.analytics.tasks.util.decorators import workflow_entry_point
+from edx.analytics.tasks.util.url import ExternalURL
+
+
+log = logging.getLogger(__name__)
+
+
+VERTICA_TO_BIGQUERY_FIELD_MAPPING = {
+    'boolean': 'bool',
+    'integer': 'int64',
+    'int': 'int64',
+    'bigint': 'int64',
+    'varbinary': 'bytes',
+    'long varbinary': 'bytes',
+    'binary': 'bytes',
+    'char': 'string',
+    'varchar': 'string',
+    'long varchar': 'string',
+    'money': 'float64',
+    'numeric': 'float64',
+    'float': 'float64',
+    'date': 'date',
+    'time': 'time',
+    # Due to an error with the Vertica JDBC client time zone information is stripped prior to extracting.  All
+    # timestamptz and timetz values are coerced to UTC (manually in the case of timestamptz).
+    'timetz': 'time',
+    'timestamptz': 'datetime',
+    'timestamp': 'datetime'
+}
+
+
+class LoadVerticaTableFromS3ToBigQueryTask(VerticaTableExportMixin, LoadVerticaTableFromS3Mixin, BigQueryLoadTask):
+    """Copies one table from S3 through GCP into BigQuery, after having been dumped from Vertica to S3."""
+
+    def __init__(self, *args, **kwargs):
+        super(LoadVerticaTableToBigQuery, self).__init__(*args, **kwargs)
+        self.bigquery_compliant_schema = None
+        self.timestamptz_column_list = None
+
+    @property
+    def table(self):
+        return self.table_name
+
+    @property
+    def table_description(self):
+        return "Copy of Vertica table {}.{} on {}".format(
+            self.vertica_schema_name, self.table_name, self.date
+        )
+
+    @property
+    def table_friendly_name(self):
+        return '{} from {}'.format(self.table_name, self.vertica_schema_name)
+
+    @property
+    def field_delimiter(self):
+        return self.sqoop_fields_terminated_by
+
+    @property
+    def null_marker(self):
+        return self.sqoop_null_string
+
+    @property
+    def schema(self):
+        """The BigQuery compliant schema."""
+        if self.bigquery_compliant_schema is None:
+            res = []
+            for field_name, vertica_field_type, nullable in self.vertica_table_schema:
+                # column_name, data_type, is_nullable
+                if vertica_field_type in VERTICA_TO_BIGQUERY_FIELD_MAPPING:
+                    res.append(bigquery.SchemaField(field_name,
+                                                    VERTICA_TO_BIGQUERY_FIELD_MAPPING[vertica_field_type],
+                                                    mode='NULLABLE' if nullable else 'REQUIRED'))
+                else:
+                    raise RuntimeError('Error for field {field}: Vertica type {type} does not have a mapping to '
+                                       'BigQuery'.format(field=field_name, type=vertica_field_type))
+            self.bigquery_compliant_schema = res
+        return self.bigquery_compliant_schema
+
+    @property
+    def insert_source_task(self):
+        return ExternalURL(url=self.s3_location_for_table)
+
+
+@workflow_entry_point
+class LoadVerticaSchemaFromS3ToBigQueryTask(VerticaSchemaExportMixin, luigi.WrapperTask):
+    """
+    A task that copies all the tables in a Vertica schema to BigQuery via S3.
+
+    Reads all tables in a schema and, if they are not listed in the `exclude` parameter, schedules a
+    LoadVerticaTableToBigQuery task for each table.
+    """
+    overwrite = luigi.BoolParameter(
+        default=False,
+        significant=False,
+        description='Indicates if the target data sources should be removed prior to generating.'
+    )
+    bigquery_dataset = luigi.Parameter(
+        default=None,
+        description='The target dataset that will hold the Vertica schema.'
+    )
+    max_bad_records = luigi.IntParameter(
+        default=0,
+        description="Number of bad records ignored by BigQuery before failing a load job."
+    )
+    gcp_credentials = luigi.Parameter(
+        description='Path to the external GCP/BigQuery access credentials file.',
+    )
+
+    def requires(self):
+        yield ExternalURL(url=self.vertica_credentials)
+
+        yield ExternalURL(url=self.gcp_credentials)
+
+        if self.bigquery_dataset is None:
+            self.bigquery_dataset = self.vertica_schema_name
+
+        for table_name in self.get_table_list_for_schema():
+            yield LoadVerticaTableFromS3ToBigQueryTask(
+                date=self.date,
+                overwrite=self.overwrite,
+                intermediate_warehouse_path=self.intermediate_warehouse_path,
+                dataset_id=self.bigquery_dataset,
+                credentials=self.gcp_credentials,
+                max_bad_records=self.max_bad_records,
+                table_name=table_name,
+                vertica_schema_name=self.vertica_schema_name,
+                vertica_warehouse_name=self.vertica_warehouse_name,
+                vertica_credentials=self.vertica_credentials,
+                exclude=self.exclude,
+            )
+
+

--- a/edx/analytics/tasks/warehouse/load_vertica_schema_to_bigquery.py
+++ b/edx/analytics/tasks/warehouse/load_vertica_schema_to_bigquery.py
@@ -7,10 +7,11 @@ import luigi
 from google.cloud.bigquery import SchemaField
 
 from edx.analytics.tasks.common.bigquery_load import BigQueryLoadTask
-from edx.analytics.tasks.common.vertica_export import VerticaSchemaExportMixin, VerticaTableExportMixin, VerticaTableFromS3Mixin
+from edx.analytics.tasks.common.vertica_export import (
+    VerticaSchemaExportMixin, VerticaTableExportMixin, VerticaTableFromS3Mixin
+)
 from edx.analytics.tasks.util.decorators import workflow_entry_point
 from edx.analytics.tasks.util.url import ExternalURL
-
 
 log = logging.getLogger(__name__)
 
@@ -146,5 +147,3 @@ class LoadVerticaSchemaFromS3ToBigQueryTask(VerticaSchemaExportMixin, luigi.Wrap
                 vertica_warehouse_name=self.vertica_warehouse_name,
                 vertica_credentials=self.vertica_credentials,
             )
-
-

--- a/edx/analytics/tasks/warehouse/load_vertica_schema_to_snowflake.py
+++ b/edx/analytics/tasks/warehouse/load_vertica_schema_to_snowflake.py
@@ -14,7 +14,7 @@ from edx.analytics.tasks.util.url import ExternalURL
 log = logging.getLogger(__name__)
 
 
-class LoadVerticaTableFromS3ToSnowflakeTask(VerticaTableExportMixin, LoadVerticaTableFromS3Mixin, SnowflakeLoadFromHiveTSVTask):
+class LoadVerticaTableFromS3ToSnowflakeTask(VerticaTableExportMixin, VerticaTableFromS3Mixin, SnowflakeLoadFromHiveTSVTask):
     """
     Task to load a vertica table from S3 into Snowflake.
     """
@@ -70,7 +70,7 @@ class LoadVerticaTableFromS3ToSnowflakeTask(VerticaTableExportMixin, LoadVertica
         return self.sqoop_fields_terminated_by
 
 
-class LoadVerticaSchemaFromS3ToSnowflakeTask(VerticaSchemaExportMixin, LoadVerticaTableFromS3Mixin, SnowflakeLoadDownstreamMixin, luigi.WrapperTask):
+class LoadVerticaSchemaFromS3ToSnowflakeTask(VerticaSchemaExportMixin, VerticaTableFromS3Mixin, SnowflakeLoadDownstreamMixin, luigi.WrapperTask):
     """
     A task that loads into Snowflake all the tables in S3 dumped from a Vertica schema.
 

--- a/edx/analytics/tasks/warehouse/load_vertica_schema_to_snowflake.py
+++ b/edx/analytics/tasks/warehouse/load_vertica_schema_to_snowflake.py
@@ -25,6 +25,7 @@ class LoadVerticaTableFromS3ToSnowflakeTask(VerticaTableExportMixin, VerticaTabl
 
         Information about "nullable" or required fields is not included.
         """
+        results = []
         for column_name, field_type, _ in self.vertica_table_schema:
             if column_name == 'start':
                 column_name = '"{}"'.format(column_name)

--- a/edx/analytics/tasks/warehouse/load_vertica_schema_to_snowflake.py
+++ b/edx/analytics/tasks/warehouse/load_vertica_schema_to_snowflake.py
@@ -34,7 +34,7 @@ class LoadVerticaTableFromS3ToSnowflakeTask(VerticaTableExportMixin, VerticaTabl
                 field_type = field_type.lstrip('long ')
             elif 'numeric(40' in field_type:
                 # Snowflake only handles numerics up to 38.
-                field_type = field_type.rsplit('(')[0]
+                field_type = field_type.split('(')[0]
 
             results.append((column_name, field_type))
 

--- a/edx/analytics/tasks/warehouse/load_vertica_schema_to_snowflake.py
+++ b/edx/analytics/tasks/warehouse/load_vertica_schema_to_snowflake.py
@@ -1,5 +1,5 @@
 """
-Tasks to load a Vertica schema into Snowflake.
+Tasks to load a Vertica schema from S3 into Snowflake.
 """
 
 import logging
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 
 class LoadVerticaTableFromS3ToSnowflakeTask(VerticaTableExportMixin, VerticaTableFromS3Mixin, SnowflakeLoadFromHiveTSVTask):
     """
-    Task to load a vertica table from S3 into Snowflake.
+    Task to load a Vertica table from S3 into Snowflake.
     """
 
     def snowflake_compliant_schema(self):
@@ -29,12 +29,12 @@ class LoadVerticaTableFromS3ToSnowflakeTask(VerticaTableExportMixin, VerticaTabl
         for column_name, field_type, _ in self.vertica_table_schema:
             if column_name == 'start':
                 column_name = '"{}"'.format(column_name)
-            elif field_type.lower().startswith('long'):
-                field_type = field_type.lower().lstrip('long ')
-            elif '(40' in field_type.lower():
+            elif field_type.startswith('long '):
+                field_type = field_type.lstrip('long ')
+            elif '(40' in field_type:
                 field_type = field_type.rsplit('(')[0]
 
-            results.append((column_name, field_type.lower()))
+            results.append((column_name, field_type))
 
         return results
 

--- a/edx/analytics/tasks/warehouse/load_vertica_schema_to_snowflake.py
+++ b/edx/analytics/tasks/warehouse/load_vertica_schema_to_snowflake.py
@@ -29,9 +29,10 @@ class LoadVerticaTableFromS3ToSnowflakeTask(VerticaTableExportMixin, VerticaTabl
         for column_name, field_type, _ in self.vertica_table_schema:
             if column_name == 'start':
                 column_name = '"{}"'.format(column_name)
-            elif field_type.startswith('long '):
+            if field_type.startswith('long '):
                 field_type = field_type.lstrip('long ')
-            elif '(40' in field_type:
+            elif 'numeric(40' in field_type:
+                # Snowflake only handles numerics up to 38.
                 field_type = field_type.rsplit('(')[0]
 
             results.append((column_name, field_type))

--- a/edx/analytics/tasks/warehouse/load_vertica_schema_to_snowflake.py
+++ b/edx/analytics/tasks/warehouse/load_vertica_schema_to_snowflake.py
@@ -7,7 +7,7 @@ import logging
 import luigi
 
 from edx.analytics.tasks.common.snowflake_load import SnowflakeLoadDownstreamMixin, SnowflakeLoadFromHiveTSVTask
-from edx.analytics.tasks.common.vertica_export import LoadVerticaTableFromS3Mixin, VerticaSchemaExportMixin, VerticaTableExportMixin
+from edx.analytics.tasks.common.vertica_export import VerticaSchemaExportMixin, VerticaTableExportMixin, VerticaTableFromS3Mixin
 from edx.analytics.tasks.util.url import ExternalURL
 
 

--- a/edx/analytics/tasks/warehouse/load_vertica_schema_to_snowflake.py
+++ b/edx/analytics/tasks/warehouse/load_vertica_schema_to_snowflake.py
@@ -85,9 +85,8 @@ class LoadVerticaTableFromS3ToSnowflake(LoadVerticaTableFromS3ToSnowflakeMixin, 
     @property
     def insert_source_task(self):
         """
-        We are already exporting vertica tables to S3 using SqoopImportFromVertica through VerticaSchemaToBigQueryTask
-        workflow, so we specify ExternalURL here instead. In the future we can change this to a
-        SqoopImportFromVertica task.
+        This assumes we have already exported vertica tables to S3 using SqoopImportFromVertica through VerticaSchemaToS3Task
+        workflow, so we specify ExternalURL here.
         """
         partition_path_spec = HivePartition('dt', self.date).path_spec
         intermediate_warehouse_path = url_path_join(self.warehouse_path, 'import/vertica/sqoop/')

--- a/edx/analytics/tasks/warehouse/load_vertica_schema_to_snowflake.py
+++ b/edx/analytics/tasks/warehouse/load_vertica_schema_to_snowflake.py
@@ -7,9 +7,10 @@ import logging
 import luigi
 
 from edx.analytics.tasks.common.snowflake_load import SnowflakeLoadDownstreamMixin, SnowflakeLoadFromHiveTSVTask
-from edx.analytics.tasks.common.vertica_export import VerticaSchemaExportMixin, VerticaTableExportMixin, VerticaTableFromS3Mixin
+from edx.analytics.tasks.common.vertica_export import (
+    VerticaSchemaExportMixin, VerticaTableExportMixin, VerticaTableFromS3Mixin
+)
 from edx.analytics.tasks.util.url import ExternalURL
-
 
 log = logging.getLogger(__name__)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ edx.analytics.tasks =
     insert-into-table = edx.analytics.tasks.common.mysql_load:MysqlInsertTask
     bigquery-load = edx.analytics.tasks.common.bigquery_load:BigQueryLoadTask
     snowflake-load = edx.analytics.tasks.common.snowflake_load:SnowflakeLoadTask
+    export-vertica-sqoop = edx.analytics.tasks.common.vertica_export:ExportVerticaTableToS3Task
 
     # insights
     answer-dist = edx.analytics.tasks.insights.answer_dist:AnswerDistributionPerCourse
@@ -63,20 +64,20 @@ edx.analytics.tasks =
     load-d-user-course = edx.analytics.tasks.warehouse.load_internal_reporting_user_course:LoadUserCourseSummary
     load-events = edx.analytics.tasks.warehouse.load_internal_reporting_events:TrackingEventRecordDataTask
     load-f-user-activity = edx.analytics.tasks.warehouse.load_internal_reporting_user_activity:LoadInternalReportingUserActivityToWarehouse
+    load-ga-permissions = edx.analytics.tasks.warehouse.load_ga_permissions:LoadGoogleAnalyticsPermissionsWorkflow
+    load-google-sheet-warehouse = edx.analytics.tasks.warehouse.load_google_sheet_to_warehouse:LoadGoogleSpreadsheetsToWarehouseWorkflow
     load-insights= edx.analytics.tasks.warehouse.load_warehouse_insights:LoadInsightsTableToVertica
     load-internal-active-users = edx.analytics.tasks.warehouse.load_internal_reporting_active_users:LoadInternalReportingActiveUsersToWarehouse
     load-internal-course-structure = edx.analytics.tasks.warehouse.load_internal_reporting_course_structure:LoadCourseBlockRecordToVertica
     load-internal-database = edx.analytics.tasks.warehouse.load_internal_reporting_database:ImportMysqlToVerticaTask
+    load-vertica-schema-snowflake = edx.analytics.tasks.warehouse.load_vertica_schema_to_snowflake:LoadVerticaSchemaFromS3ToSnowflakeTask
+    load-vertica-schema-bigquery = edx.analytics.tasks.warehouse.load_vertica_schema_to_bigquery:LoadVerticaSchemaFromS3ToBigQueryTask
     load-warehouse = edx.analytics.tasks.warehouse.load_warehouse:LoadWarehouseWorkflow
     load-warehouse-bigquery=edx.analytics.tasks.warehouse.load_warehouse_bigquery:LoadWarehouseBigQueryTask
     load-warehouse-snowflake=edx.analytics.tasks.warehouse.load_warehouse_snowflake:LoadWarehouseSnowflakeTask
     push_to_vertica_lms_courseware_link_clicked = edx.analytics.tasks.warehouse.lms_courseware_link_clicked:PushToVerticaLMSCoursewareLinkClickedTask
     run-vertica-sql-script = edx.analytics.tasks.warehouse.run_vertica_sql_script:RunVerticaSqlScriptTask
     run-vertica-sql-scripts = edx.analytics.tasks.warehouse.run_vertica_sql_scripts:RunVerticaSqlScriptTask
-    test-vertica-sqoop = edx.analytics.tasks.common.vertica_export:VerticaSchemaToBigQueryTask
-    load-ga-permissions = edx.analytics.tasks.warehouse.load_ga_permissions:LoadGoogleAnalyticsPermissionsWorkflow
-    load-vertica-schema-snowflake = edx.analytics.tasks.warehouse.load_vertica_schema_to_snowflake:VerticaSchemaToSnowflakeTask
-    load-google-sheet-warehouse = edx.analytics.tasks.warehouse.load_google_sheet_to_warehouse:LoadGoogleSpreadsheetsToWarehouseWorkflow
 
     # financial:
     cybersource = edx.analytics.tasks.warehouse.financial.cybersource:DailyPullFromCybersourceTask


### PR DESCRIPTION
Reorganize Vertica exports to separate the writing to S3 from the loading into BigQuery and Snowflake.  We will write separate Jenkins jobs to do the export versus the loading, so that the loading into BQ and Snowflake can be done in parallel.
