### PR TITLE
change user activity hive table used by load snowflake task

### DIFF
--- a/edx/analytics/tasks/common/bigquery_load.py
+++ b/edx/analytics/tasks/common/bigquery_load.py
@@ -279,8 +279,8 @@ class BigQueryLoadTask(BigQueryLoadDownstreamMixin, luigi.Task):
             # Exclude any files which should not be uploaded to
             # BigQuery.  It is easier to remove them here than in the
             # load steps.  The pattern is a Python regular expression.
-            exclusion_pattern = ".*_SUCCESS$|.*_metadata$"
-            command = ['gsutil', '-m', 'rsync', '-x', exclusion_pattern, source_path, destination_path]
+            exclusion_pattern = ".*_SUCCESS$|.*_metadata$|.*\$folder\$"
+            command = ['gsutil', '-m', 'rsync', '-r', '-x', exclusion_pattern, source_path, destination_path]
 
         log.debug(" ".join(command))
         return_code = subprocess.call(command)

--- a/edx/analytics/tasks/warehouse/load_warehouse_bigquery.py
+++ b/edx/analytics/tasks/warehouse/load_warehouse_bigquery.py
@@ -200,25 +200,11 @@ class LoadInternalReportingUserActivityToBigQuery(WarehouseMixin, BigQueryLoadTa
     def __init__(self, *args, **kwargs):
         super(LoadInternalReportingUserActivityToBigQuery, self).__init__(*args, **kwargs)
 
-        # Find the most recent data for the source.
-        path = url_path_join(self.warehouse_path, 'internal_reporting_user_activity')
-        path_targets = PathSetTask([path]).output()
-        paths = list(set([os.path.dirname(target.path) for target in path_targets]))
-        dates = [path.rsplit('/', 2)[-1] for path in paths]
-        latest_date = sorted(dates)[-1]
-
-        self.load_date = datetime.datetime.strptime(latest_date, "dt=%Y-%m-%d").date()
-
-    @property
-    def partition(self):
-        """The table is partitioned by date."""
-        return HivePartition('dt', self.load_date.isoformat())  # pylint: disable=no-member
-
     @property
     def insert_source_task(self):
-        hive_table = "internal_reporting_user_activity"
-        partition_location = url_path_join(self.warehouse_path, hive_table, self.partition.path_spec) + '/'
-        return ExternalURL(url=partition_location)
+        hive_table = "user_activity_by_user"
+        url = url_path_join(self.warehouse_path, hive_table) + '/dt=*/'
+        return ExternalURL(url=url)
 
     @property
     def table(self):

--- a/edx/analytics/tasks/warehouse/load_warehouse_bigquery.py
+++ b/edx/analytics/tasks/warehouse/load_warehouse_bigquery.py
@@ -197,13 +197,10 @@ class LoadUserCourseSummaryToBigQuery(WarehouseMixin, BigQueryLoadTask):
 
 class LoadInternalReportingUserActivityToBigQuery(WarehouseMixin, BigQueryLoadTask):
 
-    def __init__(self, *args, **kwargs):
-        super(LoadInternalReportingUserActivityToBigQuery, self).__init__(*args, **kwargs)
-
     @property
     def insert_source_task(self):
         hive_table = "user_activity_by_user"
-        url = url_path_join(self.warehouse_path, hive_table) + '/dt=*/'
+        url = url_path_join(self.warehouse_path, hive_table)
         return ExternalURL(url=url)
 
     @property

--- a/edx/analytics/tasks/warehouse/load_warehouse_snowflake.py
+++ b/edx/analytics/tasks/warehouse/load_warehouse_snowflake.py
@@ -231,9 +231,6 @@ class LoadUserCourseSummaryToSnowflake(WarehouseMixin, SnowflakeLoadFromHiveTSVT
 
 class LoadInternalReportingUserActivityToSnowflake(WarehouseMixin, SnowflakeLoadFromHiveTSVTask):
 
-    def __init__(self, *args, **kwargs):
-        super(LoadInternalReportingUserActivityToSnowflake, self).__init__(*args, **kwargs)
-
     @property
     def insert_source_task(self):
         hive_table = "user_activity_by_user"

--- a/edx/analytics/tasks/warehouse/load_warehouse_snowflake.py
+++ b/edx/analytics/tasks/warehouse/load_warehouse_snowflake.py
@@ -234,25 +234,15 @@ class LoadInternalReportingUserActivityToSnowflake(WarehouseMixin, SnowflakeLoad
     def __init__(self, *args, **kwargs):
         super(LoadInternalReportingUserActivityToSnowflake, self).__init__(*args, **kwargs)
 
-        # Find the most recent data for the source.
-        path = url_path_join(self.warehouse_path, 'internal_reporting_user_activity')
-        path_targets = PathSetTask([path]).output()
-        paths = list(set([os.path.dirname(target.path) for target in path_targets]))
-        dates = [path.rsplit('/', 2)[-1] for path in paths]
-        latest_date = sorted(dates)[-1]
-
-        self.load_date = datetime.datetime.strptime(latest_date, "dt=%Y-%m-%d").date()
-
-    @property
-    def partition(self):
-        """The table is partitioned by date."""
-        return HivePartition('dt', self.load_date.isoformat())  # pylint: disable=no-member
-
     @property
     def insert_source_task(self):
-        hive_table = "internal_reporting_user_activity"
-        partition_location = url_path_join(self.warehouse_path, hive_table, self.partition.path_spec) + '/'
-        return ExternalURL(url=partition_location)
+        hive_table = "user_activity_by_user"
+        url = url_path_join(self.warehouse_path, hive_table)
+        return ExternalURL(url=url)
+
+    @property
+    def pattern(self):
+        return '.*dt=.*/.*'
 
     @property
     def table(self):


### PR DESCRIPTION
There is a huge mismatch in the number of rows in `f_user_activity` between Vertica and Snowflake. This is because they are A) using different intermediate hive tables to pull data from and B) the Snowflake load job is only pulling in the most recent day's entry (which has stopped updating) whereas the Vertica job just pulls in all entries.

I am changing the load snowflake and bigquery jobs from loading the most recent date from `internal_reporting_user_activity` to all time from the `user_activity_by_user` hive table. Also changing the pipeline to copy in all data, rather than the most recent day.

It seems that wildcards are not supported in the `CREATE STAGE` command in Snowflake. Therefore, I needed to move the wildcard handling to the `COPY INTO` command by passing in a custom pattern.

I have tested this in Snowflake by setting up a personal schema/DB and running the load-snowflake job. Now both Vertica and Snowflake have roughly 270 million rows in the `f_user_activity` table (they are slightly off, probably due to the time of day that I ran the job).