### PR TITLE
fix: Pin setuptools to last supporting Py 2.7

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,3 +1,3 @@
 pip==9.0.1
-setuptools==36.4.0
+setuptools==44.1.1
 wheel==0.30.0


### PR DESCRIPTION
PyPI is deprecating non-SNI clients from connecting and downloading packages in a rolling blackout: https://github.com/pypa/pypi-support/issues/978

This seems to have hit us because we have a pinned version of setuptools that pre-dates the SNI implementation. This PR bumps setuptools to the last version supported in Py 2.7.

Analytics Pipeline Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] If you have a migration please contact data engineering team before merging.
  - [ ] Before merging run full acceptance tests suite and provide URL for the acceptance tests run.
  - [ ] A member of data engineering team has approved the pull request.
  
