### PR TITLE
BOM-2247: Upgrade pip-tools to v5.5

### DIFF
--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.0                # via pip-tools
-pip-tools==5.3.0
+pip-tools==5.5.0
 six==1.10.0


### PR DESCRIPTION
Currently, we are have pinned pip to version 20.1.1 in configuration, which is compatible with pip-tools < 6.0 So in this PR we are upgrading pip-tools to 5.5* according to this compatibility chart
https://github.com/jazzband/pip-tools/#versions-and-compatibility

Relevant JIRA: https://openedx.atlassian.net/browse/BOM-2247