### PR TITLE
Add extraction of course_id from a block-based URL.

### DIFF
--- a/edx/analytics/tasks/util/tests/test_eventlog.py
+++ b/edx/analytics/tasks/util/tests/test_eventlog.py
@@ -185,6 +185,22 @@ class GetCourseIdTest(TestCase):
         }
         self.assertEquals(eventlog.get_course_id(event, from_url=True), 'course-v1:DemoX+DemoX+T1_2014')
 
+    def test_course_id_from_xblock_browser_url(self):
+        event = {
+            'event_source': 'browser',
+            'context': {},
+            'page': 'https://courses.edx.org/xblock/block-v1:DemoX+DemoX+T1_2014+type@vertical+block@3848270?p1=0&p2=0'
+        }
+        self.assertEquals(eventlog.get_course_id(event, from_url=True), 'course-v1:DemoX+DemoX+T1_2014')
+
+    def test_course_id_from_invalid_xblock_browser_url(self):
+        event = {
+            'event_source': 'browser',
+            'context': {},
+            'page': 'https://courses.edx.org/xblock/block-v1:DemoX+DemoX+T1_2014?p1=0&p2=0'
+        }
+        self.assertIsNone(eventlog.get_course_id(event, from_url=True))
+
     def test_missing_context(self):
         event = {
             'event_source': 'server'


### PR DESCRIPTION
https://openedx.atlassian.net/browse/DENG-522

At some point in August, the format of most course-based URLs changed from:

`https://courses.edx.org/courses/course-v1:org+course+run/courseware/unit1/der_3-sequential/?activate_block_id=block-v1%3Aorg%2Bcourse%2Brun%2Btype%40sequential%2Bblock%40der_3-sequential`

to:

`https://courses.edx.org/xblock/block-v1:org+course+run+type@vertical+block@3848270e75f34e409eaad53a2a7f1da5?show_title=0&show_bookmark_button=0`

This PR adds the parsing of course_ids from the "xblock"-based course URLs which are in events. These course_ids are currently ending up as "" (empty string) and are being ignored by the pipeline code.

---

Make sure that the following steps are done before merging:

  - [ ] If you have a migration please contact data engineering team before merging.
  - [ ] Before merging run full acceptance tests suite and provide URL for the acceptance tests run.
  - [ ] A member of data engineering team has approved the pull request.
  
