### PR TITLE
Add 502 and 520 to the edxapp api client retry codes

### DIFF
--- a/edx/analytics/tasks/util/edx_api_client.py
+++ b/edx/analytics/tasks/util/edx_api_client.py
@@ -15,7 +15,9 @@ DEFAULT_RETRY_STATUS_CODES = (
     requests.codes.request_timeout,         # HTTP Status Code 408
     requests.codes.too_many_requests,       # HTTP Status Code 429
     requests.codes.service_unavailable,     # HTTP Status Code 503
-    requests.codes.gateway_timeout          # HTTP Status Code 504
+    requests.codes.gateway_timeout,         # HTTP Status Code 504
+    requests.codes.bad_gateway,             # HTTP Status Code 502
+    520,                                    # This is a custom Cloudwatch code for "Unknown error".
 )
 DEFAULT_TIMEOUT_SECONDS = 7200
 


### PR DESCRIPTION
This seems to mitigate an issue we're having with the load-course-structure jenkins job where it gives up early due to a 502 response that never got retried: http://jenkins.analytics.edx.org/job/load-course-structure/108

Here's a successful run which took 28 hours instead of typical 20 hours: http://jenkins.analytics.edx.org/job/load-course-structure/109

We've seen _both_ 502 and 520, hence adding retries on both in this PR.

Related to OpsGenie alerts `#6440` and `#6242`
