### PR TITLE
Pin pip, setuptools, wheel to fix opaque keys issue

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,2 +1,3 @@
 pip==9.0.1
 setuptools==36.4.0
+wheel==0.30.0

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,2 +1,2 @@
-pip
-setuptools
+pip==9.0.1
+setuptools==36.4.0


### PR DESCRIPTION
Currently EMR is failing to package up .egg-info since we un-pinned pip and friends. This means that stevedore plugins that rely on that to find plugins can't find them, which breaks parsing of new-style course keys and other things. This change should get us back to a time when all of those things played nicely together.

Analytics Pipeline Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] If you have a migration please contact data engineering team before merging.
  - [ ] Before merging run full acceptance tests suite and provide URL for the acceptance tests run.
  - [ ] A member of data engineering team has approved the pull request.
  
