### PR TITLE
Numpy version update

### DIFF
--- a/edx/analytics/tasks/insights/tests/test_module_engagement.py
+++ b/edx/analytics/tasks/insights/tests/test_module_engagement.py
@@ -579,11 +579,11 @@ class ModuleEngagementSummaryMetricRangesDataTaskReducerTest(ReducerTestMixin, T
 
     def test_zeroes_are_normal(self):
         values = [1, 0, 0, 0]
-        self.assert_ranges(values, [('normal', 0.0, 0.55), ('high', 0.55, 'inf')])
+        self.assert_ranges(values, [('normal', 0.0, '0.5499999999999998'), ('high', '0.5499999999999998', 'inf')])
 
     def test_zeroes_are_low(self):
         values = [0, 0, 0] + ([1] * 10) + ([2] * 4)
-        self.assert_ranges(values, [('low', 0, 0.4), ('normal', 0.4, 2.0), ('high', 2.0, 'inf')])
+        self.assert_ranges(values, [('low', 0, '0.3999999999999999'), ('normal', '0.3999999999999999', 2.0), ('high', 2.0, 'inf')])
 
 
 @ddt

--- a/requirements/default.in
+++ b/requirements/default.in
@@ -16,7 +16,7 @@ graphitesend==0.10.0    # Apache
 gspread==3.1.0    # MIT
 html5lib==1.0.1 	# MIT
 isoweek==1.3.3		# BSD
-numpy==1.11.3 		# BSD
+numpy==1.16.5 		# BSD
 paypalrestsdk==1.9.0    # Paypal SDK License
 psycopg2==2.6.2     # LGPL
 pygeoip==0.3.2 		# LGPL

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -56,7 +56,7 @@ jinja2==2.10.3
 jmespath==0.9.4           # via boto3, botocore
 lockfile==0.12.2          # via python-daemon
 markupsafe==1.1.1
-numpy==1.11.3
+numpy==1.16.5
 oscrypto==1.1.0           # via snowflake-connector-python
 paramiko==2.6.0
 paypalrestsdk==1.9.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -59,7 +59,7 @@ jinja2==2.10.3
 jmespath==0.9.4
 lockfile==0.12.2
 markupsafe==1.1.1
-numpy==1.11.3
+numpy==1.16.5
 oscrypto==1.1.0
 paramiko==2.6.0
 paypalrestsdk==1.9.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -73,7 +73,7 @@ mccabe==0.6.1             # via pylint
 mock==2.0.0
 nose-ignore-docstring==0.2
 nose==1.3.7
-numpy==1.11.3
+numpy==1.16.5
 oscrypto==1.1.0
 pandas==0.13.0
 paramiko==2.6.0


### PR DESCRIPTION
**Changes** 
- updated `numpy` version to `1.16.5`.
- Implemented `round` function because of value difference because of `numpy`  version update
- `percentile()` returns 16 digits after decimal in updated numpy version `1.16.5` whereas earlier version `1.11.3` returned 17 digits after the decimal and this cause test to fail.
- Updated tests with new values.



@brianhw : Tagging you here since upgrading the lib needed to change the tests. Can you please look at the changes and suggest what should be the better way to handle the rounding? 