### PR TITLE
Add last activity date to program learner report

### DIFF
--- a/edx/analytics/tasks/programs/program_reports.py
+++ b/edx/analytics/tasks/programs/program_reports.py
@@ -132,6 +132,7 @@ class BuildLearnerProgramReport(OverwriteOutputMixin, ProgramsReportTaskMixin, R
             'Track',
             'Grade',
             'Letter Grade',
+            'Last Activity Date'
             'Date First Enrolled',
             'Date Last Unenrolled',
             'Currently Enrolled',


### PR DESCRIPTION
https://openedx.atlassian.net/browse/MST-85

Add last activity date to program learner  report.
Work-in-progress.

Related: https://github.com/edx/edx-analytics-pipeline-scripts/pull/545