### PR TITLE
fix: map mysql datatype to snowflake datatype.

### DIFF
--- a/edx/analytics/tasks/warehouse/load_internal_reporting_database.py
+++ b/edx/analytics/tasks/warehouse/load_internal_reporting_database.py
@@ -340,6 +340,8 @@ class LoadMysqlTableFromS3ToSnowflakeTask(MysqlTableExportMixin, SnowflakeLoadFr
                 field_type = 'VARCHAR'
             elif field_type == 'longblob':
                 field_type = 'BINARY'
+            elif field_type == 'json':
+                field_type = 'VARIANT'
 
             if field_null == 'NO':
                 field_type += ' NOT NULL'


### PR DESCRIPTION
Job **snowflake-lms-read-replica-import-from-s3** is failing due to following error: **snowflake-lms-read-replica-import-from-s3: Unsupported data type 'JSON'.**
Upon investigation found that **discussions_discussiontopiclink** has a column **context** with datatype **json**, this data type is not supported in snowflake. The data type for json in snowflake is object,  snowflake documentation : https://docs.snowflake.com/en/sql-reference/data-types-semistructured.html#object

**Original Error:**
https://jenkins.analytics.edx.org/job/snowflake-lms-read-replica-import-from-s3/802/consoleFull
Make sure that the following steps are done before merging:

  - [ ] If you have a migration please contact data engineering team before merging.
  - [ ] Before merging run full acceptance tests suite and provide URL for the acceptance tests run.
  - [ ] A member of data engineering team has approved the pull request.
  
