### PR TITLE
BOM-2247: Upgrade pip-tools

### DIFF
--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.0                # via pip-tools
-pip-tools==4.2.0
+pip-tools==5.3.0
 six==1.10.0


### PR DESCRIPTION
We are using `pip==20.0.2` in configuration, which is compatible with pip-tools up to version `5.3.0`.
The compatibility chart is available at https://github.com/jazzband/pip-tools/#versions-and-compatibility

See https://openedx.atlassian.net/browse/BOM-2247 for details.