### PR TITLE
Spike:  copy S3 database/schema data to another location in S3

### DIFF
--- a/edx/analytics/tasks/common/vertica_export.py
+++ b/edx/analytics/tasks/common/vertica_export.py
@@ -371,7 +371,7 @@ class ExportVerticaSchemaToS3Task(VerticaSchemaExportMixin, VerticaTableToS3Mixi
             json.dump(metadata, metadata_file)
 
 
-class CopyVerticaDatabaseFromS3ToS3Task(VerticaExportMixin, luigi.Task):
+class CopyVerticaSchemaFromS3ToS3Task(VerticaExportMixin, luigi.Task):
     """
     Provides entry point for copying a MySQL database destined for Snowflake from one location in S3 to another.
     """
@@ -386,7 +386,7 @@ class CopyVerticaDatabaseFromS3ToS3Task(VerticaExportMixin, luigi.Task):
         """
         Inits this Luigi task.
         """
-        super(CopyVerticaDatabaseFromS3ToS3Task, self).__init__(*args, **kwargs)
+        super(CopyVerticaSchemaFromS3ToS3Task, self).__init__(*args, **kwargs)
         self.metadata = None
 
     @property
@@ -397,7 +397,7 @@ class CopyVerticaDatabaseFromS3ToS3Task(VerticaExportMixin, luigi.Task):
                 self.metadata = json.load(metadata_file)
         return self.metadata
 
-    def get_table_list_for_database(self):
+    def get_table_list_for_schema(self):
         return self.schema_metadata['table_list']
 
     def requires(self):
@@ -459,7 +459,7 @@ class CopyVerticaDatabaseFromS3ToS3Task(VerticaExportMixin, luigi.Task):
         if self.new_warehouse_path == self.warehouse_path:
             raise Exception("Must set new_warehouse_path {} to be different than warehouse_path {}".format(new_warehouse_path, self.warehouse_path))
 
-        for table_name in self.get_table_list_for_database():
+        for table_name in self.get_table_list_for_schema():
             self.copy_table(table_name)
 
         self.copy_metadata_file()

--- a/edx/analytics/tasks/warehouse/load_internal_reporting_database.py
+++ b/edx/analytics/tasks/warehouse/load_internal_reporting_database.py
@@ -1088,9 +1088,7 @@ class CopyMysqlDatabaseFromS3ToS3Task(WarehouseMixin, luigi.Task):
         """
         super(CopyMysqlDatabaseFromS3ToS3Task, self).__init__(*args, **kwargs)
         self.metadata = None
-        self.s3_client = ScalableS3Client(
-            signatureVersion='v4',
-        )
+        self.s3_client = ScalableS3Client()
 
     @property
     def database_metadata(self):
@@ -1156,7 +1154,7 @@ class CopyMysqlDatabaseFromS3ToS3Task(WarehouseMixin, luigi.Task):
         # of False will be significantly more efficient."
         # kwargs['preserve_acl'] = True;
         
-        self.s3_client.copy(source_path, destination_path, **kwargs)
+        self.s3_client.copy(source_path, destination_path, part_size=3000000000, **kwargs)
 
     def copy_metadata_file(self):
         self.copy_table(DUMP_METADATA_OUTPUT)

--- a/edx/analytics/tasks/warehouse/load_internal_reporting_database.py
+++ b/edx/analytics/tasks/warehouse/load_internal_reporting_database.py
@@ -1064,7 +1064,7 @@ class ImportMysqlDatabaseFromS3ToSnowflakeSchemaTask(MysqlToSnowflakeTaskMixin, 
         return all(r.complete() for r in luigi.task.flatten(self.requires()))
 
 
-class CopyMysqlDatabaseFromS3ToS3Task(WarehouseMixin, luigi.WrapperTask):
+class CopyMysqlDatabaseFromS3ToS3Task(WarehouseMixin, luigi.Task):
     """
     Provides entry point for copying a MySQL database destined for Snowflake from one location in S3 to another.
     """
@@ -1112,6 +1112,9 @@ class CopyMysqlDatabaseFromS3ToS3Task(WarehouseMixin, luigi.WrapperTask):
 
     def get_table_list_for_database(self):
         return self.database_metadata['table_list']
+
+    def requires(self):
+        return ExternalURL(self.get_schema_metadata_target().path)
 
     def output(self):
         partition_path_spec = HivePartition('dt', self.date.isoformat()).path_spec

--- a/edx/analytics/tasks/warehouse/load_internal_reporting_database.py
+++ b/edx/analytics/tasks/warehouse/load_internal_reporting_database.py
@@ -1088,7 +1088,9 @@ class CopyMysqlDatabaseFromS3ToS3Task(WarehouseMixin, luigi.Task):
         """
         super(CopyMysqlDatabaseFromS3ToS3Task, self).__init__(*args, **kwargs)
         self.metadata = None
-        self.s3_client = ScalableS3Client()
+        self.s3_client = ScalableS3Client(
+            signatureVersion='v4',
+        )
 
     @property
     def database_metadata(self):
@@ -1153,6 +1155,7 @@ class CopyMysqlDatabaseFromS3ToS3Task(WarehouseMixin, luigi.Task):
         # on the new object. If you don't care about the ACL, a value
         # of False will be significantly more efficient."
         # kwargs['preserve_acl'] = True;
+        
         self.s3_client.copy(source_path, destination_path, **kwargs)
 
     def copy_metadata_file(self):

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -99,3 +99,7 @@ yarn-api-client==0.2.3
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools==41.4.0        # via google-cloud-core, protobuf, python-daemon
+
+# Add this here for the copy S3 task as a standalone hack.
+# But pick a version that matches the boto requirements above...
+awscli==1.14.46


### PR DESCRIPTION
Support copying Mysql database data on S3 from one location to another.   Do the same for Vertica schema.  Main purpose is to move S3 data to be used as a "reference" to a separate location in S3 from that used for daily production runs.  

This is mostly for demonstration at this point, since it requires installing awscli on the cluster.
