### PR TITLE
Respect the warehouse command line parameter when it is passed in to snowflake tasks

### DIFF
--- a/edx/analytics/tasks/common/snowflake_load.py
+++ b/edx/analytics/tasks/common/snowflake_load.py
@@ -81,7 +81,9 @@ class SnowflakeTarget(luigi.Target):
             user=self.user,
             account=self.account,
             private_key=pkb,
-            autocommit=autocommit)
+            autocommit=autocommit,
+            warehouse=self.warehouse
+        )
 
         # Switch to specified role.
         connection.cursor().execute("USE ROLE {}".format(self.role))


### PR DESCRIPTION
Warehouse names passed in via the command line (via jenkins jobs and analytics-secure) were not being respected/used in the connection string for snowflake luigi tasks. This PR rectifies this.

Analytics Pipeline Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] If you have a migration please contact data engineering team before merging.
  - [ ] Before merging run full acceptance tests suite and provide URL for the acceptance tests run.
  - [ ] A member of data engineering team has approved the pull request.
  
