### PR TITLE
Fix Possible XSS vulnerability in html5lib < 1.0b8

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -6,5 +6,8 @@ nick: pipe
 tags:
   - analytics
   - data-engineering
-oeps: {}
+  - backend-toolings
+oeps:
+    oep-2: True
+    oep-10: True
 openedx-release: {ref: release}

--- a/requirements/default.in
+++ b/requirements/default.in
@@ -14,7 +14,7 @@ google-cloud-bigquery==0.27.0
 google-api-python-client==1.7.7
 graphitesend==0.10.0    # Apache
 gspread==3.1.0    # MIT
-html5lib==1.0b3 	# MIT
+html5lib==1.0.1 	# MIT
 isoweek==1.3.3		# BSD
 numpy==1.11.3 		# BSD
 paypalrestsdk==1.9.0    # Paypal SDK License

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -46,7 +46,7 @@ google-resumable-media==0.4.1  # via google-cloud-bigquery
 googleapis-common-protos==1.6.0  # via google-cloud-core
 graphitesend==0.10.0
 gspread==3.1.0
-html5lib==1.0b3
+html5lib==1.0.1
 httplib2==0.14.0
 idna==2.6                 # via requests, snowflake-connector-python
 ijson==2.5.1              # via snowflake-connector-python

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -48,7 +48,7 @@ google-resumable-media==0.4.1
 googleapis-common-protos==1.6.0
 graphitesend==0.10.0
 gspread==3.1.0
-html5lib==1.0b3
+html5lib==1.0.1
 httplib2==0.14.0
 idna==2.6
 ijson==2.5.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -54,7 +54,7 @@ google-resumable-media==0.4.1
 googleapis-common-protos==1.6.0
 graphitesend==0.10.0
 gspread==3.1.0
-html5lib==1.0b3
+html5lib==1.0.1
 httplib2==0.14.0
 httpretty==0.8.14
 idna==2.6


### PR DESCRIPTION
Fixes Possible XSS vulnerability in html5lib < 1.0b8 
---
[PROD-335](https://openedx.atlassian.net/browse/PROD-335)

Analytics Pipeline Pull Request
---

Make sure that the following steps are done before merging:

  - [x] If you have a migration please contact data engineering team before merging.
  - [ ] Before merging run full acceptance tests suite and provide URL for the acceptance tests run.
  - [x] A member of data engineering team has approved the pull request.
  
