### PR TITLE
Add metadata to Sqoop warehouse dumps

### DIFF
--- a/edx/analytics/tasks/common/sqoop.py
+++ b/edx/analytics/tasks/common/sqoop.py
@@ -113,6 +113,7 @@ class SqoopImportTask(OverwriteOutputMixin, SqoopImportMixin, luigi.contrib.hado
     )
     additional_metadata = luigi.DictParameter(
         default=None,
+        significant=False,
         description='Override this to provide the metadata file with additional information about the Sqoop output.',
     )
 

--- a/edx/analytics/tasks/common/vertica_export.py
+++ b/edx/analytics/tasks/common/vertica_export.py
@@ -156,21 +156,18 @@ class VerticaExportMixin(WarehouseMixin):
         """Define root URL under which data should be written to or read from in S3."""
         return url_path_join(self.warehouse_path, 'import/vertica/sqoop/')
 
-    @property
-    def s3_location_for_schema(self):
-        """
-        Returns the URL for the location of S3 data for the given schema.
-        """
-        partition_path_spec = HivePartition('dt', self.date).path_spec
-        url = url_path_join(self.intermediate_warehouse_path,
-                            self.vertica_warehouse_name,
-                            self.vertica_schema_name,
-                            'dump_schema_metadata_output',
-                            partition_path_spec) + '/'
-        return url
-
     def get_schema_metadata_target(self):
-        return get_target_from_url(url_path_join(self.s3_location_for_schema, '_metadata'))
+        """Return target for reading or writing out schema-level metadata file."""
+        partition_path_spec = HivePartition('dt', self.date).path_spec
+        url = url_path_join(
+            self.intermediate_warehouse_path,
+            self.vertica_warehouse_name,
+            self.vertica_schema_name,
+            'dump_schema_metadata_output',
+            partition_path_spec,
+            '_metadata'
+        )
+        return get_target_from_url(url)
 
 
 class VerticaTableExportMixin(VerticaExportMixin):

--- a/edx/analytics/tasks/common/vertica_export.py
+++ b/edx/analytics/tasks/common/vertica_export.py
@@ -275,6 +275,15 @@ class ExportVerticaTableToS3Task(VerticaTableExportMixin, VerticaTableToS3Mixin,
                 raise RuntimeError('Error Sqoop copy of {schema}.{table} found no viable columns!'.
                                    format(schema=self.schema_name, table=self.table))
 
+            additional_metadata = {
+                'table_schema': self.vertica_table_schema,
+                'timezone_adjusted_column_list': timestamptz_column_list,
+                'database': self.vertica_warehouse_name,
+                'schema_name': self.vertica_schema_name,
+                'table_name': self.table_name,
+                'date': self.date.isoformat(),
+            }
+
             self._sqoop_dump_vertica_table_task = SqoopImportFromVertica(
                 schema_name=self.vertica_schema_name,
                 table_name=self.table_name,
@@ -287,6 +296,7 @@ class ExportVerticaTableToS3Task(VerticaTableExportMixin, VerticaTableToS3Mixin,
                 delimiter_replacement=self.sqoop_delimiter_replacement,
                 columns=column_list,
                 timezone_adjusted_column_list=timestamptz_column_list,
+                additional_metadata=additional_metadata,
             )
         return self._sqoop_dump_vertica_table_task
 

--- a/edx/analytics/tasks/common/vertica_export.py
+++ b/edx/analytics/tasks/common/vertica_export.py
@@ -163,7 +163,7 @@ class VerticaExportMixin(WarehouseMixin):
             self.intermediate_warehouse_path,
             self.vertica_warehouse_name,
             self.vertica_schema_name,
-            'dump_schema_metadata_output',
+            '_metadata_export_schema',
             partition_path_spec,
             '_metadata'
         )

--- a/edx/analytics/tasks/common/vertica_export.py
+++ b/edx/analytics/tasks/common/vertica_export.py
@@ -373,9 +373,7 @@ class ExportVerticaSchemaToS3WithMetadataTask(VerticaSchemaExportMixin, VerticaT
     @property
     def s3_location_for_schema(self):
         """
-        Returns the URL for the location of S3 data for the given table and schema.
-
-        This logic is shared by classes that dump data to S3 and those that load data from S3, so they agree.
+        Returns the URL for the location of S3 data for the given schema.
         """
         partition_path_spec = HivePartition('dt', self.date).path_spec
         url = url_path_join(self.intermediate_warehouse_path,

--- a/edx/analytics/tasks/warehouse/load_internal_reporting_database.py
+++ b/edx/analytics/tasks/warehouse/load_internal_reporting_database.py
@@ -28,7 +28,7 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 # define pseudo-table-name to use for storing database-level metadata output.
-DUMP_METADATA_OUTPUT = 'dump_metadata_output'
+DUMP_METADATA_OUTPUT = '_metadata_export_database'
 
 
 class MysqlToWarehouseTaskMixin(WarehouseMixin):

--- a/edx/analytics/tasks/warehouse/load_internal_reporting_database.py
+++ b/edx/analytics/tasks/warehouse/load_internal_reporting_database.py
@@ -13,7 +13,7 @@ from edx.analytics.tasks.common.mysql_load import get_mysql_query_results
 from edx.analytics.tasks.common.snowflake_load import (
     SnowflakeLoadDownstreamMixin, SnowflakeLoadFromHiveTSVTask, SnowflakeTarget
 )
-from edx.analytics.tasks.common.sqoop import SqoopImportFromMysql
+from edx.analytics.tasks.common.sqoop import METADATA_FILENAME, SqoopImportFromMysql
 from edx.analytics.tasks.common.vertica_load import SchemaManagementTask, VerticaCopyTask
 from edx.analytics.tasks.util.hive import HivePartition, WarehouseMixin
 from edx.analytics.tasks.util.url import ExternalURL, get_target_from_url, url_path_join
@@ -26,6 +26,9 @@ except ImportError:
 
 
 log = logging.getLogger(__name__)
+
+# define pseudo-table-name to use for storing database-level metadata output.
+DUMP_METADATA_OUTPUT = 'dump_metadata_output'
 
 
 class MysqlToWarehouseTaskMixin(WarehouseMixin):
@@ -419,9 +422,9 @@ class ImportMysqlToVerticaTask(MysqlToVerticaTaskMixin, luigi.WrapperTask):
             self.warehouse_path,
             self.warehouse_subdirectory,
             self.database,
-            'dump_schema_metadata_output',
+            DUMP_METADATA_OUTPUT,
             partition_path_spec,
-            '_metadata',
+            METADATA_FILENAME,
         )
         metadata_target = get_target_from_url(metadata_destination)
         with metadata_target.open('w') as metadata_file:
@@ -870,6 +873,183 @@ class ImportMysqlDatabaseToSnowflakeSchemaTask(MysqlToSnowflakeTaskMixin, Snowfl
                         date=self.date,
                         credentials=self.credentials,
                         exclude_field=self.exclude_field,
+                    )
+                )
+        return self.required_tasks
+
+    def complete(self):
+        """
+        Reduces the result of the required tasks into a single complete/not-complete.
+        """
+        # OverwriteOutputMixin changes the complete() method behavior, so we override it.
+        return all(r.complete() for r in luigi.task.flatten(self.requires()))
+
+
+class LoadMysqlTableFromS3ToSnowflakeTask(MysqlToSnowflakeTaskMixin, SnowflakeLoadFromHiveTSVTask):
+    """
+    Task to import a table from S3 but originally from MySQL into Snowflake.
+    """
+    table_name = luigi.Parameter(
+        description='The name of the table to be loaded.',
+    )
+    # Some fields are no longer needed when reading from S3.
+    exclude_field = None
+    db_credentials = None
+
+    def __init__(self, *args, **kwargs):
+        """
+        Init this task.
+        """
+        super(LoadMysqlTableFromS3ToSnowflakeTask, self).__init__(*args, **kwargs)
+        metadata_target = self._get_metadata_target()
+        with metadata_target.open('r') as metadata_file:
+            self.metadata = json.load(metadata_file)
+
+    def _get_metadata_target(self):
+        """Returns target for metadata file from the given dump."""
+        # find the .metadata file in the source directory.
+        metadata_path = url_path_join(self.s3_location_for_table, METADATA_FILENAME)
+        return get_target_from_url(metadata_path)
+
+    @property
+    def mysql_table_schema(self):
+        # Override the default property.
+        return self.metadata['additional_metadata']['table_schema']
+
+    def get_snowflake_schema(self):
+        """
+        Transforms MySQL table schema into a Snowflake-compliant schema.
+        """
+        results = []
+        for field_name, field_type, field_null in self.mysql_table_schema:
+
+            # Enclose any Snowflake-reserved keyword field names within double-quotes.
+            if field_name.upper() in SNOWFLAKE_RESERVED_KEYWORDS:
+                field_name = '"{}"'.format(field_name.upper())
+
+            mysql_types_with_parentheses = ['smallint', 'int', 'bigint', 'datetime', 'varchar']
+            if field_type == 'tinyint(1)':
+                field_type = 'BOOLEAN'
+            elif any(_type in field_type for _type in mysql_types_with_parentheses):
+                field_type = field_type.rsplit('(')[0]
+            elif field_type == 'longtext':
+                field_type = 'VARCHAR'
+            elif field_type == 'longblob':
+                field_type = 'BINARY'
+
+            if field_null == 'NO':
+                field_type += ' NOT NULL'
+
+            results.append((field_name, field_type))
+
+        return results
+
+    @property
+    def s3_location_for_table(self):
+        partition_path_spec = HivePartition('dt', self.date.isoformat()).path_spec
+        destination = url_path_join(
+            self.warehouse_path,
+            self.warehouse_subdirectory,
+            self.database,
+            self.table_name,
+            partition_path_spec
+        ) + '/'
+        return destination
+
+    @property
+    def insert_source_task(self):
+        """
+        Insert the Sqoop task that imports the source MySQL data into S3.
+        """
+        return ExternalURL(url=self.s3_location_for_table)
+
+    @property
+    def table(self):
+        return self.table_name
+
+    @property
+    def table_schema(self):
+        return self.get_snowflake_schema()
+
+    @property
+    def columns(self):
+        return self.table_schema
+
+    @property
+    def file_format_name(self):
+        return 'SQOOP_MYSQL_FORMAT'
+
+    @property
+    def pattern(self):
+        return '.*part-m.*'
+
+    @property
+    def table_description(self):
+        optional = ''
+        deleted_fields = self.metadata['additional_metadata']['deleted_fields']
+        if deleted_fields:
+            optional = '  Fields not included in the copy: {}'.format(', '.join(deleted_fields))
+        return "Copy of '{}' table from '{}' MySQL database on {}.{}".format(self.table_name, self.database, self.date.isoformat(), optional)
+
+
+class ImportMysqlDatabaseFromS3ToSnowflakeSchemaTask(MysqlToSnowflakeTaskMixin, SnowflakeLoadDownstreamMixin, luigi.WrapperTask):
+    """
+    Provides entry point for importing a MySQL database into Snowflake as a single schema.
+
+    Assumes that only one database is written to each schema.
+    """
+    # Some fields are no longer needed when reading from S3.
+    exclude_field = None
+    db_credentials = None
+
+    def __init__(self, *args, **kwargs):
+        """
+        Inits this Luigi task.
+        """
+        super(ImportMysqlDatabaseFromS3ToSnowflakeSchemaTask, self).__init__(*args, **kwargs)
+        metadata_target = self.get_schema_metadata_target()
+        with metadata_target.open('r') as metadata_file:
+            self.metadata = json.load(metadata_file)
+
+        self.required_tasks = None
+
+    def get_table_list_for_database(self):
+        return self.metadata['table_list']
+
+    def get_schema_metadata_target(self):
+        partition_path_spec = HivePartition('dt', self.date.isoformat()).path_spec
+        metadata_location = url_path_join(
+            self.warehouse_path,
+            self.warehouse_subdirectory,
+            self.database,
+            DUMP_METADATA_OUTPUT,
+            partition_path_spec,
+            METADATA_FILENAME,
+        )
+        return get_target_from_url(metadata_location)
+
+    def requires(self):
+        """
+        Determines the required tasks given the list of tables exported from MySQL.
+        """
+        if self.required_tasks is None:
+            self.required_tasks = []
+            for table_name in self.get_table_list_for_database():
+                self.required_tasks.append(
+                    LoadMysqlTableFromS3ToSnowflakeTask(
+                        sf_database=self.sf_database,
+                        schema=self.schema,
+                        scratch_schema=self.scratch_schema,
+                        run_id=self.run_id,
+                        warehouse=self.warehouse,
+                        role=self.role,
+                        warehouse_path=self.warehouse_path,
+                        warehouse_subdirectory=self.warehouse_subdirectory,
+                        database=self.database,
+                        table_name=table_name,
+                        overwrite=self.overwrite,
+                        date=self.date,
+                        credentials=self.credentials,
                     )
                 )
         return self.required_tasks

--- a/edx/analytics/tasks/warehouse/load_vertica_schema_to_snowflake.py
+++ b/edx/analytics/tasks/warehouse/load_vertica_schema_to_snowflake.py
@@ -9,12 +9,12 @@ import re
 
 import luigi
 
-from edx.analytics.tasks.util.hive import HivePartition
 from edx.analytics.tasks.common.snowflake_load import SnowflakeLoadDownstreamMixin, SnowflakeLoadFromHiveTSVTask
 from edx.analytics.tasks.common.sqoop import METADATA_FILENAME
 from edx.analytics.tasks.common.vertica_export import (
-    VerticaSchemaExportMixin, VerticaTableExportMixin, VerticaTableFromS3Mixin, VerticaExportMixin
+    VerticaExportMixin, VerticaSchemaExportMixin, VerticaTableExportMixin, VerticaTableFromS3Mixin
 )
+from edx.analytics.tasks.util.hive import HivePartition
 from edx.analytics.tasks.util.url import ExternalURL, get_target_from_url, url_path_join
 
 log = logging.getLogger(__name__)
@@ -213,6 +213,13 @@ class LoadVerticaTableFromS3WithMetadataToSnowflakeTask(VerticaTableExportMixin,
     @property
     def field_delimiter(self):
         return self.metadata['format']['fields_terminated_by']
+
+    @property
+    def table_description(self):
+        optional = ''
+        return "Copy of '{}' table from '{}' schema of Vertica database on {}.{}".format(
+            self.table_name, self.vertica_schema_name, self.date.isoformat(), optional
+        )
 
 
 class LoadVerticaSchemaFromS3WithMetadataToSnowflakeTask(VerticaExportMixin, SnowflakeLoadDownstreamMixin, luigi.WrapperTask):

--- a/edx/analytics/tasks/warehouse/load_vertica_schema_to_snowflake.py
+++ b/edx/analytics/tasks/warehouse/load_vertica_schema_to_snowflake.py
@@ -2,16 +2,18 @@
 Tasks to load a Vertica schema from S3 into Snowflake.
 """
 
+import json
 import logging
 import re
 
 import luigi
 
 from edx.analytics.tasks.common.snowflake_load import SnowflakeLoadDownstreamMixin, SnowflakeLoadFromHiveTSVTask
+from edx.analytics.tasks.common.sqoop import METADATA_FILENAME
 from edx.analytics.tasks.common.vertica_export import (
     VerticaSchemaExportMixin, VerticaTableExportMixin, VerticaTableFromS3Mixin
 )
-from edx.analytics.tasks.util.url import ExternalURL
+from edx.analytics.tasks.util.url import ExternalURL, get_target_from_url, url_path_join
 
 log = logging.getLogger(__name__)
 
@@ -114,6 +116,141 @@ class LoadVerticaSchemaFromS3ToSnowflakeTask(VerticaSchemaExportMixin, VerticaTa
                 vertica_credentials=self.vertica_credentials,
                 sqoop_null_string=self.sqoop_null_string,
                 sqoop_fields_terminated_by=self.sqoop_fields_terminated_by,
+            )
+
+    def complete(self):
+        # OverwriteOutputMixin changes the complete() method behavior, so we override it.
+        return all(r.complete() for r in luigi.task.flatten(self.requires()))
+
+
+# class LoadVerticaTableFromS3WithMetadataToSnowflakeTask(VerticaTableExportMixin, VerticaTableFromS3Mixin, SnowflakeLoadFromHiveTSVTask):
+# We don't need VerticaTableFromS3Mixin, because we will get the information from the metadata file.
+class LoadVerticaTableFromS3WithMetadataToSnowflakeTask(VerticaTableExportMixin, SnowflakeLoadFromHiveTSVTask):
+    """
+    Task to load a Vertica table from S3 into Snowflake, but using a metadata file instead of Vertica.
+    """
+    # Make sure we don't use this at the table level:
+    vertica_credentials = None
+
+    def __init__(self, *args, **kwargs):
+        super(LoadVerticaTableFromS3WithMetadataToSnowflakeTask, self).__init__(*args, **kwargs)
+        metadata_target = self._get_metadata_target()
+        with metadata_target.open('r') as metadata_file:
+            self.metadata = json.load(metadata_file)
+
+    def _get_metadata_target(self):
+        """Returns target for metadata file from the given dump."""
+        # find the .metadata file in the source directory.
+        metadata_path = url_path_join(self.s3_location_for_table, METADATA_FILENAME)
+        return get_target_from_url(metadata_path)
+
+    @property
+    def vertica_table_schema(self):
+        # Override the default property.
+        return self.metadata['additional_metadata']['table_schema']
+
+    def snowflake_compliant_schema(self):
+        """
+        Returns the Snowflake schema in the format (column name, column type) for the indicated table.
+
+        Information about "nullable" or required fields is not included.
+        """
+        results = []
+        for column_name, field_type, _ in self.vertica_table_schema:
+            if column_name == 'start' or " " in column_name:
+                column_name = '"{}"'.format(column_name)
+
+            if field_type.startswith('long '):
+                field_type = field_type.lstrip('long ')
+            elif 'numeric(' in field_type:
+                # Snowflake only handles numeric precision up to 38. This regex should find either 1 or 2 numbers
+                # ex: numeric(52) or numeric(58, 4). First number is precision, second is scale.
+                precision_and_scale = re.findall(r'[0-9]+', field_type)
+                if int(precision_and_scale[0]) > 38:
+                    # If it has scale, try to preserve that
+                    if len(precision_and_scale) == 2:
+                        field_type = 'numeric(38,{})'.format(precision_and_scale[1])
+                    else:
+                        field_type = 'numeric(38)'
+            elif field_type == 'uuid':
+                # Snowflake has no uuid type, but Vertica's is just a 36 character string
+                field_type = 'varchar(36)'
+
+            results.append((column_name, field_type))
+
+        return results
+
+    @property
+    def insert_source_task(self):
+        """
+        This assumes we have already exported vertica tables to S3 using SqoopImportFromVertica through VerticaSchemaToS3Task
+        workflow, so we specify ExternalURL here.
+        """
+        return ExternalURL(url=self.s3_location_for_table)
+
+    @property
+    def table(self):
+        return self.table_name
+
+    @property
+    def file_format_name(self):
+        # We could check for "source_database_type", and automatically set the format based on that.
+        # self.metadata['source_database_type'] == 'vertica'
+        return 'vertica_sqoop_export_format'
+
+    @property
+    def columns(self):
+        return self.snowflake_compliant_schema()
+
+    @property
+    def null_marker(self):
+        # return self.sqoop_null_string
+        return self.metadata['format']['null_string']
+
+    @property
+    def pattern(self):
+        return '.*part-m.*'
+
+    @property
+    def field_delimiter(self):
+        # return self.sqoop_fields_terminated_by
+        return self.metadata['format']['fields_terminated_by']
+
+
+class LoadVerticaSchemaFromS3WithMetadataToSnowflakeTask(VerticaSchemaExportMixin, VerticaTableFromS3Mixin, SnowflakeLoadDownstreamMixin, luigi.WrapperTask):
+    """
+    A task that loads into Snowflake all the tables in S3 dumped from a Vertica schema.
+
+    Reads all tables in a schema and, if they are not listed in the `exclude` parameter, schedules a
+    LoadVerticaTableFromS3ToSnowflake task for each table.
+    """
+
+    def requires(self):
+        # Should no longer need this....
+        yield ExternalURL(url=self.vertica_credentials)
+
+        # TODO: instead of getting the table list from Vertica, get it instead from S3 (somehow).
+        # unfortunately it's output is not organized by date and then table, but rather by table and then date.
+        # So it would take some digging.  Or another metadata file representing the schema-level dump.
+        # In which case, the complete method of the to-S3 schema dump would be the table list.
+        for table_name in self.get_table_list_for_schema():
+            yield LoadVerticaTableFromS3WithMetadataToSnowflakeTask(
+                date=self.date,
+                overwrite=self.overwrite,
+                intermediate_warehouse_path=self.intermediate_warehouse_path,
+                credentials=self.credentials,
+                warehouse=self.warehouse,
+                role=self.role,
+                sf_database=self.sf_database,
+                schema=self.schema,
+                scratch_schema=self.scratch_schema,
+                run_id=self.run_id,
+                table_name=table_name,
+                vertica_schema_name=self.vertica_schema_name,
+                vertica_warehouse_name=self.vertica_warehouse_name,
+                # vertica_credentials=self.vertica_credentials,
+                # sqoop_null_string=self.sqoop_null_string,
+                # sqoop_fields_terminated_by=self.sqoop_fields_terminated_by,
             )
 
     def complete(self):


### PR DESCRIPTION
When dumping Vertica schemas to S3 using Sqoop, write out metadata about each table along with the data dump, by expanding the _metadata file.   Relevant information added includes the table schema information, so that the data on S3 can be read in elsewhere.  A metadata file is also written out for the schema dump itself, so there exists a place that lists the tables that were dumped.  Note that this is additional information -- it should not affect any existing formats or existing loaders. 

Second part of this is to modify the code that reads data from S3 to Snowflake.  Instead of querying Vertica again (and possibly getting incompatible information), the loading into Snowflake can use the metadata files generated above so that it no longer accesses Vertica, finally decoupling the dump to S3 from the subsequent load.  These are currently separate Task classes, so the existing loaders are unchanged.   If we want to switch all loaders, then we can either rename the tasks or update the Jenkins jobs, and remove the old code.

Third part is to add metadata to Mysql dumps to Vertica.   This will provide metadata at database level (i.e. list of tables) to enable copying of dumps from one location in S3 to another.  However, It does not include any code for loading from S3 into Snowflake using the metadata.  