### PR TITLE
ENT-1529 | learner report pricing column is not pulling price from time of enrollment

### DIFF
--- a/edx/analytics/tasks/tests/acceptance/fixtures/input/enterprise/otto/order_line.sql
+++ b/edx/analytics/tasks/tests/acceptance/fixtures/input/enterprise/otto/order_line.sql
@@ -41,7 +41,7 @@ INSERT INTO `order_line` VALUES
   (5,'edX','CF9A708','','','edX Test Course (ID verified)','',1,100.00,100.00,100.00,100.00,100.00,100.00,100.00,100.00,'Complete',NULL,5,1,17,5),
   (6,'edX','D354B6A','','','edX Test Course (ID verified)','',1,100.00,100.00,100.00,100.00,100.00,100.00,100.00,100.00,'Complete',NULL,6,1,17,5),
   (7,'edX','D354B6A','','','edX Test Course (ID verified)','',1,100.00,100.00,100.00,100.00,100.00,100.00,100.00,100.00,'Complete',NULL,7,1,17,5),
-  (8,'edX','CF9A708','','','A demonstration course (ID verified)','',1,300.00,300.00,300.00,300.00,300.00,300.00,300.00,300.00,'Complete',NULL,8,1,2,1),
+  (8,'edX','CF9A708','','','A demonstration course (ID verified)','',1,199.00,199.00,199.00,199.00,199.00,199.00,199.00,199.00,'Complete',NULL,8,1,2,1),
   (9,'edX','CF9A708','','','Seat in edX Demo Verified Course 2 with verified certificate (and ID verification)','',1,200.00,200.00,200.00,200.00,200.00,200.00,200.00,200.00,'Complete',NULL,9,1,5,3),
   (10,'edX','CF9A708','','','edX Test Course (ID verified)','',1,100.00,100.00,100.00,100.00,100.00,100.00,100.00,100.00,'Complete',NULL,10,1,17,5),
   (11,'edX','CF9A708','','','A demonstration course (ID verified)','',1,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,'Complete',NULL,11,1,18,6);

--- a/edx/analytics/tasks/tests/acceptance/test_enterprise_enrollments.py
+++ b/edx/analytics/tasks/tests/acceptance/test_enterprise_enrollments.py
@@ -142,7 +142,7 @@ class EnterpriseEnrollmentAcceptanceTest(AcceptanceTestCase):
              datetime.datetime(2017, 5, 9, 16, 27, 35), 'ginny', 1, 'All about acceptance testing!',
              datetime.datetime(2016, 9, 1, 0, 0), datetime.datetime(2016, 12, 1, 0, 0), 'instructor_paced', '13', 2, 4,
              datetime.datetime(2015, 2, 12, 23, 14, 35), 'test5@example.com', 'test_user5', 'edX+Open_DemoX',
-             'US', None, None, None, 'Percentage, 100 (#6)', 0.85, 300.00, 56.00, None],
+             'US', None, None, None, 'Percentage, 100 (#6)', 0.85, 199.00, 56.00, None],
 
             ['0381d3cb033846d48a5cb1475b589d7f', 'Enterprise 1', 16, 5, 'course-v1:edX+Testing102x+1T2017',
              datetime.datetime(2019, 3, 22, 20, 56, 9), 'verified', 1, '', 0,


### PR DESCRIPTION
Using the order_line table to extract prices of enrollments instead of partner_stockrecord
to support changes, updated a test.
Analytics Pipeline Pull Request

Make sure that the following steps are done before merging:

  - [ ] If you have a migration please contact data engineering team before merging.
  - [ ] Before merging run full acceptance tests suite and provide URL for the acceptance tests run.
  - [ ] A member of data engineering team has approved the pull request.
  
