### PR TITLE
docs: security mention of Hadoop YARN admin UI on port 8088 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ For small installations, you may want to use our [single instance installation g
 
 For larger installations, we do not have a similarly detailed guide, you can start with our [installation guide](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/insights/index.html).
 
+The default installation of Hadoop YARN has an administrative interface and [REST API endpoint](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html) it exposes [by default on port 8088](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-common/yarn-default.xml#yarn.resourcemanager.webapp.address) that can be used to run arbritrary tasks on the server. Secure this port in production.
 
 How to Contribute
 -----------------


### PR DESCRIPTION
## Description

Hadoop YARN Resource Managers are exposed by default on a standard Hadoop installation. This could allow third parties to run undesired Hadoop jobs.

We received notice that an operator of Open edX has been affected by this issue after following the setup instructions in the README.md.

For more information on securing YARN Web UIs and REST APIs, see: https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/YarnApplicationSecurity.html#Securing_YARN_Application_Web_UIs_and_REST_APIs.

## Additional Information

* Jira: [SEC-392](https://2u-internal.atlassian.net/browse/SEC-392)