### PR TITLE
user location hotfix

### DIFF
--- a/edx/analytics/tasks/insights/location_per_course.py
+++ b/edx/analytics/tasks/insights/location_per_course.py
@@ -68,6 +68,12 @@ class LastDailyIpAddressOfUserTask(
         if not user_id:
             return
 
+        try:
+            user_id = int(user_id)
+        except ValueError:
+            self.incr_counter('User Location', 'Discard event with malformed user_id', 1)
+            return
+
         # Get timestamp instead of date string, so we get the latest ip
         # address for events on the same day.
         timestamp = eventlog.get_event_time_string(event)


### PR DESCRIPTION
events with user_id(non-int): anonede71904b92643beb3fe caused job failures. Not sure if there is anything else we can do.

The jenkins job is currently running off this branch.